### PR TITLE
UFCS: function call starts UFCS chaining

### DIFF
--- a/regression-tests/mixed-ufcs-function-call-starts-chaining.cpp2
+++ b/regression-tests/mixed-ufcs-function-call-starts-chaining.cpp2
@@ -1,0 +1,48 @@
+#include <vector>
+#include <memory>
+
+template <typename T, typename D>
+struct scope_exit {
+    scope_exit(T v, D d) 
+        : value(v)
+        , deleter(d)
+    {
+    }
+
+    ~scope_exit() {
+        deleter(value);
+    }
+
+    operator T&() { return value; }
+
+    scope_exit(const scope_exit&) = delete;
+    scope_exit& operator=(const scope_exit&) = delete;
+    scope_exit(scope_exit&& rhs) noexcept : value(std::move(rhs.value)), deleter(std::move(rhs.deleter)) {}
+    scope_exit& operator=(scope_exit&& rhs) noexcept {
+        value = std::move(rhs.value);
+        deleter = std::move(rhs.deleter);
+        return *this;
+    }
+
+private:
+    T value;
+    D deleter; 
+};
+
+template <typename T, typename D>
+auto on_scope_exit(T&& v, D&& d) {
+    return scope_exit(std::forward<T>(v),std::forward<D>(d));
+}
+
+main: () -> int = {
+
+    fopen("variable2.txt", "w").on_scope_exit(:(e:_) = {
+        e.fprintf("you can handle smart_ptrs without changing behaviour of UFCS");
+        e.fclose();
+    });
+
+    m := fopen("manual.txt", "w");
+    m.fprintf("Manual handling still works");
+    m.fclose();
+
+}

--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -32,7 +32,7 @@ auto test_generic(auto const& x) -> void;
 
 auto test_generic(auto const& x) -> void{
     std::cout 
-        << std::setw(30) << typeid(x).name() 
+        << std::setw(30) << CPP2_UFCS_0(name, typeid(x)) 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
             if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + std::to_string(cpp2::as<int>(x)))),std::string> ) return "integer " + std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }

--- a/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
@@ -19,7 +19,7 @@ auto print_an_int(auto const& x) -> void;
 
 auto print_an_int(auto const& x) -> void{
     std::cout 
-        << std::setw(30) << typeid(x).name() 
+        << std::setw(30) << CPP2_UFCS_0(name, typeid(x)) 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
             if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }

--- a/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
@@ -26,7 +26,7 @@ auto test_generic(auto const& x) -> void;
 
 auto test_generic(auto const& x) -> void{
     std::cout 
-        << "\n" << typeid(x).name() << "\n    ..." 
+        << "\n" << CPP2_UFCS_0(name, typeid(x)) << "\n    ..." 
         << [&] () -> std::string { auto&& __expr = x;
             if (cpp2::is<std::string>(__expr)) { if constexpr( requires{" matches std::string";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::string")),std::string> ) return " matches std::string"; else return std::string{}; else return std::string{}; }
             else if (cpp2::is<std::variant<int,std::string>>(__expr)) { if constexpr( requires{" matches std::variant<int, std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::variant<int, std::string>")),std::string> ) return " matches std::variant<int, std::string>"; else return std::string{}; else return std::string{}; }

--- a/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
@@ -30,7 +30,7 @@ auto test_generic(auto const& x) -> void;
 
 auto test_generic(auto const& x) -> void{
     std::cout 
-        << "\n" << typeid(x).name() << "\n    ..." 
+        << "\n" << CPP2_UFCS_0(name, typeid(x)) << "\n    ..." 
         << [&] () -> std::string { auto&& __expr = x;
             if (cpp2::is<void>(__expr)) { if constexpr( requires{" VOYDE AND EMPTIE";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" VOYDE AND EMPTIE")),std::string> ) return " VOYDE AND EMPTIE"; else return std::string{}; else return std::string{}; }
             else return " no match"; }

--- a/regression-tests/test-results/pure2-type-safety-1.cpp
+++ b/regression-tests/test-results/pure2-type-safety-1.cpp
@@ -39,7 +39,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
 }
 
 auto test_generic(auto const& x) -> void{
-    std::string msg { typeid(x).name() }; 
+    std::string msg { CPP2_UFCS_0(name, typeid(x)) }; 
     msg += " is int? ";
     print( msg, cpp2::is<int>(x));
 }

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -32,7 +32,7 @@ auto test_generic(auto const& x) -> void;
 
 auto test_generic(auto const& x) -> void{
     std::cout 
-        << std::setw(30) << typeid(x).name() 
+        << std::setw(30) << CPP2_UFCS_0(name, typeid(x)) 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
             if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }


### PR DESCRIPTION
On the stdio example there is a call to c-function:
```cpp
myfile := fopen("xyzzy", "w");
myfile.fprintf( "Hello with UFCS!" );
myfile.fclose();
``` 

This is great but we can do better than that. What I don't like about this approach is the lost opportunity to save us from resource leak. What I would like to do is to have a possibility to wrap the return `FILE*` into something that will clean things up. 

I have implemented the feature that starts UFCS chaining on the function call of syntax func1().func2() (it can go recursively further). That brings us more interesting features like wrapping things into smart pointers in one call.

```cpp
#include <vector>
#include <memory>

template <typename T, typename R>
auto on_scope_exit(T* f, R(*close)(T*)) {
    return std::unique_ptr<T, decltype(close)>{f, close};
}

main: () -> int = {
    f2 := fopen("variable2.txt", "w").on_scope_exit(fclose);
    f2.get().fprintf("you can handle smart_ptrs without changing behaviour of UFCS");

    m := fopen("manual.txt", "w");
    m.fprintf("Manual handling still works");
    m.fclose();
}
```

That can go even further. Thanks to https://github.com/hsutter/cppfront/pull/13 the code can be even simpler:

```cpp
    f2 := fopen("variable2.txt", "w").on_scope_exit(fclose);
    f2.fprintf("you can handle smart_ptrs without changing behaviour of UFCS");

    m := fopen("manual.txt", "w");
    m.fprintf("Manual handling still works");
    m.fclose();

    f := fopen("variable.txt", "w").on_scope_exit(fclose);
    f.fprintf("This one use variable and\n");
    f.fprintf("    separate\n");
    f.fprintf("        calls\n");
    f.fprintf("            of fprintfs");

    fopen("one_liner.txt", "w").on_scope_exit(fclose)
                               .fprintf("This is oneliner!!\n\nAnd it just close automatically");
}
```

The last use case (one-liner) makes me think that UFCS brings some risk of leaking resources when chained. When results of `fopen` will be used by `fprintf` directly the pointer to file will be lost.

```cpp
    // bad use
    fopen("one_liner.txt", "w").fprintf("there is a leak on the end of this function");
```

I will investigate if there is a possibility to block potentially leaking combinations. Smart pointers are safe and we can eliminate cases when rvalue pointers are passed to a chained function.