### PR TITLE
UFCS: add method chaining

### DIFF
--- a/regression-tests/mixed-ufcs-method-chaining.cpp2
+++ b/regression-tests/mixed-ufcs-method-chaining.cpp2
@@ -1,0 +1,28 @@
+#include <vector>
+
+add: (in v : _, in a : int) -> auto = {
+    cv := v;
+    for cv do :(inout e : _) = {
+        e += a;
+    }
+    return cv;
+}
+
+dbl: (in v : _) -> auto = {
+    cv := v;
+    for cv do :(inout e : _) = {
+        e *= 2;
+    }
+    return cv;
+}
+
+main: () -> int = {
+
+    v : std::vector<int> = (1,2,3,4,5,6,7,8,9,10);
+
+    for v.dbl().add(1).dbl() do :(in e : _) = {
+        std::cout << e << ", ";
+    }
+
+    std::cout << std::endl;
+}

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1692,10 +1692,18 @@ public:
 
             //  Otherwise, do the UFCS work...
 
+            auto find_id_of_a_last = [](auto& ops, auto op){
+                for (int i = std::ssize(ops)-1; i>0; --i) {
+                    if (ops[i].op->type() == op)
+                        return i;
+                }
+                return 0;
+            };
+
             //  If method are chained we need to go from the last to the first
             //  token.a(a-expr-list).b(b-expr-list).c(c-expr-list) will be tranformed to:
             //  CPP2_UFCS(c, CPP2_UFCS(b, CPP2_UFCS(a,token, a-expr-list), b-expr-list), c-expr-list )
-            for (auto i = std::ssize(n.ops)-1; i > 0; i -= 2)
+            for (auto i = find_id_of_a_last(n.ops, lexeme::LeftParen); i > 0; i -= 2)
             {
                 //  The . has its id_expr
                 assert (n.ops[i-1].id_expr);
@@ -1723,7 +1731,7 @@ public:
             }
 
             //  expr-list need to be added in reversed order then CPP2_UFCS macros
-            for (auto i = 0; i < std::ssize(n.ops); i += 2) {
+            for (auto i = 0; i < find_id_of_a_last(n.ops, lexeme::LeftParen); i += 2) {
                 //  Then make the base expression the second argument - only needed on the most nested call
                 if (i == 0) {
                     emit(*n.expr);


### PR DESCRIPTION
I have been playing with UFCS. I found that it doesn't support method chaining yet. So I have added it.

Former implementation was not supporting the method chaining - the below code failed to be compiled
```cpp
v.a().b(1,"arg").c(); // failed to use UFCS
```

The proposed change converts the above code into a nested call of `CPP2_UFCS` macros:
```cpp
CPP2_UFCS_0(c, CPP2_UFCS_0(b, CPP2_UFCS_0(a, v), 1, "arg" ) );
```

This allows using ranges library without the need of `operator|` for chaining. `operator|` does not work in cppfront at the moment. What I realized is that having UFCS that supports chaining solves the problem.

I don't have ranges working on my current system, so I put a custom example in the regression test directory.

Having the possibility of method chaining allows us to use smart pointers and pass them to the functions that need a raw pointers.

```cpp
smart.get().func(); // UFCS will be executed on raw pointer (thanks to chaining)
```