### PR TITLE
UFCS try to get pointer using get() after other matches failed

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -88,8 +88,10 @@
         #include <utility>
         #include <variant>
         #include <memory>
-        #ifdef __cpp_lib_memory_resource
+        #if __has_include(<memory_resource>)
             #include <memory_resource>
+        #elif __has_include(<experimental/memory_resource>)
+            #include <experimental/memory_resource>
         #endif
         #include <new>
         #include <scoped_allocator>
@@ -106,7 +108,9 @@
         #include <cctype>
         #include <charconv>
         #include <cstring>
-        #include <cuchar>
+        #if __has_include(<cuchar>)
+            #include <cuchar>
+        #endif
         #include <cwchar>
         #include <cwctype>
         #ifdef __cpp_lib_format
@@ -174,7 +178,9 @@
             #include <semaphore>
         #endif
         #include <shared_mutex>
-        #include <stop_token>
+        #if __has_include(<stop_token>)
+            #include <stop_token>
+        #endif
         #include <thread>
         #include <iso646.h>
     #endif

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -461,6 +461,10 @@ public:
 [](auto&& obj, auto&& ...params) { \
     if constexpr (requires{ std::forward<decltype(obj)>(obj).FUNCNAME(std::forward<decltype(params)>(params)...); }) { \
         return std::forward<decltype(obj)>(obj).FUNCNAME(std::forward<decltype(params)>(params)...); \
+    } else if constexpr ( requires{ FUNCNAME(std::forward<decltype(obj)>(obj), std::forward<decltype(params)>(params)...); }){ \
+        return FUNCNAME(std::forward<decltype(obj)>(obj), std::forward<decltype(params)>(params)...); \
+    } else if constexpr (requires{ FUNCNAME(std::forward<decltype(obj.get())>(obj.get()),std::forward<decltype(params)>(params)...); }) { \
+        return FUNCNAME(std::forward<decltype(obj.get())>(obj.get()), std::forward<decltype(params)>(params)...); \
     } else { \
         return FUNCNAME(std::forward<decltype(obj)>(obj), std::forward<decltype(params)>(params)...); \
     } \
@@ -470,6 +474,10 @@ public:
 [](auto&& obj) { \
     if constexpr (requires{ std::forward<decltype(obj)>(obj).FUNCNAME(); }) { \
         return std::forward<decltype(obj)>(obj).FUNCNAME(); \
+    } else if constexpr ( requires{ FUNCNAME(std::forward<decltype(obj)>(obj)); }) { \
+        return FUNCNAME(std::forward<decltype(obj)>(obj)); \
+    } else if constexpr (requires{ FUNCNAME(std::forward<decltype(obj.get())>(obj.get())); }) { \
+        return FUNCNAME(std::forward<decltype(obj.get())>(obj.get())); \
     } else { \
         return FUNCNAME(std::forward<decltype(obj)>(obj)); \
     } \


### PR DESCRIPTION
The current implementation of UFCS is not handling smart pointers well. For example, using fopen the code looks like this:

```cpp
main: () -> int = {
    myfile := fopen("file-opened-with-c-function.txt", "w");
    myfile.fprintf("Unified Function Call Syntax Rocks!\n\n");
    myfile.fclose();
}
```

there is a need to call fclose at the end of the scope. We can introduce `better_fopen` that will return `unique_prt` with `fclose` as a deleted.

```cpp
main: () -> int = {
    myfile := better_fopen("file-opened-with-c-function.txt", "w");
    myfile.fprintf("Unified Function Call Syntax Rocks!\n\n");
}
```

That will ensure closing but will not work with UFCS. 

In this change, I have introduced an additional check (after other matches failed) if there is a call to the `get()` method that matches a function signature. If yes then the underlying raw pointer is taken using `get()` method and used to match function syntax.