### PR TITLE
[FIX] preserve parens around expressions calculating value of argument for a function call

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1980,7 +1980,9 @@ public:
     auto emit(expression_node const& n) -> void
     {
         assert(n.expr);
+        push_need_expression_list_parens(true);
         emit(*n.expr);
+        pop_need_expression_list_parens();
     }
 
 

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1990,7 +1990,7 @@ public:
     //
     auto emit(expression_list_node const& n) -> void
     {
-        if (should_add_expression_list_parens() && !n.expressions.empty()) {
+        if (should_add_expression_list_parens() && !n.expressions.empty() && !n.inside_initializer) {
             printer.print_cpp2("(", n.position());
         }
 
@@ -2024,7 +2024,7 @@ public:
             }
         }
 
-        if (should_add_expression_list_parens() && !n.expressions.empty()) {
+        if (should_add_expression_list_parens() && !n.expressions.empty() && !n.inside_initializer) {
             printer.print_cpp2(")", n.position());
         }
         //  We want to consume only one of these

--- a/source/parse.h
+++ b/source/parse.h
@@ -257,6 +257,7 @@ struct expression_list_node
 {
     source_position open_paren  = {};
     source_position close_paren = {};
+    bool inside_initializer     = false;
 
     struct term {
         passing_style                    pass = {};
@@ -1317,9 +1318,10 @@ private:
 
         if (curr().type() == lexeme::LeftParen)
         {
+            bool inside_initializer = (peek(-1)->type() == lexeme::Assignment);
             auto open_paren = curr().position();
             next();
-            auto expr_list = expression_list(open_paren);
+            auto expr_list = expression_list(open_paren, inside_initializer);
             if (!expr_list) {
                 error("unexpected text - ( is not followed by an expression-list");
                 next();
@@ -1704,10 +1706,11 @@ private:
     //G     expression
     //G     expression-list , expression
     //G
-    auto expression_list(source_position open_paren) -> std::unique_ptr<expression_list_node> {
+    auto expression_list(source_position open_paren, bool inside_initializer = false) -> std::unique_ptr<expression_list_node> {
         auto pass = passing_style::in;
         auto n = std::make_unique<expression_list_node>();
         n->open_paren = open_paren;
+        n->inside_initializer = inside_initializer;
 
         if (curr().type() == lexeme::Identifier && curr() == "out") {
             pass = passing_style::out;


### PR DESCRIPTION
The current implementation removes parentheses used in expression that calculates the value of arguments for a function.

cpp2 code:
```cpp
f: (x:_) = {}

main: () -> int = {
    i := 2;
    f((i+(i+1)*2)/2);
}
```
When compiled with cppfront we get (I am skipping the boilerplate)
```cpp
[[nodiscard]] auto main() -> int{
    auto i { 2 }; 
    f( i + i + 1 * 2 / 2);
}
```
All parentheses inside the function call are gone. `(i+(i+1)*2)/2` is not equal `i + i + 1 * 2 / 2`.

This fix corrects that behavior and preserves these parentheses. The generated code after the fix:
```cpp
[[nodiscard]] auto main() -> int{
    auto i { 2 }; 
    f((i + (i + 1) * 2) / 2);
}

```

Close https://github.com/hsutter/cppfront/issues/66