### PR TITLE
Add CMake file + GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ilammy/msvc-dev-cmd@v1
+      if: runner.os == 'Windows'
+    - name: Generating Makefiles
+      shell: bash
+      run: cmake .
+    - name: Compiling
+      shell: bash
+      run: cmake --build .
+    - name: Running Tests
+      shell: bash
+      run: ctest --output-on-failure
+  mingw:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        sys: [ mingw64, mingw32, ucrt64, clang64 ]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        release: false
+        msystem: ${{matrix.sys}}
+        pacboy: cc:p cmake:p ninja:p
+    - uses: actions/checkout@v2
+    - name: Generating Makefiles
+      run: cmake .
+    - name: Compiling
+      run: cmake --build .
+    - name: Test
+      run: ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+project(cppfront CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(cppfront source/cppfront.cpp)


### PR DESCRIPTION
A little CMakeLists.txt file that is used by new GitHub action workflows to build cppfront on different platforms. The [only one failing](https://github.com/dacap/cppfront/actions/runs/3118528674/jobs/5057882349#step:5:11) right now is in Ubuntu with gcc 9 (it looks like the <compare> header file is not available). I can add an extra check for that header file in the CMakeLists.txt, but I think it would be better if it can be detected with a preprocessor macro (so cppfront could be still compiled with CMake).

After this is merged (or some other/modified version of this) I can add the automatic compilation and execution of all regression tests on each pushed commit or PR with cmake/ctest.

I accept the Contributor License Agreement: https://github.com/hsutter/cppfront/blob/fa65d346996ec472e16c61838fbc7a47736d7872/CONTRIBUTING.md#contributor-license-agreement
