### PR TITLE
Update cpp2util.h

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -386,8 +386,8 @@ public:
    ~deferred_init() noexcept       { if (init) t.~T(); }
     auto value()    noexcept -> T& { Default.expects(init);  return t; }
 
-    auto construct     (auto ...args) -> void { Default.expects(!init);  new (&t) T(std::forward<decltype(args)>(args)...);  init = true; }
-    auto construct_list(auto ...args) -> void { Default.expects(!init);  new (&t) T{std::forward<decltype(args)>(args)...};  init = true; }
+    auto construct     (auto&& ...args) -> void { Default.expects(!init);  new (&t) T(std::forward<decltype(args)>(args)...);  init = true; }
+    auto construct_list(auto&& ...args) -> void { Default.expects(!init);  new (&t) T{std::forward<decltype(args)>(args)...};  init = true; }
 };
 
 template<typename T>


### PR DESCRIPTION
The "args" not forwarding correctly
```
auto construct(auto ...args) -> void { Default.expects(!init);  new (&t) T(std::forward<decltype(args)>(args)...);  init = true; }
auto construct_list(auto ...args) -> void { Default.expects(!init);  new (&t) T{ std::forward<decltype(args)>(args)... };  init = true; }
```

```
union 
{
   int i;
   T t; 
};
```

Also, I'm curious what is the reason for using int instead of a 1-byte wide type.