### PR TITLE
[SUGGESTION] Add inspection of `std::variant` and `std::optional` values

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -813,6 +813,31 @@ auto as( std::variant<Ts...> const& x ) {
     throw std::bad_variant_access();
 }
 
+template< auto value, typename... Ts >
+constexpr auto is_impl( std::variant<Ts...> const& v ) -> bool {
+    if (v.valueless_by_exception()) return false;
+    //  Need to guard this with is_any otherwise the holds_alternative is illegal
+    if constexpr (is_any<std::monostate, Ts...>) if (std::holds_alternative<std::monostate>(v)) return false;
+
+    return std::visit([](auto&& arg) -> bool {
+        return cpp2::is<value>(CPP2_FORWARD(arg));
+    }, v);
+}
+
+template< auto value, typename... Ts >
+constexpr auto is( std::variant<Ts...> const& v ) -> bool {
+    return cpp2::is_impl<value>(v);
+}
+
+template< cstring_wrapper value, typename... Ts >
+constexpr auto is( std::variant<Ts...> const& v ) -> bool {
+    return cpp2::is_impl<value>(v);
+}
+
+template< double_wrapper value, typename... Ts >
+constexpr auto is( std::variant<Ts...> const& v ) -> bool {
+    return cpp2::is_impl<value>(v);
+}
 
 //-------------------------------------------------------------------------------------------------------------
 //  std::any is and as

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -871,6 +871,26 @@ template<typename T, typename U>
 constexpr auto is( std::optional<U> const& x ) -> bool
     { return !x.has_value(); }
 
+template<auto value, typename T>
+constexpr auto is_impl( std::optional<T> const& x ) -> bool {
+    if ( x.has_value() )
+        return cpp2::is<value>(x.value());
+    else
+        return false;
+}
+
+template<auto value, typename T>
+constexpr auto is( std::optional<T> const& x ) -> bool
+    { return cpp2::is_impl<value>(x); }
+
+template<cstring_wrapper value, typename T>
+constexpr auto is( std::optional<T> const& x ) -> bool
+    { return cpp2::is_impl<value>(x); }
+
+template<double_wrapper value, typename T>
+constexpr auto is( std::optional<T> const& x ) -> bool
+    { return cpp2::is_impl<value>(x); }
+
 template<typename T, typename X>
     requires std::is_same_v<X,std::optional<T>>
 constexpr auto as( X const& x ) -> auto&&

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1282,8 +1282,11 @@ public:
 
             auto id = std::string{};
             printer.emit_to_string(&id);
-            assert(alt->id_expression);
-            emit(*alt->id_expression);
+            assert(alt->id_expression || alt->literal);
+            if (alt->id_expression)
+                emit(*alt->id_expression);
+            else if (alt->literal)
+                emit(*alt->literal);
             printer.emit_to_string();
 
             assert (*alt->is_as_keyword == "is" || *alt->is_as_keyword == "as");


### PR DESCRIPTION
Current implementation of `inspect` and `is` allows to inspect types. https://github.com/hsutter/cppfront/pull/79 add inspection capabilities to check values of variables (what allows to replace cpp1 switches). 

This change introduce possibility to inspect values stored in `std::variant` and `std::optional` what make given code work:
```cpp
v : std::variant<lexeme, lexeme2, std::string, int, double, char, my_struct> = lexeme2::hash;

std::cout << inspect v -> std::string {
    is lexeme::hash  = "original lexeme";
    is lexeme2::hash = "fake lexeme2";
    is "hash"        = "it is string 'hash'";
    is 42            = "the answer is 42";
    is 1.23          = "the answer is 1.23";
    is 'a'           = "this is 'a'";
    is _             = "don't know";
} << std::endl;
```
or you can use it as if statement with `std::optional`
```cpp
o : std::optional<std::string> = "hash";

if o is "hash" {
    std::cout << "Optional has 'hash' value" << std::endl;
} else {
    std::cout << "There is something else" << std::endl;
}
```
or `std::variant`
```cpp
if v is 1.23 {
  std::cout << "This is 1.23" << std::end;
}
```

This PR is based on https://github.com/hsutter/cppfront/pull/79