### PR TITLE
[SUGGESTION][FIX] Add support for raw string literals in mixed mode

### DIFF
--- a/source/common.h
+++ b/source/common.h
@@ -46,7 +46,7 @@ struct source_line
 {
     std::string text;
 
-    enum class category { empty, preprocessor, comment, import, cpp1, cpp2 }
+    enum class category { empty, preprocessor, comment, import, cpp1, cpp2, rawstring }
         cat = category::empty;
 
     auto prefix() const -> std::string
@@ -58,6 +58,7 @@ struct source_line
         break;case category::import:        return "/* i */ ";
         break;case category::cpp1:          return "/* 1 */ ";
         break;case category::cpp2:          return "/* 2 */ ";
+        break;case category::rawstring:     return "/* R */ ";
         break;default: assert(!"illegal category"); abort();
         }
     }

--- a/source/load.h
+++ b/source/load.h
@@ -196,27 +196,29 @@ auto starts_with_identifier_colon(std::string const& line) -> bool
 struct process_line_ret {
     bool all_comment_line;
     bool empty_line;
+    bool all_rawstring_line;
 };
 auto process_cpp_line(
     std::string const&  line,
     bool&               in_comment,
     bool&               in_string_literal,
+    bool&               in_raw_string_literal,
     std::vector<int>&   brace_depth,
     lineno_t            lineno,
     std::vector<error>& errors
 )
     -> process_line_ret
 {
-    if (!in_comment && !in_string_literal && starts_with_whitespace_slash_slash(line)) {
-        return { true, false };
+    if (!in_comment && !in_string_literal && !in_raw_string_literal && starts_with_whitespace_slash_slash(line)) {
+        return { true, false, false };
     }
 
-    if (!in_comment && !in_string_literal && starts_with_whitespace_slash_star_and_no_star_slash(line)) {
+    if (!in_comment && !in_string_literal && !in_raw_string_literal && starts_with_whitespace_slash_star_and_no_star_slash(line)) {
         in_comment = true;
-        return { true, false };
+        return { true, false, false };
     }
 
-    struct process_line_ret r { in_comment, true };
+    struct process_line_ret r { in_comment, true , in_raw_string_literal};
 
     auto prev = ' ';
     for (auto i = colno_t{0}; i < ssize(line); ++i)
@@ -225,7 +227,7 @@ auto process_cpp_line(
         //  Note: in_literal is for { and } and so doesn't have to work for escaped ' characters
         //
         auto peek       = [&](int num) {  return (i+num < std::ssize(line)) ? line[i+num] : '\0';  };
-        auto in_literal = [&]()        {  return in_string_literal || (prev == '\'' && peek(1) == '\'');  };
+        auto in_literal = [&]()        {  return in_string_literal || in_raw_string_literal || (prev == '\'' && peek(1) == '\'');  };
 
         //  Process this source character
         //
@@ -233,19 +235,31 @@ auto process_cpp_line(
             r.empty_line = false;
         }
 
-        if (in_comment && !in_string_literal) {
+        if (in_comment && !in_string_literal && !in_raw_string_literal) {
             switch (line[i]) {
                 break;case '/': if (prev == '*') { in_comment = false; }
                 break;default: ;
             }
         }
-
+        else if (in_raw_string_literal) {
+            switch (line[i]) {
+                break;case '\"': if (prev == ')') { in_raw_string_literal = false; }
+                break;default: ;
+            }
+        }
         else {
             r.all_comment_line = false;
+            r.all_rawstring_line = false;
             switch (line[i]) {
+                break;case 'R':
+                    if (!in_comment && !in_string_literal && !in_raw_string_literal && peek(1) == '"' && peek(2) == '(') {
+                        in_raw_string_literal = true;
+                        i+=2;
+                    }
+                    
                 break;case '\"':
                     //  If this isn't an escaped quote, toggle string literal state
-                    if (!in_comment && prev != '\\' && (in_string_literal || prev != '\'')) {
+                    if (!in_comment && prev != '\\' && (in_string_literal || prev != '\'') && !in_raw_string_literal) {
                         in_string_literal = !in_string_literal;
                     }
 
@@ -270,10 +284,10 @@ auto process_cpp_line(
                     }
 
                 break;case '*':
-                    if (!in_string_literal && prev == '/') { in_comment = true; }
+                    if (!in_string_literal && !in_raw_string_literal && prev == '/') { in_comment = true; }
 
                 break;case '/':
-                    if (!in_string_literal && prev == '/') { in_comment = false; return r; }
+                    if (!in_string_literal  && !in_raw_string_literal && prev == '/') { in_comment = false; return r; }
 
                 break;default: ;
             }
@@ -438,6 +452,7 @@ public:
 
         auto in_comment        = false;
         auto in_string_literal = false;
+        auto in_raw_string_literal = false;
         auto brace_depth = std::vector<int>();
 
         while (in.getline(&buf[0], max_line_len)) {
@@ -462,7 +477,7 @@ public:
                 //  Switch to cpp2 mode if we're not in a comment, not inside nested { },
                 //  and the line starts with "nonwhitespace :" but not "::"
                 //
-                if (!in_comment && std::ssize(brace_depth) == 0 && starts_with_identifier_colon(lines.back().text))
+                if (!in_comment && !in_raw_string_literal && std::ssize(brace_depth) == 0 && starts_with_identifier_colon(lines.back().text))
                 {
                     cpp2_found= true;
 
@@ -506,12 +521,16 @@ public:
                             lines.back().text,
                             in_comment,
                             in_string_literal,
+                            in_raw_string_literal,
                             brace_depth,
                             std::ssize(lines) - 1,
                             errors
                         );
                         if (stats.all_comment_line) {
                             lines.back().cat = source_line::category::comment;
+                        }
+                        else if (stats.all_rawstring_line) {
+                            lines.back().cat = source_line::category::rawstring;
                         }
                         else if (stats.empty_line) {
                             lines.back().cat = source_line::category::empty;

--- a/source/load.h
+++ b/source/load.h
@@ -243,13 +243,12 @@ auto process_cpp_line(
             }
         }
         else if (in_raw_string_literal) {
-            auto d_char_seq_len = d_char_sequence.size();
-            switch (line[i]) {
-                break;case '\"': if ( i > d_char_seq_len && peek(-d_char_seq_len-1) == ')') { 
-                    in_raw_string_literal = (d_char_sequence != line.substr(i-d_char_seq_len, d_char_seq_len)); 
-                }
-                break;default: ;
+            auto end_pos = line.find(d_char_sequence, i);
+            if (end_pos == std::string::npos) {
+                return r;
             }
+            in_raw_string_literal = false;
+            i = end_pos+d_char_sequence.size()-1;
         }
         else {
             r.all_comment_line = false;
@@ -260,7 +259,7 @@ auto process_cpp_line(
                         i+=2;
                         if (i < ssize(line) - 1) {
                             if (auto paren_pos = line.find("(", i); paren_pos != std::string::npos) {
-                                d_char_sequence = line.substr(i, paren_pos-i);
+                                d_char_sequence = ")"+line.substr(i, paren_pos-i)+"\"";
                                 in_raw_string_literal = true;
                             }
                         }

--- a/source/load.h
+++ b/source/load.h
@@ -203,7 +203,7 @@ auto process_cpp_line(
     bool&               in_comment,
     bool&               in_string_literal,
     bool&               in_raw_string_literal,
-    std::string&        d_char_sequence,
+    std::string&        raw_string_closing_seq,
     std::vector<int>&   brace_depth,
     lineno_t            lineno,
     std::vector<error>& errors
@@ -243,12 +243,12 @@ auto process_cpp_line(
             }
         }
         else if (in_raw_string_literal) {
-            auto end_pos = line.find(d_char_sequence, i);
+            auto end_pos = line.find(raw_string_closing_seq, i);
             if (end_pos == std::string::npos) {
                 return r;
             }
             in_raw_string_literal = false;
-            i = end_pos+d_char_sequence.size()-1;
+            i = end_pos+raw_string_closing_seq.size()-1;
         }
         else {
             r.all_comment_line = false;
@@ -259,7 +259,7 @@ auto process_cpp_line(
                         i+=2;
                         if (i < ssize(line) - 1) {
                             if (auto paren_pos = line.find("(", i); paren_pos != std::string::npos) {
-                                d_char_sequence = ")"+line.substr(i, paren_pos-i)+"\"";
+                                raw_string_closing_seq = ")"+line.substr(i, paren_pos-i)+"\"";
                                 in_raw_string_literal = true;
                             }
                         }
@@ -461,7 +461,7 @@ public:
         auto in_comment            = false;
         auto in_string_literal     = false;
         auto in_raw_string_literal = false;
-        std::string d_char_sequence;
+        std::string raw_string_closing_seq;
 
         auto brace_depth = std::vector<int>();
 
@@ -532,7 +532,7 @@ public:
                             in_comment,
                             in_string_literal,
                             in_raw_string_literal,
-                            d_char_sequence,
+                            raw_string_closing_seq,
                             brace_depth,
                             std::ssize(lines) - 1,
                             errors

--- a/source/load.h
+++ b/source/load.h
@@ -459,8 +459,8 @@ public:
             return false;
         }
 
-        auto in_comment        = false;
-        auto in_string_literal = false;
+        auto in_comment            = false;
+        auto in_string_literal     = false;
         auto in_raw_string_literal = false;
         std::string d_char_sequence;
 


### PR DESCRIPTION
Current implementation in mixed mode is not parsing raw string literals well.

Cpp2 source code
```cpp
auto r = R"(
    this is raw string literal
    \n
    /*   */
    //
i: int = 42;
)";

/*
 *
 *   this is a comment
 *
 */

main: () -> int = {
    std::cout << "Hello world\n\n" << std::quoted(r) << std::endl;
}
```
Compiles to
```cpp
// ----- Cpp2 support -----
#include "cpp2util.h"

#line 1 "/Users/filipsajdak/dev/execspec/external/tests/raw_string.cpp2"

auto r = R"(
    this is raw string literal
    \n
    /*   */
    //

#line 7 "/Users/filipsajdak/dev/execspec/external/tests/raw_string.cpp2"
#line 8 "/Users/filipsajdak/dev/execspec/external/tests/raw_string.cpp2"
)";

#line 16 "/Users/filipsajdak/dev/execspec/external/tests/raw_string.cpp2"
[[nodiscard]] auto main() -> int;

//=== Cpp2 definitions ==========================================================

#line 7 "/Users/filipsajdak/dev/execspec/external/tests/raw_string.cpp2"
int i { 42 }; 
#line 9 "/Users/filipsajdak/dev/execspec/external/tests/raw_string.cpp2"

/*
 
    this is a comment
 
 */

[[nodiscard]] auto main() -> int{
    std::cout << "Hello world\n\n" << std::quoted(r) << std::endl;
}
```

The proposed change makes cppfront parse raw string literals in a similar way as it parses `/* */` comments. After this change cppfront produces:
```cpp
// ----- Cpp2 support -----
#include "cpp2util.h"

#line 1 "/Users/filipsajdak/dev/execspec/external/tests/raw_string.cpp2"

auto r = R"(
    this is raw string literal
    \n
    /*   */
    //
i: int = 42;
)";

#line 16 "/Users/filipsajdak/dev/execspec/external/tests/raw_string.cpp2"
[[nodiscard]] auto main() -> int;

//=== Cpp2 definitions ==========================================================

#line 9 "/Users/filipsajdak/dev/execspec/external/tests/raw_string.cpp2"

/*
 
    this is a comment
 
 */

[[nodiscard]] auto main() -> int{
    std::cout << "Hello world\n\n" << std::quoted(r) << std::endl;
}
```
Debug info shows that the lines are recognized as `/* R */` which was added symbol to mark raw string literals lines.
```
/*   */ 
/* 1 */ auto r = R"(
/* R */     this is raw string literal
/* R */     \n
/* R */     /*   */
/* R */     //
/* R */ i: int = 42;
/* 1 */ )";
/* 2 */ 
/* 2 */ /*
/* 2 */  *
/* 2 */  *   this is a comment
/* 2 */  *
/* 2 */  */
/* 2 */ 
/* 2 */ main: () -> int = {
/* 2 */     std::cout << "Hello world\n\n" << std::quoted(r) << std::endl;
/* 2 */ }
```

Close https://github.com/hsutter/cppfront/issues/62