### PR TITLE
Improves main function

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -199,6 +199,9 @@
     #include <cstddef>
     #include <utility>
     #include <cstdio>
+    #include <vector>
+    #include <string_view>
+    #include <span>
 
     #if defined(CPP2_USE_SOURCE_LOCATION)
         #include <source_location>
@@ -297,7 +300,6 @@ constexpr auto contract_group::set_handler(handler h) -> handler {
     return old;
 }
 
-
 //  Null pointer deref checking
 //
 auto assert_not_null(auto&& p CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT) -> auto&&
@@ -325,7 +327,6 @@ auto assert_in_bounds(auto&& x, auto&& arg CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAU
 {
     return std::forward<decltype(x)>(x) [ std::forward<decltype(arg)>(arg) ];
 }
-
 
 //-----------------------------------------------------------------------
 //
@@ -825,6 +826,41 @@ inline auto to_string(std::tuple<Ts...> const& t) -> std::string
     }
 }
 
+// Helper to convert the arguments of main to safer type.
+inline auto convert_main_args(int argc, char** argv) -> std::vector<std::string_view>
+{
+    std::vector<std::string_view> args;
+    for (int i = 0; i < argc; ++i) {
+        args.push_back(argv[i]);
+    }
+    args.shrink_to_fit();
+    return args;
+}
+
+#define CPP2_MAIN_VOID_NO_ARGS \
+    int main() { \
+        cpp2__main(); \
+        return 0; \
+    }
+
+#define CPP2_MAIN_INT_NO_ARGS \
+    int main() { \
+        return cpp2__main(); \
+    }
+
+#define CPP2_MAIN_VOID_ARGS \
+    int main(int argc, char** argv) { \
+        auto args = cpp2::convert_main_args(argc, argv); \
+        cpp2__main(std::span{args}); \
+        return 0; \
+    }
+
+#define CPP2_MAIN_INT_ARGS \
+    int main(int argc, char** argv) { \
+        auto args = cpp2::convert_main_args(argc, argv); \
+        return cpp2__main(std::span{args}); \
+    }
+
 
 //-----------------------------------------------------------------------
 //
@@ -880,7 +916,6 @@ inline auto fopen( const char* filename, const char* mode ) {
 
 
 }
-
 
 using cpp2::cpp2_new;
 

--- a/regression-tests/mixed-bounds-check.cpp2
+++ b/regression-tests/mixed-bounds-check.cpp2
@@ -1,7 +1,7 @@
 
 #include <vector>
 
