### PR TITLE
regression-tests: run tests using bash

### DIFF
--- a/regression-tests/run-tests.sh
+++ b/regression-tests/run-tests.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+rm -rf ./test-results/*
+cp ./*.cpp2 ./test-results
+
+stats() {
+    echo "$1 SUCCESS"
+    echo "$2 FAILED"
+}
+
+declare -a transpile_success
+declare -a transpile_failure
+transpile() {
+    for filename in `find ./test-results -name "$1"`; do
+        cppfront $2 $filename &> ./$filename-output 2>&1 && transpile_success+=($filename) || transpile_failure+=($filename)
+    done
+}
+
+declare -a compile_success
+declare -a compile_failure
+compile() {
+    for filename in `find ./test-results -regex '.*\(cpp\)$' -type f`; do
+        g++-$1 -I$2 -o $filename.out $filename -std=c++20 >> ./$filename-output 2>&1 \
+        && compile_success+=($filename) \
+        || compile_failure+=($filename)
+    done
+}
+
+declare -a run_success
+declare -a run_failure
+run() {
+    for filename in `find ./test-results -regex '.*\(out\)$' -type f`; do
+        ./$filename >> ./$filename-output 2>&1 \
+        && run_success+=($filename) \
+        || run_failure+=($filename)
+    done
+}
+
+#### TRANSPILE ####
+echo "TRANSPILE:"
+transpile "mixed*.cpp2"
+transpile "pure*.cpp2" "-p"
+
+stats ${#transpile_success[@]} ${#transpile_failure[@]}
+printf '%s\n' "${transpile_failure[@]}"
+
+#### COMPILE ####
+echo "COMPILE:"
+compile 11 ../include
+stats ${#compile_success[@]} ${#compile_failure[@]}
+printf '%s\n' "${compile_failure[@]}"
+
+#### EXECUTE ####
+echo "RUN"
+run
+stats ${#run_success[@]} ${#run_failure[@]}
+printf '%s\n' "${run_failure[@]}"


### PR DESCRIPTION
Convenience script for running regression tests on Linux. Current results on Ubuntu and gcc11:

```
./run-tests.sh
TRANSPILE:
34 SUCCESS
8 FAILED
./test-results/mixed-lifetime-safety-pointer-init-3.cpp2
./test-results/mixed-initialization-safety-1.cpp2
./test-results/mixed-lifetime-safety-pointer-init-2.cpp2
./test-results/mixed-initialization-safety-2.cpp2
./test-results/mixed-lifetime-safety-pointer-init-1.cpp2
./test-results/pure2-bounds-safety-pointer-arithmetic-error.cpp2
./test-results/pure2-lifetime-safety-pointer-init-1.cpp2
./test-results/pure2-lifetime-safety-reject-null.cpp2
COMPILE:
33 SUCCESS
1 FAILED
./test-results/mixed-captures-in-expressions-and-postconditions.cpp
./run-tests.sh: line 26: 184219 Segmentation fault      (core dumped) ./$filename >> ./$filename-output 2>&1
./run-tests.sh: line 26: 184231 Aborted                 (core dumped) ./$filename >> ./$filename-output 2>&1
RUN:
31 SUCCESS
2 FAILED
./test-results/mixed-lifetime-safety-and-null-contracts.cpp.out
./test-results/mixed-bounds-safety-with-assert.cpp.out
```
