### PR TITLE
[SUGGESTION][FIX] Add pointer deduce type support

### DIFF
--- a/regression-tests/pure2-deduced-pointers.cpp2
+++ b/regression-tests/pure2-deduced-pointers.cpp2
@@ -1,0 +1,24 @@
+main: (argc : int, argv : **char) -> int = {
+    a:     int = 2;
+    pa:   *int = a&;
+    ppa: **int = pa&;
+
+    pa = 0;   // caught
+
+    pa2:= ppa*;
+    pa2 = 0;  // caught
+
+    pa3 := a&;
+    pa3 = 0;  // caught
+    pa3 += 2; // caught
+
+    ppa2 := pa2&;
+    pa4 := ppa2*;
+    pa4 = 0;  // caught
+
+    pppa := ppa&;
+    pa5 := pppa**;
+    pa5 = 0;  // caught
+
+    return a*pa**ppa**; // 8
+}

--- a/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
@@ -15,7 +15,7 @@ auto null_from_cpp1() -> int* { return nullptr; }
 
 auto try_pointer_stuff() -> void;
 #line 21 "mixed-lifetime-safety-and-null-contracts.cpp2"
-auto call_my_framework(cpp2::in<const char *> msg) -> void;
+auto call_my_framework(cpp2::in<const char*> msg) -> void;
 
 //=== Cpp2 definitions ==========================================================
 
@@ -29,12 +29,12 @@ auto call_my_framework(cpp2::in<const char *> msg) -> void;
 #line 14 "mixed-lifetime-safety-and-null-contracts.cpp2"
 
 auto try_pointer_stuff() -> void{
-    int* p { null_from_cpp1() }; 
+    int * p { null_from_cpp1() }; 
     *p = 42;    // deliberate null dereference
                 // to show -n
 }
 
-auto call_my_framework(cpp2::in<const char *> msg) -> void { 
+auto call_my_framework(cpp2::in<const char*> msg) -> void { 
     std::cout 
         << "sending error to my framework... [" 
         << msg << "]\n"; }

--- a/regression-tests/test-results/mixed-type-safety-1.cpp
+++ b/regression-tests/test-results/mixed-type-safety-1.cpp
@@ -44,7 +44,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void
     print( "1   is int? ", cpp2::is<int>(1));
 
     auto c { cpp2_new<Circle>() }; // safe by construction
-    Shape* s { CPP2_UFCS_0(get, c) }; // safe by Lifetime
+    Shape * s { CPP2_UFCS_0(get, c) }; // safe by Lifetime
     print("\ns* is Shape?  ", cpp2::is<Shape>(*s));
     print(  "s* is Circle? ", cpp2::is<Circle>(*s));
     print(  "s* is Square? ", cpp2::is<Square>(*s));

--- a/regression-tests/test-results/pure2-deduced-pointers.cpp2.output
+++ b/regression-tests/test-results/pure2-deduced-pointers.cpp2.output
@@ -1,0 +1,9 @@
+pure2-deduced-pointers.cpp2...
+pure2-deduced-pointers.cpp2(6,8): error: = - pointer assignment from null or integer is illegal
+pure2-deduced-pointers.cpp2(9,9): error: = - pointer assignment from null or integer is illegal
+pure2-deduced-pointers.cpp2(12,9): error: = - pointer assignment from null or integer is illegal
+pure2-deduced-pointers.cpp2(13,9): error: += - pointer assignment from null or integer is illegal
+pure2-deduced-pointers.cpp2(17,9): error: = - pointer assignment from null or integer is illegal
+pure2-deduced-pointers.cpp2(21,9): error: = - pointer assignment from null or integer is illegal
+  ==> program violates lifetime safety guarantee - see previous errors
+

--- a/source/parse.h
+++ b/source/parse.h
@@ -847,6 +847,10 @@ struct declaration_node
     source_position pos;
     std::unique_ptr<unqualified_id_node> identifier;
 
+    token const* dereference = nullptr;
+    int dereference_cnt = 0;
+    token const* address_of  = nullptr;
+
     enum active { function, object };
     std::variant<
         std::unique_ptr<function_type_node>,
@@ -2873,6 +2877,19 @@ private:
                     error("pointer cannot be initialized to null or int - leave it uninitialized and then set it to a non-null value when you have one");
                     violates_lifetime_safety = true;
                     throw std::runtime_error("null initialization detected");
+                }
+            }
+
+            if (deduced_type) {
+                if (peek(1)->type() == lexeme::Ampersand) {
+                    n->address_of  = &curr();
+                } 
+                else if (peek(1)->type() == lexeme::Multiply) {
+                    n->dereference = &curr();
+                    n->dereference_cnt = 1;
+                    while(peek(n->dereference_cnt+1)->type() == lexeme::Multiply) {
+                        n->dereference_cnt += 1;
+                    }
                 }
             }
 


### PR DESCRIPTION
Current implementation is not handling deduced pointer types when analysing safety checks.

It means that this code will pass safety checks
```cpp
i : int = 42;
pi := i&;
pi = 0; // this should trigger error
```

This change introduce support for deduced pointer types and makes safety checks work with below code:
```cpp
main: (argc : int, argv : **char) -> int = {
    a:     int = 2;
    pa:   *int = a&;
    ppa: **int = pa&;

    pa = 0; // error

    pa2:= ppa*;
    pa2 = 0; // error

    pa3 := a&;
    pa3 = 0;  // error
    pa3 += 2; // error

    ppa2 := pa2&;
    pa4 := ppa2*;

    pa4 = 0; // error

    pppa := ppa&;
    pa5 := pppa**;
    pa5 = 0; // error

    return a*pa**ppa**; // 8
}
```
and will cause errors
```
tests/pointer-to-pointer.cpp2...
pointer-to-pointer.cpp2(6,8): error: = - pointer assignment from null or integer is illegal
pointer-to-pointer.cpp2(9,9): error: = - pointer assignment from null or integer is illegal
pointer-to-pointer.cpp2(12,9): error: = - pointer assignment from null or integer is illegal
pointer-to-pointer.cpp2(13,9): error: += - pointer assignment from null or integer is illegal
pointer-to-pointer.cpp2(18,9): error: = - pointer assignment from null or integer is illegal
pointer-to-pointer.cpp2(22,9): error: = - pointer assignment from null or integer is illegal
  ==> program violates lifetime safety guarantee - see previous errors
```

Based on https://github.com/hsutter/cppfront/pull/93