### PR TITLE
[SUGGESTION] Add inspect alternatives for literals

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1282,8 +1282,11 @@ public:
 
             auto id = std::string{};
             printer.emit_to_string(&id);
-            assert(alt->id_expression);
-            emit(*alt->id_expression);
+            assert(alt->id_expression || alt->literal);
+            if (alt->id_expression)
+                emit(*alt->id_expression);
+            else if (alt->literal)
+                emit(*alt->literal);
             printer.emit_to_string();
 
             assert (*alt->is_as_keyword == "is" || *alt->is_as_keyword == "as");


### PR DESCRIPTION
The current implementation of alternatives for inspect handles only types. It makes it impossible to replace the cpp1 switch with it. This change brings support for literals in alternatives which makes it possible to use as in given example:
```cpp
std::cout << inspect v -> std::string {
  is lexeme::hash  = "lexeme hash enum";
  is lexeme2::hash = "lexeme2 hash enum";
  is "hash"        = "'hash' string";
  is 42            = "42 int";
  is 1.23          = "1.23 double";
  is 'a'           = "'a' character";
  is _             = "unmatched value";
} << std::endl;
```

The implementation of specializations of `is()` functions is complicated by the fact that the support for Non-Type Template Parameters (NTTP) is not fully (uniformly) implemented in GCC, clang, and MSVC. I have made a lot of tests to find a solution with workarounds that will not require preprocessor ifs for the specific compiler but one issue in clang makes me use it (probably a bug in clang). A working prototype of the solution is available here: https://godbolt.org/z/j1fqWKa9G (if you have any idea how to improve the implementation please let me know).

One of the supported NTTPs is `double` but there is an issue in clang and MSVC with it which was solved by introducing an intermediate type `double_wrapper` that makes it work for clang and MSVC. Unfortunately, it additionally needs a special version of `is()` function that makes the magic work for clang.

During my experiments, I have been studying https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2392r0.pdf to understand the feature.

This PR makes https://github.com/hsutter/cppfront/pull/74 obsolete - enums are also covered by this implementation. Closes https://github.com/hsutter/cppfront/issues/73