### PR TITLE
[FIX] Add missing overload for `is` function to handle enums

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -548,6 +548,14 @@ auto is( X const& x ) -> bool {
     return x == X();
 }
 
+template< auto value, typename X >
+auto is( X const& x ) -> bool {
+    if constexpr (std::is_convertible_v<decltype(value),X>) {
+        return x == value;
+    } else {
+        return false;
+    }
+}
 
 //-------------------------------------------------------------------------------------------------------------
 //  Built-in as (partial)


### PR DESCRIPTION
The current implementation does not have an overload for the `is` function to handle `enums`.

The below code compiles by cppfront but the result code fails to compile with the cpp1 compiler.
```cpp
enum class lexeme : std::uint8_t {
    hash,
};

to_string: (e:lexeme) -> auto = {
    return inspect (e) -> std::string {
        is lexeme::hash = "hash";
        is _ = "INTERNAL_ERROR";
    };
}
```
cppfront result
```cpp
[[nodiscard]] auto to_string(cpp2::in<lexeme> e) -> auto{
    return [&] () -> std::string { auto&& __expr = (e);
        if (cpp2::is<lexeme::hash>(__expr)) { if constexpr( requires{"hash";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF("hash"),std::string> ) return "hash"; else return std::string{}; else return std::string{}; }
        else return "INTERNAL_ERROR"; }
    ()
; }
```

Unfortunately, there is no overload that can match using an enum value. This change provides additional overload that works with enums - it checks if the value is an enum type and if the compared value is the same type as the enum value provided.

Working prototype: https://godbolt.org/z/1c4o8qG6P

Close https://github.com/hsutter/cppfront/issues/73