### PR TITLE
write double backslashes in paths in #line directives

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -226,13 +226,8 @@ class positional_printer
 
         //  Not using print() here because this is transparent to the curr_pos
         if (!flag_clean_cpp1) {
-            out << "#line " << line << " \"";
-            for (auto c : filename)
-            {
-               if (c == '\\') out << "\\\\";
-               else out << c;
-            }
-            out << "2\"\n";
+            const std::string filename2 = filename + '2';
+            out << "#line " << line << ' ' << std::quoted(filename2) << '\n';
         }
     }
 

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -226,7 +226,13 @@ class positional_printer
 
         //  Not using print() here because this is transparent to the curr_pos
         if (!flag_clean_cpp1) {
-            out << "#line " << line << " \"" << filename << "2\"\n";
+            out << "#line " << line << " \"";
+            for (auto c : filename)
+            {
+               if (c == '\\') out << "\\\\";
+               else out << c;
+            }
+            out << "2\"\n";
         }
     }
 


### PR DESCRIPTION
When the `#line` directives are emitted, the path of the compiled file is written in the output cpp file. However, double backslashes are not used which may lead to interpreting characters as escape sequences when a relative path is supplied as argument.

Consider this source code located in a file called `demo.cpp2` in a folder called `learn`:
```
main: () -> int = {
   std::cout << "Hello, world!\n";
}
```

Compile it with a relative path:
```
cppfront.exe ..\learn\demo.cpp2
```

It produces this output:
```
// ----- Cpp2 support -----
#include "cpp2util.h"


#line 1 "..\learn\demo.cpp2"
[[nodiscard]] auto main() -> int;

//=== Cpp2 definitions ==========================================================

#line 1 "..\learn\demo.cpp2"
[[nodiscard]] auto main() -> int{
   std::cout << "Hello, world!\n";
}
```

When you run this with `cl.exe` you get the following warnings:
```
demo.cpp
..\learn\demo.cpp(5): warning C4129: 'l': unrecognized character escape sequence
..\learn\demo.cpp(5): warning C4129: 'd': unrecognized character escape sequence
..learndemo.cpp2(5): warning C4129: 'l': unrecognized character escape sequence
..learndemo.cpp2(5): warning C4129: 'd': unrecognized character escape sequence
```

This PR fixes this so that the output is as follows:
```
// ----- Cpp2 support -----
#include "cpp2util.h"


#line 1 "..\\learn\\demo.cpp2"
[[nodiscard]] auto main() -> int;

//=== Cpp2 definitions ==========================================================

#line 1 "..\\learn\\demo.cpp2"
[[nodiscard]] auto main() -> int{
   std::cout << "Hello, world!\n";
}
```