### PR TITLE
[FIX] Add support for multi-level pointers

### DIFF
--- a/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
@@ -15,7 +15,7 @@ auto null_from_cpp1() -> int* { return nullptr; }
 
 auto try_pointer_stuff() -> void;
 #line 21 "mixed-lifetime-safety-and-null-contracts.cpp2"
-auto call_my_framework(cpp2::in<const char *> msg) -> void;
+auto call_my_framework(cpp2::in<const char*> msg) -> void;
 
 //=== Cpp2 definitions ==========================================================
 
@@ -29,12 +29,12 @@ auto call_my_framework(cpp2::in<const char *> msg) -> void;
 #line 14 "mixed-lifetime-safety-and-null-contracts.cpp2"
 
 auto try_pointer_stuff() -> void{
-    int* p { null_from_cpp1() }; 
+    int * p { null_from_cpp1() }; 
     *p = 42;    // deliberate null dereference
                 // to show -n
 }
 
-auto call_my_framework(cpp2::in<const char *> msg) -> void { 
+auto call_my_framework(cpp2::in<const char*> msg) -> void { 
     std::cout 
         << "sending error to my framework... [" 
         << msg << "]\n"; }

--- a/regression-tests/test-results/mixed-type-safety-1.cpp
+++ b/regression-tests/test-results/mixed-type-safety-1.cpp
@@ -44,7 +44,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void
     print( "1   is int? ", cpp2::is<int>(1));
 
     auto c { cpp2_new<Circle>() }; // safe by construction
-    Shape* s { CPP2_UFCS_0(get, c) }; // safe by Lifetime
+    Shape * s { CPP2_UFCS_0(get, c) }; // safe by Lifetime
     print("\ns* is Shape?  ", cpp2::is<Shape>(*s));
     print(  "s* is Circle? ", cpp2::is<Circle>(*s));
     print(  "s* is Square? ", cpp2::is<Square>(*s));


### PR DESCRIPTION
Current implementation supports only pointer of the form
```cpp
p: *int = ...;
```

This change extends that to allow multi-level pointers and make below code compilable
```cpp
main: (argc : int, argv : **char) -> int = {
    a:     int = 2;
    pa:   *int = a&;
    ppa: **int = pa&;

    return a*pa**ppa**; // 8
}
```
and generates the cpp1 code
```cpp
// ----- Cpp2 support -----
#include "cpp2util.h"


#line 1 "tests/pointer-to-pointer.cpp2"
[[nodiscard]] auto main(cpp2::in<int> argc, cpp2::in<char * *> argv) -> int;

//=== Cpp2 definitions ==========================================================

#line 1 "tests/pointer-to-pointer.cpp2"
[[nodiscard]] auto main(cpp2::in<int> argc, cpp2::in<char * *> argv) -> int{
    int a { 2 }; 
    int* pa { &a }; 
    int** ppa { &pa }; 

    return a * *pa * **ppa; // 8
}
```

Closes https://github.com/hsutter/cppfront/issues/78 and makes possible to implement correct main function with arguments.

# Open issues

This change still does not support deduced pointer types (just like the current implementation). That means:
```cpp
pa = 0;
```
will cause an error as cppfront knows that pa is a pointer to pointer
```
tests/pointer-to-pointer.cpp2...
pointer-to-pointer.cpp2(6,8): error: = - pointer assignment from null or integer is illegal
  ==> program violates lifetime safety guarantee - see previous errors
```
but this code:
```cpp
pa2 := ppa*;
pa2 = 0;

pa3 := a&;
pa3 = 0;
```
will pass lifetime safety guarantee checks and will compile to cpp1 code:
```cpp
auto pa2 { *ppa }; 
pa2 = 0;

auto pa3 { &a }; 
pa3 = 0;
```

Having multi-level pointer makes that issue more important to be fixed as it is easier to deduce a pointer from pointer to pointer.