### PR TITLE
Fixed incorrect linkage for the code of conduct in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 See [License](LICENSE)
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 Cppfront is a experimental compiler from a potential C++ 'syntax 2' (Cpp2) to today's 'syntax 1' (Cpp1), to learn some things, prove out some concepts, and share some ideas. This compiler is a work in progress and currently hilariously incomplete... basic functions work, classes will be next, then metaclasses and lightweight exceptions.
 


### PR DESCRIPTION
Absolutely silly PR, but I noticed the readme's COC button wasn't redirecting correctly in my browsers (firefox & chrome). Case sensitivity strikes again. The other md files look fine.

Saw your talk, eagerly looking forward to how this progresses!

edit: Saw a previous PR also mentioned this, but checking the commit history it seems the fix was applied the `CODE_OF_CONDUCT.md` only, not `README.md`