### PR TITLE
[SUGGESTION][FIX] Add support for pointer as function return types

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -2338,6 +2338,9 @@ public:
             auto& r = std::get<function_type_node::id>(n.returns);
             assert(r);
             emit(*r);
+            for (auto _ : n.returns_pointer_declarators) {
+                printer.print_cpp2("*", n.position());
+            }
         }
 
         else {

--- a/source/parse.h
+++ b/source/parse.h
@@ -808,6 +808,7 @@ struct function_type_node
         std::unique_ptr<id_expression_node>,
         std::unique_ptr<parameter_declaration_list_node>
     > returns;
+    std::vector<token const*> returns_pointer_declarators;
 
     std::vector<std::unique_ptr<contract_node>> contracts;
 
@@ -2739,6 +2740,13 @@ private:
         if (curr().type() == lexeme::Arrow)
         {
             next();
+
+            if (curr().type() == lexeme::Multiply) {
+                while (curr().type() == lexeme::Multiply) {
+                    n->returns_pointer_declarators.push_back(&curr());
+                    next();
+                }
+            }
 
             if (auto t = id_expression()) {
                 auto is_void = false;


### PR DESCRIPTION
Current implementation does not allows to write functions that explicitly return pointers (they can be deduced with using auto).

```cpp
working: (inout i : int) -> auto = {
    return i&;
}

not_working: (inout i : int) -> *int = {
    return i&;
}
```

During the presentation, Herb presented a function that returns a pointer (https://github.com/hsutter/cppfront/wiki/Design-note%3A-Postfix-operators#two-examples-from-cppfront-parseh) so I have implemented it.
```cpp
peek: (this, num: int) -> * const token = {
    // skipping content
}
```
If we skip explicit `this` use then the rest of the function will compile in cppfront after this change. So, this code will compile:
```cpp
peek: (num: int) -> * const token = {
    // skipping content
}
```

The support for multi-level pointers is included.