### PR TITLE
[FIX] Add handling of composition of standard types

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -771,6 +771,15 @@ inline auto to_string(T const& sv) -> std::string
     return std::string{sv};
 }
 
+template <typename... Ts>
+inline auto to_string(std::variant<Ts...> const& v) -> std::string;
+
+template < typename T, typename U>
+inline auto to_string(std::pair<T,U> const& p) -> std::string;
+
+template < typename... Ts>
+inline auto to_string(std::tuple<Ts...> const& t) -> std::string;
+
 template<typename T>
 inline auto to_string(std::optional<T> const& o) -> std::string {
     if (o.has_value()) {


### PR DESCRIPTION
The current implementation does not allow to:
* put variant, pair, tuple inside optional,
* put pair, tuple inside variant,
* put pair inside tuple

Below code will not compile:
```cpp
p : std::pair<std::string_view, std::optional<std::string>> = ("first", std::nullopt);
std::cout << "p = (p)$\n";

t : std::tuple<double, std::optional<std::pair<std::string_view, int>>, std::optional<std::tuple<int, int, int>>> = (3.14, std::nullopt, std::nullopt);
std::cout << "t = (t)$\n";

vv : std::variant<int, std::string, std::pair<int, double> > = ();
std::cout << "vv = (vv)$\n";
```

This is just because the order of definitions of to_string specializations matters. When the compiler matches to_string for optional it is not aware of the existence of specializations for variant, pair, or tuple.

This change proposes to add forward declarations to to_string specializations for variant, pair, and tuple.