### PR TITLE
[FIX] Correct get_declaration_of not to skip first symbol

### DIFF
--- a/source/sema.h
+++ b/source/sema.h
@@ -244,11 +244,11 @@ public:
 
         //  Then look backward to find the first declaration of
         //  this name that is not deeper (in a nested scope)
-        for ( ; i != symbols.cbegin(); --i )
+        for (auto ri = std::make_reverse_iterator(i+1); ri != symbols.crend(); ++ri )
         {
-            if (i->sym.index() == symbol::active::declaration && i->depth <= depth)
+            if (ri->sym.index() == symbol::active::declaration && ri->depth <= depth)
             {
-                auto const& decl = std::get<symbol::active::declaration>(i->sym);
+                auto const& decl = std::get<symbol::active::declaration>(ri->sym);
 
                 assert(decl.declaration);
                 if (
@@ -261,7 +261,7 @@ public:
                 if (decl.identifier && *decl.identifier == t) {
                     return &decl;
                 }
-                depth = i->depth;
+                depth = ri->depth;
             }
         }
 

--- a/source/sema.h
+++ b/source/sema.h
@@ -250,9 +250,10 @@ public:
             {
                 auto const& decl = std::get<symbol::active::declaration>(i->sym);
 
-                //  Don't look beyond the current function
                 assert(decl.declaration);
-                if (decl.declaration->type.index() == declaration_node::function) {
+                if (
+                    decl.declaration->type.index() == declaration_node::function //  Don't look beyond the current function
+                ) {
                     return nullptr;
                 }
 


### PR DESCRIPTION
While looking for the symbol there is a loop that searches backward using normal iterators. The loop will never check symbols.cbegin() as it is excluded by `i != symbols.cbegin()` condition.

That makes in the below code we will never find the `fun` symbol
```cpp
fun: (inout i : int) -> * const int = {
    return i&;
}

main: () -> int = {
    i := 42;
    p := fun(i);
    // ...
}
```

This change replaces normal iterators with `std::reverse_iterator`.