### PR TITLE
[SUGGESTION] Add possibility of using lambda in is-statements (inspect and if statements)

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -704,6 +704,31 @@ constexpr auto is( X const& x ) -> bool {
         return false;
 }
 
+template <typename F, typename Capture = std::monostate>
+    requires (
+        requires { &F::operator(); }
+    )
+struct lambda_wrapper {
+    F f;
+    Capture capture;
+
+    constexpr lambda_wrapper(F f, Capture capture = {})
+    : f{f}, capture{capture} {}
+
+    template <typename X>
+    auto operator()(X&& x) const {
+        if constexpr (std::is_same_v<Capture, std::monostate>)
+            return f(std::forward<X>(x));
+        else
+            return f(std::forward<X>(x), capture);
+    }
+};
+
+template< lambda_wrapper value, typename X >
+constexpr auto is( X const& x ) -> bool {
+    return value(x);
+}
+
 //-------------------------------------------------------------------------------------------------------------
 //  Built-in as (partial)
 //

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1283,10 +1283,16 @@ public:
             auto id = std::string{};
             printer.emit_to_string(&id);
             assert(alt->id_expression || alt->literal);
-            if (alt->id_expression)
+            if (alt->id_expression) {
                 emit(*alt->id_expression);
-            else if (alt->literal)
+                if (alt->expr) {
+                    push_need_expression_list_parens(true);
+                    emit(*alt->expr);
+                    pop_need_expression_list_parens();
+                }
+            } else if (alt->literal) {
                 emit(*alt->literal);
+            }
             printer.emit_to_string();
 
             assert (*alt->is_as_keyword == "is" || *alt->is_as_keyword == "as");

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1282,8 +1282,11 @@ public:
 
             auto id = std::string{};
             printer.emit_to_string(&id);
-            assert(alt->id_expression);
-            emit(*alt->id_expression);
+            assert(alt->id_expression || alt->literal);
+            if (alt->id_expression)
+                emit(*alt->id_expression);
+            else if (alt->literal)
+                emit(*alt->literal);
             printer.emit_to_string();
 
             assert (*alt->is_as_keyword == "is" || *alt->is_as_keyword == "as");


### PR DESCRIPTION
In https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2392r0.pdf there is an example that uses lambda with `is` keyword.

```cpp
cout << inspect i -> std::string {
  is in(1,2) = "1 or 2";
  is in(2,3) = "3";
  is _ = "something else";
};
```
or
```cpp
if i is in(10,20) {
  cout << "I between 10 and 20" << endl;
}
```

I started to experiment with current implementation to achieve the same functionality and I came up with implementation that you can check here: https://godbolt.org/z/464PP7bW6 (working prototype).

Unfortunately lambda with the capture list cannot be argument of the template (only gcc supports that). So, I have created a wrapper that stores a lambda and the arguments that normally will go to the capture list.

```cpp
#include <utility>
#include <tuple>
#include <iostream>
#include <vector>

constexpr auto less_than = [](auto value) {
    return cpp2::lambda_wrapper([](auto x, auto capture) { return x < capture;}, value);
};

constexpr auto in = [](auto min, auto max) {
    return cpp2::lambda_wrapper([](auto x, auto capture) { 
        return std::get<0>(capture) <= x && x <= std::get<1>(capture);
    }, std::pair(min,max));
};

constexpr auto empty = cpp2::lambda_wrapper([](auto x){
    return std::empty(x);
});

main: () -> int = {
    i := 15;

    if i is less_than(20) {
        std::cout << "less than 20" << std::endl;
    }

    if i is in(10,30) {
        std::cout << "i is between 10 and 30" << std::endl;
    }

    v : std::vector<int> = ();

    if v is empty {
        std::cout << "v is empty" << std::endl;
    }
}
```

`lambda_wrapper` shall use `std::tuple` to store arguments that shall go to capture list but `std::tuple` is not structural type and cannot be used in that context. There are possible workarounds (https://stackoverflow.com/questions/69194075/structural-tuple-like-wrapping-a-variadic-set-of-template-parameters-values-in) but I decided to propose something simple.

The current implementation can handle lambda that captures:
* none argument - using `std::monostate` that is default second template argument type (`lambda_wrapper([](auto x){/**/})`),
* one argument - (`lambda_wrapper([](auto x, auto capture){/**/}, captured_value)`),
* two arguments - using `std::pair` (`lambda_wrapper([](auto x, auto capture){/**/}, std::pair(/* captured two values */) )`),

If more captured values will be needed we need to add tuple-like structure that will be structural type.

On the last push I have made possible using `lambda_wrapper` in inspect alternatives (by making `id-expression ( expression-list )` an valid alternative syntax.

That makes this code works:
```cpp
std::cout << inspect i -> std::string {
    is less_than(10) = "i less than 10";
    is in(11,20) = "i is between 11 and 20";
    is _ = "i is out of our interest";
} << std::endl;
```
