### PR TITLE
[REFACTOR] Change CPP2_UFCS macro to work for both cases - no need for CPP2_UFCS_0

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -459,22 +459,13 @@ public:
 //-----------------------------------------------------------------------
 //
 #define CPP2_UFCS(FUNCNAME,PARAM1,...) \
-[](auto&& obj, auto&& ...params) { \
-    if constexpr (requires{ std::forward<decltype(obj)>(obj).FUNCNAME(std::forward<decltype(params)>(params)...); }) { \
-        return std::forward<decltype(obj)>(obj).FUNCNAME(std::forward<decltype(params)>(params)...); \
+[](auto&& obj __VA_OPT__(, auto&& ...params)) { \
+    if constexpr (requires{ std::forward<decltype(obj)>(obj).FUNCNAME( __VA_OPT__(std::forward<decltype(params)>(params)...) ); }) { \
+        return std::forward<decltype(obj)>(obj).FUNCNAME( __VA_OPT__(std::forward<decltype(params)>(params)...) ); \
     } else { \
-        return FUNCNAME(std::forward<decltype(obj)>(obj), std::forward<decltype(params)>(params)...); \
+        return FUNCNAME(std::forward<decltype(obj)>(obj) __VA_OPT__(, std::forward<decltype(params)>(params)...) ); \
     } \
-}(PARAM1, __VA_ARGS__)
-
-#define CPP2_UFCS_0(FUNCNAME,PARAM1) \
-[](auto&& obj) { \
-    if constexpr (requires{ std::forward<decltype(obj)>(obj).FUNCNAME(); }) { \
-        return std::forward<decltype(obj)>(obj).FUNCNAME(); \
-    } else { \
-        return FUNCNAME(std::forward<decltype(obj)>(obj)); \
-    } \
-}(PARAM1)
+}(PARAM1 __VA_OPT__(, __VA_ARGS__))
 
 
 //-----------------------------------------------------------------------

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1624,13 +1624,7 @@ public:
             //  The ( has its expr_list and op_close
             assert (n.ops[1].expr_list && n.ops[1].op_close);
 
-            //  If there are no additional arguments, use the CPP2_UFCS_0 version
-            if (!n.ops[1].expr_list->expressions.empty()) {
-                printer.print_cpp2("CPP2_UFCS(", n.position());
-            }
-            else {
-                printer.print_cpp2("CPP2_UFCS_0(", n.position());
-            }
+            printer.print_cpp2("CPP2_UFCS(", n.position());
 
             //  Make the "funcname" the first argument to CPP2_UFCS
             emit(*n.ops[0].id_expr);


### PR DESCRIPTION
The current implementation has two macros `CPP2_UFCS` and `CPP2_UFCS_0`. One for functions/methods with arguments and the other for no arguments cases. There is a special macro `__VA_OPT__()` that includes its argument only if `__VA_ARGS__` has more than zero arguments.

In this change `CPP2_UFCS_0` is no longer needed and is removed. `CPP2_UFCS` works for both cases.

pure2-stdio.cpp2
```cpp

//  "A better C than C" ... ?
//
main: () -> int = {
    s: std::string = "Fred";
    myfile := fopen("xyzzy", "w");
    myfile.fprintf( "Hello %s with UFCS!", s.c_str() );
    myfile.fclose();
}

```
generates
```cpp
// ----- Cpp2 support -----
#include "cpp2util.h"


#line 4 "external/cppfront/regression-tests/pure2-stdio.cpp2"
[[nodiscard]] auto main() -> int;
#line 10 "external/cppfront/regression-tests/pure2-stdio.cpp2"


//=== Cpp2 definitions ==========================================================

#line 1 "external/cppfront/regression-tests/pure2-stdio.cpp2"

//  "A better C than C" ... ?
//
[[nodiscard]] auto main() -> int{
    std::string s { "Fred" }; 
    auto myfile { fopen("xyzzy", "w") }; 
    CPP2_UFCS(fprintf, myfile, "Hello %s with UFCS!", CPP2_UFCS(c_str, s));
    CPP2_UFCS(fclose, myfile);
}
```
compiles and run fine.