-main: () -> int = {
+main: () = {
     v : std::vector = (1, 2, 3, 4, 5);
     std::cout << v[5] << "\n";
 }

--- a/regression-tests/mixed-bounds-safety-with-assert-2.cpp2
+++ b/regression-tests/mixed-bounds-safety-with-assert-2.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int = {
+main: () = {
     v: std::vector<int> = (1, 2, 3, 4, 5);
     add_42_to_subrange(v, 1, 3);
 

--- a/regression-tests/mixed-bounds-safety-with-assert.cpp2
+++ b/regression-tests/mixed-bounds-safety-with-assert.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int = {
+main: () = {
     v: std::vector<int> = (1, 2, 3, 4, 5);
     print_subrange(v, 1, 13);
 }

--- a/regression-tests/mixed-captures-in-expressions-and-postconditions.cpp2
+++ b/regression-tests/mixed-captures-in-expressions-and-postconditions.cpp2
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <vector>
 
-main: () -> int = {
+main: () = {
     vec: std::vector<std::string>
             = ("hello", "2022");
 

--- a/regression-tests/mixed-function-expression-and-std-for-each.cpp2
+++ b/regression-tests/mixed-function-expression-and-std-for-each.cpp2
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     vec: std::vector<std::string> 
             = ("hello", "2022");
     view: std::span = vec;

--- a/regression-tests/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp2
+++ b/regression-tests/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp2
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     vec: std::vector<std::string> 
             = ("hello", "2022");
     view: std::span = vec;

--- a/regression-tests/mixed-function-expression-and-std-ranges-for-each.cpp2
+++ b/regression-tests/mixed-function-expression-and-std-ranges-for-each.cpp2
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     vec: std::vector<std::string> 
             = ("hello", "2022");
     view: std::span = vec;

--- a/regression-tests/mixed-function-expression-with-pointer-capture.cpp2
+++ b/regression-tests/mixed-function-expression-with-pointer-capture.cpp2
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     vec: std::vector<std::string> 
             = ("hello", "2023");
     view: std::span = vec;

--- a/regression-tests/mixed-function-expression-with-repeated-capture.cpp2
+++ b/regression-tests/mixed-function-expression-with-repeated-capture.cpp2
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     vec: std::vector<std::string> 
             = ("hello", "2022");
     view: std::span = vec;

--- a/regression-tests/mixed-initialization-safety-1.cpp2
+++ b/regression-tests/mixed-initialization-safety-1.cpp2
@@ -16,7 +16,7 @@ fill: (
     x = value.substr(0, count);
 }
 
-main: () -> int =
+main: () =
 {
     x: std::string;         // note: uninitialized!
 

--- a/regression-tests/mixed-initialization-safety-2.cpp2
+++ b/regression-tests/mixed-initialization-safety-2.cpp2
@@ -16,7 +16,7 @@ fill: (
     x = value.substr(0, count);
 }
 
-main: () -> int =
+main: () =
 {
     x: std::string;         // note: uninitialized!
 

--- a/regression-tests/mixed-initialization-safety-3.cpp2
+++ b/regression-tests/mixed-initialization-safety-3.cpp2
@@ -2,7 +2,7 @@
 #include <vector>
 #include <ctime>
 
-main: () -> int = {
+main: () = {
     x: std::string;         // note: uninitialized!
 
     if flip_a_coin() {

--- a/regression-tests/mixed-intro-for-with-counter-include-last.cpp2
+++ b/regression-tests/mixed-intro-for-with-counter-include-last.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int
+main: ()
 = {
     v: std::vector<int> = (1, 2, 3, 4, 5);
     counter := 42;

--- a/regression-tests/mixed-lifetime-safety-and-null-contracts.cpp2
+++ b/regression-tests/mixed-lifetime-safety-and-null-contracts.cpp2
@@ -3,7 +3,7 @@
 #include <vector>
 #include <string>
 
-main: () -> int = {
+main: () = {
     cpp2::Null.set_handler(call_my_framework&);
     try_pointer_stuff();
     std::cout << "done\n";

--- a/regression-tests/mixed-lifetime-safety-pointer-init-1.cpp2
+++ b/regression-tests/mixed-lifetime-safety-pointer-init-1.cpp2
@@ -2,7 +2,7 @@
 #include <cstdlib>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     x: int = 42;
     p: *int;
 

--- a/regression-tests/mixed-lifetime-safety-pointer-init-2.cpp2
+++ b/regression-tests/mixed-lifetime-safety-pointer-init-2.cpp2
@@ -2,7 +2,7 @@
 #include <cstdlib>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     x: int = 42;
     p: *int;
 

--- a/regression-tests/mixed-lifetime-safety-pointer-init-3.cpp2
+++ b/regression-tests/mixed-lifetime-safety-pointer-init-3.cpp2
@@ -2,7 +2,7 @@
 #include <cstdlib>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     x: int = 42;
     p: *int;
 

--- a/regression-tests/mixed-lifetime-safety-pointer-init-4.cpp2
+++ b/regression-tests/mixed-lifetime-safety-pointer-init-4.cpp2
@@ -2,7 +2,7 @@
 #include <cstdlib>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     x: int = 42;
     y: int = 43;
     p: *int;

--- a/regression-tests/mixed-parameter-passing-with-forward.cpp2
+++ b/regression-tests/mixed-parameter-passing-with-forward.cpp2
@@ -39,4 +39,4 @@ parameter_styles: (
 
 }
 
-main: () -> int = { }
+main: () = { }

--- a/regression-tests/mixed-parameter-passing.cpp2
+++ b/regression-tests/mixed-parameter-passing.cpp2
@@ -37,4 +37,4 @@ parameter_styles: (
 
 }
 
-main: () -> int = { }
+main: () = { }

--- a/regression-tests/mixed-postexpression-with-capture.cpp2
+++ b/regression-tests/mixed-postexpression-with-capture.cpp2
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <iostream>
 
-main: () -> int = {
+main: () = {
     insert_at( 0, 42 );
 }
 

--- a/regression-tests/mixed-postfix-expression-custom-formatting.cpp2
+++ b/regression-tests/mixed-postfix-expression-custom-formatting.cpp2
@@ -12,4 +12,4 @@ test: (a:_) -> std::string = {
         );
 }
 
-main: () -> int = { }
+main: () = { }

--- a/regression-tests/mixed-string-interpolation.cpp2
+++ b/regression-tests/mixed-string-interpolation.cpp2
@@ -5,7 +5,7 @@
 
 struct custom_struct_with_no_stringize_customization { } custom;
 
-main: () -> int = {
+main: () = {
     a := 2;
     b: std::optional<int> = ();
     std::cout << "a = (a)$, b = (b)$\n";

--- a/regression-tests/mixed-type-safety-1.cpp2
+++ b/regression-tests/mixed-type-safety-1.cpp2
@@ -23,7 +23,7 @@ print: ( msg: std::string, b: bool ) =
 
 //--- examples -------------------------
 
-main: () -> int = 
+main: () =
 {
     print( "1.1 is int? ", 1.1 is int );
     print( "1   is int? ", 1   is int );

--- a/regression-tests/pure2-bounds-safety-pointer-arithmetic-error.cpp2
+++ b/regression-tests/pure2-bounds-safety-pointer-arithmetic-error.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int
+main: ()
 = {
     words: std::vector<std::string> = ( "decorated", "hello", "world" );
 

--- a/regression-tests/pure2-bounds-safety-span.cpp2
+++ b/regression-tests/pure2-bounds-safety-span.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int
+main: ()
 = {
     words: std::vector<std::string> = ( "decorated", "hello", "world" );
 

--- a/regression-tests/pure2-bugfix-for-name-lookup-and-value-decoration.cpp2
+++ b/regression-tests/pure2-bugfix-for-name-lookup-and-value-decoration.cpp2
@@ -3,7 +3,7 @@ vals: () -> (i : int) = {
     return;
 }
 
-main: () -> int = {
+main: () = {
     v := vals();
     v.i;
 }

--- a/regression-tests/pure2-hello.cpp2
+++ b/regression-tests/pure2-hello.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int = {
+main: () = {
     std::cout << "Hello " << name() << "\n";
 }
 

--- a/regression-tests/pure2-inspect-expression-in-generic-function-multiple-types.cpp2
+++ b/regression-tests/pure2-inspect-expression-in-generic-function-multiple-types.cpp2
@@ -1,4 +1,4 @@
-main: () -> int = {
+main: () = {
     v: std::variant<int, double> = 42.0;
     a: std::any = "xyzzy" as std::string;
     o: std::optional<int> = ();

--- a/regression-tests/pure2-inspect-expression-with-as-in-generic-function.cpp2
+++ b/regression-tests/pure2-inspect-expression-with-as-in-generic-function.cpp2
@@ -1,4 +1,4 @@
-main: () -> int = {
+main: () = {
     print_an_int("syzygy");
     print_an_int(1);
     print_an_int(1.1);

--- a/regression-tests/pure2-inspect-fallback-with-variant-any-optional.cpp2
+++ b/regression-tests/pure2-inspect-fallback-with-variant-any-optional.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int = {
+main: () = {
     v: std::variant<int, std::string> = "xyzzy" as std::string;
     a: std::any = "xyzzy" as std::string;
     o: std::optional<std::string> = "xyzzy" as std::string;

--- a/regression-tests/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp2
+++ b/regression-tests/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int = {
+main: () = {
     p: std::unique_ptr<int> = ();
     i: std::vector<int>::iterator = ();
     v: std::variant<std::monostate, int, std::string> = ();

--- a/regression-tests/pure2-int-main-arg.cpp2
+++ b/regression-tests/pure2-int-main-arg.cpp2
@@ -1,0 +1,4 @@
+main: (move args :std::span<std::string_view>) -> int = {
+    for args do: (arg: _) = std::cout << arg << '\n';
+    return 0;
+}

--- a/regression-tests/pure2-intro-example-hello-2022.cpp2
+++ b/regression-tests/pure2-intro-example-hello-2022.cpp2
@@ -1,4 +1,4 @@
-main: () -> int = {
+main: () = {
     vec: std::vector<std::string> 
             = ("hello", "2022");
     view: std::span = vec;

--- a/regression-tests/pure2-intro-example-three-loops.cpp2
+++ b/regression-tests/pure2-intro-example-three-loops.cpp2
@@ -7,7 +7,7 @@ decorate_and_print: (inout thing:_) = {
     print(thing);
 }
 
-main: () -> int = {
+main: () = {
     words: std::vector<std::string> =
         ( "hello", "big", "world" );
     view: std::span<std::string> = words;

--- a/regression-tests/pure2-lifetime-safety-pointer-init-1.cpp2
+++ b/regression-tests/pure2-lifetime-safety-pointer-init-1.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int = {
+main: () = {
     x: int = 42;
     p: *int;
 

--- a/regression-tests/pure2-lifetime-safety-reject-null.cpp2
+++ b/regression-tests/pure2-lifetime-safety-reject-null.cpp2
@@ -3,7 +3,7 @@
 #include <vector>
 #include <string>
 
-main: () -> int
+main: ()
 = {
     words: std::vector<std::string> = ( "decorated", "hello", "world" );
 

--- a/regression-tests/pure2-stdio-with-raii.cpp2
+++ b/regression-tests/pure2-stdio-with-raii.cpp2
@@ -1,7 +1,7 @@
 
 //  "A better C than C" ... ?
 //
-main: () -> int = {
+main: () = {
     s: std::string = "Freddy";
     myfile := cpp2::fopen("xyzzy", "w");
     myfile.fprintf( "Hello %s with UFCS!", s.c_str() );

--- a/regression-tests/pure2-stdio.cpp2
+++ b/regression-tests/pure2-stdio.cpp2
@@ -1,7 +1,7 @@
 
 //  "A better C than C" ... ?
 //
-main: () -> int = {
+main: () = {
     s: std::string = "Fred";
     myfile := fopen("xyzzy", "w");
     myfile.fprintf( "Hello %s with UFCS!", s.c_str() );

--- a/regression-tests/pure2-type-safety-1.cpp2
+++ b/regression-tests/pure2-type-safety-1.cpp2
@@ -1,5 +1,5 @@
 
-main: () -> int = 
+main: () =
 {
     v: std::variant<int, double> = 42.0;
     a: std::any = "xyzzy";

--- a/regression-tests/pure2-type-safety-2-with-inspect-expression.cpp2
+++ b/regression-tests/pure2-type-safety-2-with-inspect-expression.cpp2
@@ -1,4 +1,4 @@
-main: () -> int = {
+main: () = {
     v: std::variant<int, double> = 42.0;
     a: std::any = "xyzzy";
     o: std::optional<int> = ();

--- a/regression-tests/pure2-void-main-arg.cpp2
+++ b/regression-tests/pure2-void-main-arg.cpp2
@@ -1,0 +1,3 @@
+main: (move args :std::span<std::string_view>) = {
+    for args do: (arg: _) = std::cout << arg << '\n';
+}

--- a/regression-tests/test-results/mixed-bounds-check.cpp
+++ b/regression-tests/test-results/mixed-bounds-check.cpp
@@ -10,7 +10,9 @@
 
 #line 3 "mixed-bounds-check.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector v { 1, 2, 3, 4, 5 }; 
     std::cout << v[5] << "\n";
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-bounds-check.cpp
+++ b/regression-tests/test-results/mixed-bounds-check.cpp
@@ -5,13 +5,12 @@
 
 #include <vector>
 
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 3 "mixed-bounds-check.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector v { 1, 2, 3, 4, 5 }; 
     std::cout << v[5] << "\n";
 }

--- a/regression-tests/test-results/mixed-bounds-safety-with-assert-2.cpp
+++ b/regression-tests/test-results/mixed-bounds-safety-with-assert-2.cpp
@@ -15,14 +15,14 @@ auto add_42_to_subrange(auto& rng, cpp2::in<int> start, cpp2::in<int> end) -> vo
 
 #line 1 "mixed-bounds-safety-with-assert-2.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<int> v { 1, 2, 3, 4, 5 }; 
     add_42_to_subrange(v, 1, 3);
 
     for ( auto&& cpp2_range = v;  auto const& i : cpp2_range ) 
         std::cout << i << "\n";
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto add_42_to_subrange(auto& rng, cpp2::in<int> start, cpp2::in<int> end) -> void
 {
     cpp2::Bounds.expects(0 <= start, "");

--- a/regression-tests/test-results/mixed-bounds-safety-with-assert-2.cpp
+++ b/regression-tests/test-results/mixed-bounds-safety-with-assert-2.cpp
@@ -3,7 +3,6 @@
 
 
 #line 2 "mixed-bounds-safety-with-assert-2.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 10 "mixed-bounds-safety-with-assert-2.cpp2"
 auto add_42_to_subrange(auto& rng, cpp2::in<int> start, cpp2::in<int> end) -> void;
 #line 23 "mixed-bounds-safety-with-assert-2.cpp2"
@@ -16,7 +15,7 @@ auto add_42_to_subrange(auto& rng, cpp2::in<int> start, cpp2::in<int> end) -> vo
 
 #line 1 "mixed-bounds-safety-with-assert-2.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<int> v { 1, 2, 3, 4, 5 }; 
     add_42_to_subrange(v, 1, 3);
 

--- a/regression-tests/test-results/mixed-bounds-safety-with-assert.cpp
+++ b/regression-tests/test-results/mixed-bounds-safety-with-assert.cpp
@@ -3,7 +3,6 @@
 
 
 #line 2 "mixed-bounds-safety-with-assert.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 7 "mixed-bounds-safety-with-assert.cpp2"
 auto print_subrange(auto const& rng, cpp2::in<int> start, cpp2::in<int> end) -> void;
 #line 19 "mixed-bounds-safety-with-assert.cpp2"
@@ -16,7 +15,7 @@ auto print_subrange(auto const& rng, cpp2::in<int> start, cpp2::in<int> end) -> 
 
 #line 1 "mixed-bounds-safety-with-assert.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<int> v { 1, 2, 3, 4, 5 }; 
     print_subrange(v, 1, 13);
 }

--- a/regression-tests/test-results/mixed-bounds-safety-with-assert.cpp
+++ b/regression-tests/test-results/mixed-bounds-safety-with-assert.cpp
@@ -15,11 +15,11 @@ auto print_subrange(auto const& rng, cpp2::in<int> start, cpp2::in<int> end) -> 
 
 #line 1 "mixed-bounds-safety-with-assert.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<int> v { 1, 2, 3, 4, 5 }; 
     print_subrange(v, 1, 13);
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto print_subrange(auto const& rng, cpp2::in<int> start, cpp2::in<int> end) -> void{
     cpp2::Bounds.expects(0 <= start, "");
     cpp2::Bounds.expects(end <= CPP2_UFCS_0(size, rng), "");

--- a/regression-tests/test-results/mixed-captures-in-expressions-and-postconditions.cpp
+++ b/regression-tests/test-results/mixed-captures-in-expressions-and-postconditions.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <vector>
 
-[[nodiscard]] auto main() -> int;
 #line 17 "mixed-captures-in-expressions-and-postconditions.cpp2"
 #line 19 "mixed-captures-in-expressions-and-postconditions.cpp2"
 auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void;
@@ -15,7 +14,7 @@ auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void;
 
 #line 4 "mixed-captures-in-expressions-and-postconditions.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
 

--- a/regression-tests/test-results/mixed-captures-in-expressions-and-postconditions.cpp
+++ b/regression-tests/test-results/mixed-captures-in-expressions-and-postconditions.cpp
@@ -14,7 +14,7 @@ auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void;
 
 #line 4 "mixed-captures-in-expressions-and-postconditions.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
 
@@ -25,7 +25,7 @@ auto main() -> int{
     y = "-ish\n";
     std::ranges::for_each( vec, callback );
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 std::vector<int> vec {  }; 
 
 auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void

--- a/regression-tests/test-results/mixed-function-expression-and-std-for-each.cpp
+++ b/regression-tests/test-results/mixed-function-expression-and-std-for-each.cpp
@@ -13,7 +13,7 @@
 
 #line 6 "mixed-function-expression-and-std-for-each.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 
@@ -37,3 +37,5 @@ auto main() -> int{
         std::cout << str << "\n";
     }
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-function-expression-and-std-for-each.cpp
+++ b/regression-tests/test-results/mixed-function-expression-and-std-for-each.cpp
@@ -8,13 +8,12 @@
 #include <algorithm>
 #include <iostream>
 
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 6 "mixed-function-expression-and-std-for-each.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 

--- a/regression-tests/test-results/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp
+++ b/regression-tests/test-results/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp
@@ -14,7 +14,7 @@
 
 #line 7 "mixed-function-expression-and-std-ranges-for-each-with-capture.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 
@@ -29,3 +29,5 @@ auto main() -> int{
     for ( auto&& cpp2_range = view;  auto const& str : cpp2_range ) 
         std::cout << str << "\n";
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp
+++ b/regression-tests/test-results/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp
@@ -9,13 +9,12 @@
 #include <algorithm>
 #include <iostream>
 
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 7 "mixed-function-expression-and-std-ranges-for-each-with-capture.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 

--- a/regression-tests/test-results/mixed-function-expression-and-std-ranges-for-each.cpp
+++ b/regression-tests/test-results/mixed-function-expression-and-std-ranges-for-each.cpp
@@ -14,7 +14,7 @@
 
 #line 7 "mixed-function-expression-and-std-ranges-for-each.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 
@@ -28,3 +28,5 @@ auto main() -> int{
     for ( auto&& cpp2_range = view;  auto const& str : cpp2_range ) 
         std::cout << str << "\n";
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-function-expression-and-std-ranges-for-each.cpp
+++ b/regression-tests/test-results/mixed-function-expression-and-std-ranges-for-each.cpp
@@ -9,13 +9,12 @@
 #include <algorithm>
 #include <iostream>
 
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 7 "mixed-function-expression-and-std-ranges-for-each.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 

--- a/regression-tests/test-results/mixed-function-expression-with-pointer-capture.cpp
+++ b/regression-tests/test-results/mixed-function-expression-with-pointer-capture.cpp
@@ -14,7 +14,7 @@
 
 #line 7 "mixed-function-expression-with-pointer-capture.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<std::string> vec { 
                "hello", "2023" }; 
     std::span view { vec }; 
@@ -30,3 +30,5 @@ auto main() -> int{
     for ( auto&& cpp2_range = view;  auto const& str : cpp2_range ) 
         std::cout << str << "\n";
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-function-expression-with-pointer-capture.cpp
+++ b/regression-tests/test-results/mixed-function-expression-with-pointer-capture.cpp
@@ -9,13 +9,12 @@
 #include <algorithm>
 #include <iostream>
 
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 7 "mixed-function-expression-with-pointer-capture.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<std::string> vec { 
                "hello", "2023" }; 
     std::span view { vec }; 

--- a/regression-tests/test-results/mixed-function-expression-with-repeated-capture.cpp
+++ b/regression-tests/test-results/mixed-function-expression-with-repeated-capture.cpp
@@ -9,13 +9,12 @@
 #include <algorithm>
 #include <iostream>
 
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 7 "mixed-function-expression-with-repeated-capture.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 

--- a/regression-tests/test-results/mixed-function-expression-with-repeated-capture.cpp
+++ b/regression-tests/test-results/mixed-function-expression-with-repeated-capture.cpp
@@ -14,7 +14,7 @@
 
 #line 7 "mixed-function-expression-with-repeated-capture.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 
@@ -29,3 +29,5 @@ auto main() -> int{
     for ( auto&& cpp2_range = view;  auto const& str : cpp2_range ) 
         std::cout << str << "\n";
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-initialization-safety-3.cpp
+++ b/regression-tests/test-results/mixed-initialization-safety-3.cpp
@@ -21,7 +21,7 @@ auto print_decorated(auto const& x) -> void;
 
 #line 4 "mixed-initialization-safety-3.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     cpp2::deferred_init<std::string> x; // note: uninitialized!
 
     if (flip_a_coin()) {
@@ -31,7 +31,7 @@ auto main() -> int{
     }
     print_decorated(x.value());
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto fill(
     cpp2::out<std::string> x, 
     cpp2::in<std::string> value, 

--- a/regression-tests/test-results/mixed-initialization-safety-3.cpp
+++ b/regression-tests/test-results/mixed-initialization-safety-3.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 #include <ctime>
 
-[[nodiscard]] auto main() -> int;
 #line 16 "mixed-initialization-safety-3.cpp2"
 auto fill(
     cpp2::out<std::string> x, 
@@ -22,7 +21,7 @@ auto print_decorated(auto const& x) -> void;
 
 #line 4 "mixed-initialization-safety-3.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     cpp2::deferred_init<std::string> x; // note: uninitialized!
 
     if (flip_a_coin()) {

--- a/regression-tests/test-results/mixed-intro-for-with-counter-include-last.cpp
+++ b/regression-tests/test-results/mixed-intro-for-with-counter-include-last.cpp
@@ -3,7 +3,6 @@
 
 
 #line 2 "mixed-intro-for-with-counter-include-last.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 10 "mixed-intro-for-with-counter-include-last.cpp2"
 
 #include <vector>
@@ -14,7 +13,7 @@
 
 #line 1 "mixed-intro-for-with-counter-include-last.cpp2"
 
-[[nodiscard]] auto main() -> int
+auto main() -> int
 {
     std::vector<int> v { 1, 2, 3, 4, 5 }; 
     auto counter { 42 }; 

--- a/regression-tests/test-results/mixed-intro-for-with-counter-include-last.cpp
+++ b/regression-tests/test-results/mixed-intro-for-with-counter-include-last.cpp
@@ -13,7 +13,7 @@
 
 #line 1 "mixed-intro-for-with-counter-include-last.cpp2"
 
-auto main() -> int
+auto cpp2__main() -> void
 {
     std::vector<int> v { 1, 2, 3, 4, 5 }; 
     auto counter { 42 }; 
@@ -21,3 +21,5 @@ auto main() -> int
         std::cout << i << " " << counter << "\n";
     } while (false); counter *= 2; }
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
@@ -20,11 +20,12 @@ auto call_my_framework(cpp2::in<const char *> msg) -> void;
 
 #line 5 "mixed-lifetime-safety-and-null-contracts.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     cpp2::Null.set_handler(&call_my_framework);
     try_pointer_stuff();
     std::cout << "done\n";
 }
+CPP2_MAIN_VOID_NO_ARGS
 #line 14 "mixed-lifetime-safety-and-null-contracts.cpp2"
 
 auto try_pointer_stuff() -> void{

--- a/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
@@ -7,7 +7,6 @@
 #include <vector>
 #include <string>
 
-[[nodiscard]] auto main() -> int;
 #line 11 "mixed-lifetime-safety-and-null-contracts.cpp2"
 
 //  Calling Cpp1 is the easiest way to create a null...
@@ -21,7 +20,7 @@ auto call_my_framework(cpp2::in<const char *> msg) -> void;
 
 #line 5 "mixed-lifetime-safety-and-null-contracts.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     cpp2::Null.set_handler(&call_my_framework);
     try_pointer_stuff();
     std::cout << "done\n";

--- a/regression-tests/test-results/mixed-lifetime-safety-pointer-init-4.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-pointer-init-4.cpp
@@ -15,7 +15,7 @@ auto print_and_decorate(auto const& thing) -> void;
 
 #line 4 "mixed-lifetime-safety-pointer-init-4.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     int x { 42 }; 
     int y { 43 }; 
     cpp2::deferred_init<int*> p; 
@@ -30,6 +30,6 @@ auto main() -> int{
 
     print_and_decorate( *p.value());
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto print_and_decorate(auto const& thing) -> void { 
     std::cout << ">> " << thing << "\n"; }

--- a/regression-tests/test-results/mixed-lifetime-safety-pointer-init-4.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-pointer-init-4.cpp
@@ -6,7 +6,6 @@
 #include <cstdlib>
 #include <iostream>
 
-[[nodiscard]] auto main() -> int;
 #line 21 "mixed-lifetime-safety-pointer-init-4.cpp2"
 auto print_and_decorate(auto const& thing) -> void;
 #line 23 "mixed-lifetime-safety-pointer-init-4.cpp2"
@@ -16,7 +15,7 @@ auto print_and_decorate(auto const& thing) -> void;
 
 #line 4 "mixed-lifetime-safety-pointer-init-4.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     int x { 42 }; 
     int y { 43 }; 
     cpp2::deferred_init<int*> p; 

--- a/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
@@ -17,7 +17,6 @@ auto parameter_styles(
     auto&&  e
     ) -> void;
 #line 42 "mixed-parameter-passing-with-forward.cpp2"
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
@@ -61,4 +60,4 @@ requires std::is_same_v<CPP2_TYPEOF(e), std::string>
 
 }
 
-[[nodiscard]] auto main() -> int{}
+auto main() -> int{ }

--- a/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
@@ -60,4 +60,6 @@ requires std::is_same_v<CPP2_TYPEOF(e), std::string>
 
 }
 
-auto main() -> int{ }
+auto cpp2__main() -> void{}
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-parameter-passing.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing.cpp
@@ -55,4 +55,6 @@ auto parameter_styles(
 
 }
 
-auto main() -> int{ }
+auto cpp2__main() -> void{}
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-parameter-passing.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing.cpp
@@ -16,7 +16,6 @@ auto parameter_styles(
     std::string&& d
     ) -> void;
 #line 40 "mixed-parameter-passing.cpp2"
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
@@ -56,4 +55,4 @@ auto parameter_styles(
 
 }
 
-[[nodiscard]] auto main() -> int{}
+auto main() -> int{ }

--- a/regression-tests/test-results/mixed-postexpression-with-capture.cpp
+++ b/regression-tests/test-results/mixed-postexpression-with-capture.cpp
@@ -17,10 +17,10 @@ auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void;
 
 #line 7 "mixed-postexpression-with-capture.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     insert_at( 0, 42 );
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 std::vector<int> vec {  }; 
 
 auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void

--- a/regression-tests/test-results/mixed-postexpression-with-capture.cpp
+++ b/regression-tests/test-results/mixed-postexpression-with-capture.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <iostream>
 
-[[nodiscard]] auto main() -> int;
 #line 12 "mixed-postexpression-with-capture.cpp2"
 #line 14 "mixed-postexpression-with-capture.cpp2"
 auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void;
@@ -18,7 +17,7 @@ auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void;
 
 #line 7 "mixed-postexpression-with-capture.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     insert_at( 0, 42 );
 }
 

--- a/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
+++ b/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
@@ -7,7 +7,6 @@ auto call(auto const& v, auto const& w, auto const& x, auto const& y, auto const
 #line 4 "mixed-postfix-expression-custom-formatting.cpp2"
 [[nodiscard]] auto test(auto const& a) -> std::string;
 #line 15 "mixed-postfix-expression-custom-formatting.cpp2"
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
@@ -26,4 +25,4 @@ auto call(auto const& v, auto const& w, auto const& x, auto const& y, auto const
         ); 
 }
 
-[[nodiscard]] auto main() -> int{}
+auto main() -> int{ }

--- a/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
+++ b/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
@@ -25,4 +25,6 @@ auto call(auto const& v, auto const& w, auto const& x, auto const& y, auto const
         ); 
 }
 
-auto main() -> int{ }
+auto cpp2__main() -> void{}
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-string-interpolation.cpp
+++ b/regression-tests/test-results/mixed-string-interpolation.cpp
@@ -14,7 +14,7 @@ struct custom_struct_with_no_stringize_customization { } custom;
 
 #line 7 "mixed-string-interpolation.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     auto a { 2 }; 
     std::optional<int> b {  }; 
     std::cout << "a = " + cpp2::to_string(a) + ", b = " + cpp2::to_string(b) + "\n";
@@ -60,3 +60,5 @@ auto main() -> int{
 
     std::cout << "custom = " + cpp2::to_string(custom) + "\n";
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-string-interpolation.cpp
+++ b/regression-tests/test-results/mixed-string-interpolation.cpp
@@ -9,13 +9,12 @@
 
 struct custom_struct_with_no_stringize_customization { } custom;
 
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 7 "mixed-string-interpolation.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     auto a { 2 }; 
     std::optional<int> b {  }; 
     std::cout << "a = " + cpp2::to_string(a) + ", b = " + cpp2::to_string(b) + "\n";

--- a/regression-tests/test-results/mixed-type-safety-1.cpp
+++ b/regression-tests/test-results/mixed-type-safety-1.cpp
@@ -37,7 +37,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void
 
 //--- examples -------------------------
 
-auto main() -> int
+auto cpp2__main() -> void
 {
     print( "1.1 is int? ", cpp2::is<int>(1.1));
     print( "1   is int? ", cpp2::is<int>(1));
@@ -48,3 +48,5 @@ auto main() -> int
     print(  "s* is Circle? ", cpp2::is<Circle>(*s));
     print(  "s* is Square? ", cpp2::is<Square>(*s));
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/mixed-type-safety-1.cpp
+++ b/regression-tests/test-results/mixed-type-safety-1.cpp
@@ -17,7 +17,6 @@ auto print(cpp2::in<std::string> msg, auto const& x) -> void;
 #line 16 "mixed-type-safety-1.cpp2"
 auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
 #line 26 "mixed-type-safety-1.cpp2"
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
@@ -38,7 +37,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void
 
 //--- examples -------------------------
 
-[[nodiscard]] auto main() -> int
+auto main() -> int
 {
     print( "1.1 is int? ", cpp2::is<int>(1.1));
     print( "1   is int? ", cpp2::is<int>(1));

--- a/regression-tests/test-results/pure2-bounds-safety-span.cpp
+++ b/regression-tests/test-results/pure2-bounds-safety-span.cpp
@@ -4,7 +4,6 @@
 
 
 #line 2 "pure2-bounds-safety-span.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 14 "pure2-bounds-safety-span.cpp2"
 auto print_and_decorate(auto const& thing) -> void;
 #line 16 "pure2-bounds-safety-span.cpp2"
@@ -14,7 +13,7 @@ auto print_and_decorate(auto const& thing) -> void;
 
 #line 1 "pure2-bounds-safety-span.cpp2"
 
-[[nodiscard]] auto main() -> int
+auto main() -> int
 {
     std::vector<std::string> words { "decorated", "hello", "world" }; 
 

--- a/regression-tests/test-results/pure2-bounds-safety-span.cpp
+++ b/regression-tests/test-results/pure2-bounds-safety-span.cpp
@@ -13,7 +13,7 @@ auto print_and_decorate(auto const& thing) -> void;
 
 #line 1 "pure2-bounds-safety-span.cpp2"
 
-auto main() -> int
+auto cpp2__main() -> void
 {
     std::vector<std::string> words { "decorated", "hello", "world" }; 
 
@@ -24,6 +24,6 @@ auto main() -> int
         print_and_decorate( s[i] );
     }
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto print_and_decorate(auto const& thing) -> void { 
     std::cout << ">> " << thing << "\n"; }

--- a/regression-tests/test-results/pure2-bugfix-for-name-lookup-and-value-decoration.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-name-lookup-and-value-decoration.cpp
@@ -21,7 +21,9 @@ struct vals__ret {
     return  { std::move(i.value()) }; 
 }
 
-auto main() -> int{
+auto cpp2__main() -> void{
     auto v { vals() }; 
     v.i;
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/pure2-bugfix-for-name-lookup-and-value-decoration.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-name-lookup-and-value-decoration.cpp
@@ -10,7 +10,6 @@ struct vals__ret {
 #line 2 "pure2-bugfix-for-name-lookup-and-value-decoration.cpp2"
 [[nodiscard]] auto vals() -> vals__ret;
 #line 6 "pure2-bugfix-for-name-lookup-and-value-decoration.cpp2"
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
@@ -22,7 +21,7 @@ struct vals__ret {
     return  { std::move(i.value()) }; 
 }
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     auto v { vals() }; 
     v.i;
 }

--- a/regression-tests/test-results/pure2-hello.cpp
+++ b/regression-tests/test-results/pure2-hello.cpp
@@ -13,10 +13,10 @@ auto decorate(std::string& s) -> void;
 
 #line 1 "pure2-hello.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::cout << "Hello " << name() << "\n";
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 [[nodiscard]] auto name() -> std::string{
     std::string s { "world" }; 
     decorate(s);

--- a/regression-tests/test-results/pure2-hello.cpp
+++ b/regression-tests/test-results/pure2-hello.cpp
@@ -4,7 +4,6 @@
 
 
 #line 2 "pure2-hello.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 6 "pure2-hello.cpp2"
 [[nodiscard]] auto name() -> std::string;
 #line 12 "pure2-hello.cpp2"
@@ -14,7 +13,7 @@ auto decorate(std::string& s) -> void;
 
 #line 1 "pure2-hello.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::cout << "Hello " << name() << "\n";
 }
 

--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -4,14 +4,13 @@
 
 
 #line 1 "pure2-inspect-expression-in-generic-function-multiple-types.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 20 "pure2-inspect-expression-in-generic-function-multiple-types.cpp2"
 auto test_generic(auto const& x) -> void;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 1 "pure2-inspect-expression-in-generic-function-multiple-types.cpp2"
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::variant<int,double> v { 42.0 }; 
     std::any a { cpp2::as<std::string>("xyzzy") }; 
     std::optional<int> o {  }; 

--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -10,7 +10,7 @@ auto test_generic(auto const& x) -> void;
 //=== Cpp2 definitions ==========================================================
 
 #line 1 "pure2-inspect-expression-in-generic-function-multiple-types.cpp2"
-auto main() -> int{
+auto cpp2__main() -> void{
     std::variant<int,double> v { 42.0 }; 
     std::any a { cpp2::as<std::string>("xyzzy") }; 
     std::optional<int> o {  }; 
@@ -28,7 +28,7 @@ auto main() -> int{
     test_generic(a);
     test_generic(o);
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto test_generic(auto const& x) -> void{
     std::cout 
         << std::setw(30) << typeid(x).name() 

--- a/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
@@ -4,14 +4,13 @@
 
 
 #line 1 "pure2-inspect-expression-with-as-in-generic-function.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 7 "pure2-inspect-expression-with-as-in-generic-function.cpp2"
 auto print_an_int(auto const& x) -> void;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 1 "pure2-inspect-expression-with-as-in-generic-function.cpp2"
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     print_an_int("syzygy");
     print_an_int(1);
     print_an_int(1.1);

--- a/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
@@ -10,12 +10,12 @@ auto print_an_int(auto const& x) -> void;
 //=== Cpp2 definitions ==========================================================
 
 #line 1 "pure2-inspect-expression-with-as-in-generic-function.cpp2"
-auto main() -> int{
+auto cpp2__main() -> void{
     print_an_int("syzygy");
     print_an_int(1);
     print_an_int(1.1);
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto print_an_int(auto const& x) -> void{
     std::cout 
         << std::setw(30) << typeid(x).name() 

--- a/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
@@ -4,7 +4,6 @@
 
 
 #line 2 "pure2-inspect-fallback-with-variant-any-optional.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 14 "pure2-inspect-fallback-with-variant-any-optional.cpp2"
 auto test_generic(auto const& x) -> void;
 
@@ -12,7 +11,7 @@ auto test_generic(auto const& x) -> void;
 
 #line 1 "pure2-inspect-fallback-with-variant-any-optional.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::variant<int,std::string> v { cpp2::as<std::string>("xyzzy") }; 
     std::any a { cpp2::as<std::string>("xyzzy") }; 
     std::optional<std::string> o { cpp2::as<std::string>("xyzzy") }; 

--- a/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
@@ -11,7 +11,7 @@ auto test_generic(auto const& x) -> void;
 
 #line 1 "pure2-inspect-fallback-with-variant-any-optional.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::variant<int,std::string> v { cpp2::as<std::string>("xyzzy") }; 
     std::any a { cpp2::as<std::string>("xyzzy") }; 
     std::optional<std::string> o { cpp2::as<std::string>("xyzzy") }; 
@@ -22,7 +22,7 @@ auto main() -> int{
     test_generic(a);
     test_generic(o);
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto test_generic(auto const& x) -> void{
     std::cout 
         << "\n" << typeid(x).name() << "\n    ..." 

--- a/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
@@ -4,7 +4,6 @@
 
 
 #line 2 "pure2-inspect-generic-void-empty-with-variant-any-optional.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 18 "pure2-inspect-generic-void-empty-with-variant-any-optional.cpp2"
 auto test_generic(auto const& x) -> void;
 
@@ -12,7 +11,7 @@ auto test_generic(auto const& x) -> void;
 
 #line 1 "pure2-inspect-generic-void-empty-with-variant-any-optional.cpp2"
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::unique_ptr<int> p {  }; 
     std::vector<int>::iterator i {  }; 
     std::variant<std::monostate,int,std::string> v {  }; 

--- a/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
@@ -11,7 +11,7 @@ auto test_generic(auto const& x) -> void;
 
 #line 1 "pure2-inspect-generic-void-empty-with-variant-any-optional.cpp2"
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::unique_ptr<int> p {  }; 
     std::vector<int>::iterator i {  }; 
     std::variant<std::monostate,int,std::string> v {  }; 
@@ -26,7 +26,7 @@ auto main() -> int{
     test_generic(a);
     test_generic(o);
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto test_generic(auto const& x) -> void{
     std::cout 
         << "\n" << typeid(x).name() << "\n    ..." 

--- a/regression-tests/test-results/pure2-int-main-arg.cpp
+++ b/regression-tests/test-results/pure2-int-main-arg.cpp
@@ -1,0 +1,16 @@
+// ----- Cpp2 support -----
+#define CPP2_USE_MODULES         Yes
+#include "cpp2util.h"
+
+
+#line 1 "pure2-int-main-arg.cpp2"
+
+//=== Cpp2 definitions ==========================================================
+
+#line 1 "pure2-int-main-arg.cpp2"
+[[nodiscard]] auto cpp2__main(std::span<std::string_view>&& args) -> int{
+    for ( auto&& cpp2_range = std::move(args);  auto const& arg : cpp2_range ) std::cout << arg << '\n';
+    return 0; 
+}
+CPP2_MAIN_INT_ARGS
+

--- a/regression-tests/test-results/pure2-int-main-arg.cpp2.output
+++ b/regression-tests/test-results/pure2-int-main-arg.cpp2.output
@@ -1,0 +1,2 @@
+pure2-int-main-arg.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/regression-tests/test-results/pure2-intro-example-hello-2022.cpp
+++ b/regression-tests/test-results/pure2-intro-example-hello-2022.cpp
@@ -4,7 +4,6 @@
 
 
 #line 1 "pure2-intro-example-hello-2022.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 12 "pure2-intro-example-hello-2022.cpp2"
 [[nodiscard]] auto decorate(auto& thing) -> int;
 #line 17 "pure2-intro-example-hello-2022.cpp2"
@@ -13,7 +12,7 @@ auto println(auto const& x, auto const& len) -> void;
 //=== Cpp2 definitions ==========================================================
 
 #line 1 "pure2-intro-example-hello-2022.cpp2"
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 

--- a/regression-tests/test-results/pure2-intro-example-hello-2022.cpp
+++ b/regression-tests/test-results/pure2-intro-example-hello-2022.cpp
@@ -12,7 +12,7 @@ auto println(auto const& x, auto const& len) -> void;
 //=== Cpp2 definitions ==========================================================
 
 #line 1 "pure2-intro-example-hello-2022.cpp2"
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<std::string> vec { 
                "hello", "2022" }; 
     std::span view { vec }; 
@@ -22,7 +22,7 @@ auto main() -> int{
         println(str, len);
     }
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 [[nodiscard]] auto decorate(auto& thing) -> int{
     thing = "[" + thing + "]";
     return CPP2_UFCS_0(ssize, thing); 

--- a/regression-tests/test-results/pure2-intro-example-three-loops.cpp
+++ b/regression-tests/test-results/pure2-intro-example-three-loops.cpp
@@ -8,7 +8,6 @@ auto print(auto const& thing) -> void;
 #line 5 "pure2-intro-example-three-loops.cpp2"
 auto decorate_and_print(auto& thing) -> void;
 #line 10 "pure2-intro-example-three-loops.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 29 "pure2-intro-example-three-loops.cpp2"
 
 
@@ -24,7 +23,7 @@ auto decorate_and_print(auto& thing) -> void{
     print(thing);
 }
 
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::vector<std::string> words { 
           "hello", "big", "world" }; 
     std::span<std::string> view { words }; 

--- a/regression-tests/test-results/pure2-intro-example-three-loops.cpp
+++ b/regression-tests/test-results/pure2-intro-example-three-loops.cpp
@@ -23,7 +23,7 @@ auto decorate_and_print(auto& thing) -> void{
     print(thing);
 }
 
-auto main() -> int{
+auto cpp2__main() -> void{
     std::vector<std::string> words { 
           "hello", "big", "world" }; 
     std::span<std::string> view { words }; 
@@ -42,3 +42,5 @@ auto main() -> int{
         decorate_and_print(word);
 
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/pure2-stdio-with-raii.cpp
+++ b/regression-tests/test-results/pure2-stdio-with-raii.cpp
@@ -11,8 +11,10 @@
 
 //  "A better C than C" ... ?
 //
-auto main() -> int{
+auto cpp2__main() -> void{
     std::string s { "Freddy" }; 
     auto myfile { cpp2::fopen("xyzzy", "w") }; 
     CPP2_UFCS(fprintf, myfile, "Hello %s with UFCS!", CPP2_UFCS_0(c_str, s));
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/pure2-stdio-with-raii.cpp
+++ b/regression-tests/test-results/pure2-stdio-with-raii.cpp
@@ -4,7 +4,6 @@
 
 
 #line 4 "pure2-stdio-with-raii.cpp2"
-[[nodiscard]] auto main() -> int;
 
 //=== Cpp2 definitions ==========================================================
 
@@ -12,7 +11,7 @@
 
 //  "A better C than C" ... ?
 //
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::string s { "Freddy" }; 
     auto myfile { cpp2::fopen("xyzzy", "w") }; 
     CPP2_UFCS(fprintf, myfile, "Hello %s with UFCS!", CPP2_UFCS_0(c_str, s));

--- a/regression-tests/test-results/pure2-stdio.cpp
+++ b/regression-tests/test-results/pure2-stdio.cpp
@@ -13,9 +13,11 @@
 
 //  "A better C than C" ... ?
 //
-auto main() -> int{
+auto cpp2__main() -> void{
     std::string s { "Fred" }; 
     auto myfile { fopen("xyzzy", "w") }; 
     CPP2_UFCS(fprintf, myfile, "Hello %s with UFCS!", CPP2_UFCS_0(c_str, s));
     CPP2_UFCS_0(fclose, myfile);
 }
+CPP2_MAIN_VOID_NO_ARGS
+

--- a/regression-tests/test-results/pure2-stdio.cpp
+++ b/regression-tests/test-results/pure2-stdio.cpp
@@ -4,7 +4,6 @@
 
 
 #line 4 "pure2-stdio.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 10 "pure2-stdio.cpp2"
 
 
@@ -14,7 +13,7 @@
 
 //  "A better C than C" ... ?
 //
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::string s { "Fred" }; 
     auto myfile { fopen("xyzzy", "w") }; 
     CPP2_UFCS(fprintf, myfile, "Hello %s with UFCS!", CPP2_UFCS_0(c_str, s));

--- a/regression-tests/test-results/pure2-type-safety-1.cpp
+++ b/regression-tests/test-results/pure2-type-safety-1.cpp
@@ -4,7 +4,6 @@
 
 
 #line 2 "pure2-type-safety-1.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 24 "pure2-type-safety-1.cpp2"
 auto test_generic(auto const& x) -> void;
 #line 30 "pure2-type-safety-1.cpp2"
@@ -16,7 +15,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
 
 #line 1 "pure2-type-safety-1.cpp2"
 
-[[nodiscard]] auto main() -> int
+auto main() -> int
 {
     std::variant<int,double> v { 42.0 }; 
     std::any a { "xyzzy" }; 

--- a/regression-tests/test-results/pure2-type-safety-1.cpp
+++ b/regression-tests/test-results/pure2-type-safety-1.cpp
@@ -15,7 +15,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
 
 #line 1 "pure2-type-safety-1.cpp2"
 
-auto main() -> int
+auto cpp2__main() -> void
 {
     std::variant<int,double> v { 42.0 }; 
     std::any a { "xyzzy" }; 
@@ -36,7 +36,7 @@ auto main() -> int
     test_generic(a);
     test_generic(o);
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto test_generic(auto const& x) -> void{
     std::string msg { typeid(x).name() }; 
     msg += " is int? ";

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -4,14 +4,13 @@
 
 
 #line 1 "pure2-type-safety-2-with-inspect-expression.cpp2"
-[[nodiscard]] auto main() -> int;
 #line 20 "pure2-type-safety-2-with-inspect-expression.cpp2"
 auto test_generic(auto const& x) -> void;
 
 //=== Cpp2 definitions ==========================================================
 
 #line 1 "pure2-type-safety-2-with-inspect-expression.cpp2"
-[[nodiscard]] auto main() -> int{
+auto main() -> int{
     std::variant<int,double> v { 42.0 }; 
     std::any a { "xyzzy" }; 
     std::optional<int> o {  }; 

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -10,7 +10,7 @@ auto test_generic(auto const& x) -> void;
 //=== Cpp2 definitions ==========================================================
 
 #line 1 "pure2-type-safety-2-with-inspect-expression.cpp2"
-auto main() -> int{
+auto cpp2__main() -> void{
     std::variant<int,double> v { 42.0 }; 
     std::any a { "xyzzy" }; 
     std::optional<int> o {  }; 
@@ -28,7 +28,7 @@ auto main() -> int{
     test_generic(a);
     test_generic(o);
 }
-
+CPP2_MAIN_VOID_NO_ARGS
 auto test_generic(auto const& x) -> void{
     std::cout 
         << std::setw(30) << typeid(x).name() 

--- a/regression-tests/test-results/pure2-void-main-arg.cpp
+++ b/regression-tests/test-results/pure2-void-main-arg.cpp
@@ -1,0 +1,15 @@
+// ----- Cpp2 support -----
+#define CPP2_USE_MODULES         Yes
+#include "cpp2util.h"
+
+
+#line 1 "pure2-void-main-arg.cpp2"
+
+//=== Cpp2 definitions ==========================================================
+
+#line 1 "pure2-void-main-arg.cpp2"
+auto cpp2__main(std::span<std::string_view>&& args) -> void{
+    for ( auto&& cpp2_range = std::move(args);  auto const& arg : cpp2_range ) std::cout << arg << '\n';
+}
+CPP2_MAIN_VOID_ARGS
+

--- a/regression-tests/test-results/pure2-void-main-arg.cpp2.output
+++ b/regression-tests/test-results/pure2-void-main-arg.cpp2.output
@@ -1,0 +1,2 @@
+pure2-void-main-arg.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -2371,12 +2371,16 @@ public:
             }
             else {
                 assert (n.identifier);
-                if (func->returns.index() != function_type_node::empty && !func->is_main) {
+                if (func->returns.index() != function_type_node::empty) {
                     printer.print_cpp2( "[[nodiscard]] ", n.position() );
                 }
                 printer.print_cpp2( "auto ", n.position() );
-                printer.print_cpp2( *n.identifier->identifier, n.identifier->position() );
-                emit( *func, n.identifier->identifier );
+                if (func->is_main) {
+                    printer.print_cpp2("cpp2__main", n.identifier->position());
+                } else {
+                    printer.print_cpp2(*n.identifier->identifier, n.identifier->position());
+                }
+                emit(*func, n.identifier->identifier);
             }
 
             //  Function declaration
@@ -2490,6 +2494,11 @@ public:
                 function_return_locals, function_epilog, n.position().colno
             );
 
+            if (func->is_main) {
+                std::string ret = func->returns.index() != function_type_node::empty ? "INT" : "VOID";
+                std::string args = func->parameters->parameters.empty() ? "NO_ARGS" : "ARGS";
+                printer.print_cpp2("\nCPP2_MAIN_" + ret + '_' + args + '\n', func->position());
+            }
             function_returns.pop_back();
         }
 

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -2357,6 +2357,10 @@ public:
 
             auto& func = std::get<declaration_node::function>(n.type);
             assert(func);
+            if (printer.doing_declarations_only() && func->is_main) {
+                // main doesn't need a forward declaration.
+                return;
+            }
 
             //  If this is at expression scope, we can't emit "[[nodiscard]] auto name"
             //  so print the provided intro instead, which will be a lambda-capture-list
@@ -2367,7 +2371,7 @@ public:
             }
             else {
                 assert (n.identifier);
-                if (func->returns.index() != function_type_node::empty) {
+                if (func->returns.index() != function_type_node::empty && !func->is_main) {
                     printer.print_cpp2( "[[nodiscard]] ", n.position() );
                 }
                 printer.print_cpp2( "auto ", n.position() );

--- a/source/parse.h
+++ b/source/parse.h
@@ -804,6 +804,7 @@ struct function_type_node
 {
     std::unique_ptr<parameter_declaration_list_node> parameters;
     bool throws = false;
+    bool is_main = false;
 
     enum active { empty = 0, id, list };
     std::variant<


### PR DESCRIPTION
Two patches:
1. Removes the forward declaration of `main` and its `[[nodiscard]]`.
2. Allows `main` to return `void` and allows a `std::span<std::string_view>` argument instead of `int, char**`.