### PR TITLE
Regression test for overlapping inspect

### DIFF
--- a/regression-tests/pure2-inspect-expression-in-generic-function-overlapping-types.cpp2
+++ b/regression-tests/pure2-inspect-expression-in-generic-function-overlapping-types.cpp2
@@ -1,0 +1,23 @@
+main: () -> int = {
+    v: std::variant<int, std::string> = "xyzzy" as std::string;
+    a: std::any = "xyzzy" as std::string;
+    o: std::optional<std::string> = "xyzzy" as std::string;
+
+    test_generic(v);
+    test_generic(a);
+    test_generic(o);
+
+}
+
+test_generic: ( x: _ ) = {
+    std::cout
+        << std::setw(30) << typeid(x).name() 
+        << inspect x -> std::string {
+            is std::string = "matches std::string";
+            is std::variant<int, std::string> = "matches std::variant<int, std::string>";
+            is std::any = "matches std::any";
+            is std::optional<std::string> = "matches std::optional<std::string>";
+            is _   = "no match";
+        }
+        << "\n";
+}


### PR DESCRIPTION
Hi I saw your talk today and am curious about how `inspect` is intended to behave when there are overlapping matches. Should it execute the first match? All the matches? Fail to compile? I've attached a regression test to demonstrate.

Current behaviour is:
```c++
// ----- Cpp2 support -----
#include "cpp2util.h"


#line 1 "../regression-tests/pure2-inspect-expression-in-generic-function-overlapping-types.cpp2"
[[nodiscard]] auto main() -> int;
#line 12 "../regression-tests/pure2-inspect-expression-in-generic-function-overlapping-types.cpp2"
auto test_generic(auto const& x) -> void;

//=== Cpp2 definitions ==========================================================

#line 1 "../regression-tests/pure2-inspect-expression-in-generic-function-overlapping-types.cpp2"
[[nodiscard]] auto main() -> int{
    std::variant<int,std::string> v { cpp2::as<std::string>("xyzzy") };
    std::any a { cpp2::as<std::string>("xyzzy") };
    std::optional<std::string> o { cpp2::as<std::string>("xyzzy") };

    test_generic(v);
    test_generic(a);
    test_generic(o);

}

auto test_generic(auto const& x) -> void{
    std::cout
        << std::setw(30) << typeid(x).name()
        << [&] () -> std::string { auto&& __expr = x;
            if (cpp2::is<std::string>(__expr)) { if constexpr( requires{"matches std::string";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF("matches std::string"),std::string> ) return "matches std::string"; else return std::string{}; else return std::string{}; }
            else if (cpp2::is<std::variant<int,std::string>>(__expr)) { if constexpr( requires{"matches std::variant<int, std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF("matches std::variant<int, std::string>"),std::string> ) return "matches std::variant<int, std::string>"; else return std::string{}; else return std::string{}; }
            else if (cpp2::is<std::any>(__expr)) { if constexpr( requires{"matches std::any";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF("matches std::any"),std::string> ) return "matches std::any"; else return std::string{}; else return std::string{}; }
            else if (cpp2::is<std::optional<std::string>>(__expr)) { if constexpr( requires{"matches std::optional<std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF("matches std::optional<std::string>"),std::string> ) return "matches std::optional<std::string>"; else return std::string{}; else return std::string{}; }
            else return "no match"; }
        ()
        << "\n";
}
```

I tried it in [godbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(j:1,lang:c%2B%2B,source:'%23include+%3Cmemory%3E%0A%23include+%3Ciostream%3E%0A%0Atemplate+%3Cclass+T%3E%0Aclass+out+%7B%0Apublic:+%0A++//+Constructor.+Unlike+std::reference_wrapper,+this+constructor%0A++//+is+explicit.+This+is+because+the+purpose+of+this+class+is+to%0A++//+retain+reference+semantics+while+making+it+obvious+what+is+%0A++//+happening+at+the+call+site+of+functions+that+retrieve+results+%0A++//+by+filling+in+paramaters,+e.g.+%0A++//+++++int+i%3B+%0A++//+++++foo(out%3Cint%3E(i))%3B%0A++explicit+out(T%26+x)+noexcept+:+_ptr(std::addressof(x))+%7B%7D%3B%0A%0A++//+Move+constructor+deleted+to+prevent+construction+from%0A++//+temporaries+e.g.+%0A++//+++++out%3Cint%3E(7)%3B%0A++out(T%26%26+val)+%3D+delete%3B%0A%0A++//+Assignment+should+work+like+regular+assignment+to+a+reference.%0A++//+e.g.+%0A++//+++++void+foo(out%3Cint%3E+i)+%7B+%0A++//+++++++++i+%3D+7%3B+%0A++//+++++%7D%3B%0A++out%26+operator%3D(const+T%26+x)+noexcept+%7B+*_ptr+%3D+x%3B+return+*this%3B+%7D%3B%0A%0A++//+Necessary+if+functions+that+accept+an+%60out%60+need+to+modify%0A++//+it+after+assigning,+e.g.%0A++//+++++void+foo(out%3CMyClass%3E+bar)+%7B%0A++//+++++++++bar+%3D+MyClass()%3B%0A++//+++++++++bar.get().member_int+%3D+7%3B%0A++//+++++%7D%0A++out%26+get()+%7B%0A%0A++%7D%0A%0A++//+Default+copy+constructor+is+useful.%0A++out(const+out%26)+noexcept+%3D+default%3B%0Aprivate:%0A++T*+_ptr%3B%0A%7D%3B%0A%0Avoid+out_fun(out%3Cint%3E+out_arg)+%7B%0A++out_arg+%3D+1%3B%0A%7D%0A%0Aint+main(int+argc,+char**+argv)+%7B%0A%09int+my_var+%3D+0%3B%0A%09out_fun(out%3Cint%3E(my_var))%3B%0A++%09std::cout+%3C%3C+my_var%3B%0A%7D%0A'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:g62,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',trim:'1'),lang:c%2B%2B,libs:!(),options:'-O2',source:1),l:'5',n:'0',o:'x86-64+gcc+6.2+(Editor+%231,+Compiler+%231)+C%2B%2B',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4) and it seems like the `std::any` matcher fails to compile, and for the rest it executes the first successful match. (but I may have screwed up while trying to compile the generated C++ code, maybe the `std::any` would compile if I did something different)