### PR TITLE
[SUGGESTION][FIX] Add narrowing 'as' cast and static assert failure instead of nonesuch…

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1160,6 +1160,18 @@ inline constexpr auto as() -> O
     }
 }
 
+template< typename IsChecked, typename C, typename X >
+auto inspect_as( X&& x ) -> auto
+{
+    using T = std::remove_cvref_t<X>;
+
+    if constexpr (is_optional_v<C> ) {
+        return as<C, T>(std::forward<X>(x));
+    } else {
+        return as<std::optional<C>, T>(std::forward<X>(x)).value();
+    }
+}
+
 template<typename T, auto x>
 constexpr auto as( ) -> decltype(auto)
     { return as<T, x, decltype(x)>();  }

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1178,11 +1178,13 @@ constexpr auto as( ) -> decltype(auto)
 
 //-----------------------------------------------------------------------
 //
-template<typename T, typename X>
-    requires std::is_same_v<X,std::optional<T>>
-constexpr auto as( X const& x ) -> decltype(auto)
-    { return x.value(); }
+//  Unsafe narrow cast
 
+template <typename C, typename X>
+auto unsafe_narrow( X&& x ) noexcept -> decltype(auto)
+{
+    return static_cast<C>(std::forward<X>(x));
+}
 
 //-----------------------------------------------------------------------
 //

--- a/regression-tests/test-results/mixed-inspect-values.cpp
+++ b/regression-tests/test-results/mixed-inspect-values.cpp
@@ -50,7 +50,7 @@ auto test(auto const& x) -> void{
         else if (cpp2::is(__expr, in_2_3)) { if constexpr( requires{"3";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("3")),std::string> ) return "3"; else return std::string{}; else return std::string{}; }
         else if (cpp2::is(__expr, std::move(forty_two))) { if constexpr( requires{"the answer";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("the answer")),std::string> ) return "the answer"; else return std::string{}; else return std::string{}; }
         else if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + cpp2::to_string(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + cpp2::to_string(x))),std::string> ) return "integer " + cpp2::to_string(x); else return std::string{}; else return std::string{}; }
-        else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{cpp2::as<std::string>(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((cpp2::as<std::string>(x))),std::string> ) return cpp2::as<std::string>(x); else return std::string{}; else return std::string{}; }
+        else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{cpp2::inspect_as<std::string, std::string>(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((cpp2::inspect_as<std::string, std::string>(x))),std::string> ) return cpp2::inspect_as<std::string, std::string>(x); else return std::string{}; else return std::string{}; }
         else return "(no match)"; }
     () << "\n";
 }

--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -35,8 +35,8 @@ auto test_generic(auto const& x, auto const& msg) -> void{
         << std::setw(30) << msg 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + std::to_string(cpp2::as<int>(x)))),std::string> ) return "integer " + std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
-            else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{'"' + cpp2::as<std::string>(x) + '"';} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(('"' + cpp2::as<std::string>(x) + '"')),std::string> ) return '"' + cpp2::as<std::string>(x) + '"'; else return std::string{}; else return std::string{}; }
+            if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + std::to_string(cpp2::inspect_as<int, int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + std::to_string(cpp2::inspect_as<int, int>(x)))),std::string> ) return "integer " + std::to_string(cpp2::inspect_as<int, int>(x)); else return std::string{}; else return std::string{}; }
+            else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{'"' + cpp2::inspect_as<std::string, std::string>(x) + '"';} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(('"' + cpp2::inspect_as<std::string, std::string>(x) + '"')),std::string> ) return '"' + cpp2::inspect_as<std::string, std::string>(x) + '"'; else return std::string{}; else return std::string{}; }
             else return "not an int or string"; }
         () 
         << "\n";

--- a/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
@@ -22,7 +22,7 @@ auto print_an_int(auto const& x) -> void{
         << std::setw(30) << cpp2::to_string(x) 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
+            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::inspect_as<int, int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::inspect_as<int, int>(x)))),std::string> ) return std::to_string(cpp2::inspect_as<int, int>(x)); else return std::string{}; else return std::string{}; }
             else return "not an int"; }
         () 
         << "\n";

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -35,7 +35,7 @@ auto test_generic(auto const& x, auto const& msg) -> void{
         << std::setw(30) << msg 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
+            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::inspect_as<int, int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::inspect_as<int, int>(x)))),std::string> ) return std::to_string(cpp2::inspect_as<int, int>(x)); else return std::string{}; else return std::string{}; }
             else return "not an int"; }
         () 
         << "\n";

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1996,6 +1996,16 @@ public:
     {
         std::string prefix = {};
         std::string suffix = {};
+        bool        as_on_literal = false;
+
+        assert(n.expr);
+        assert(n.expr->get_postfix_expression_node()->expr);
+        if (auto t = n.expr->get_postfix_expression_node()->expr->get_token();
+            t && is_literal(t->type()) && t->type() != lexeme::StringLiteral && t->type() != lexeme::FloatLiteral
+            && std::ssize(n.ops) > 0 && *n.ops[0].op == "as"
+        ) {
+            as_on_literal = true;
+        }
 
         for (auto i = n.ops.rbegin(); i != n.ops.rend(); ++i)
         {
@@ -2014,8 +2024,14 @@ public:
             }
         }
 
+        if (as_on_literal) {
+            auto last_pos = prefix.rfind('>'); assert(last_pos != prefix.npos);
+            prefix.insert(last_pos, ", " + print_to_string(*n.expr));
+        }
+
         printer.print_cpp2(prefix, n.position());
-        emit(*n.expr);
+        if(!as_on_literal)
+            emit(*n.expr);
         printer.print_cpp2(suffix, n.position());
     }
 


### PR DESCRIPTION
The current implementation allows for writing below code
```cpp
args : std::span<Arg> = (argv, argc as std::size_t);
c : std::ifstream = args.back(); // <= here it crashes
```
It fails as `as<std::size_t>(argc)` matches `as(...)` that returns `nonesuch`. 

This change introduces `as` casts:

1. `as` - static asserted casts,
2. `as std::optional<T>` - optional cast,
3. `cpp2::unsafe_narrow<T>()` - narrow cast,

If the safe cast is not possible, the `as` cast will fail to compile with information to use optional cast `as std::optional<T>`.
```
error: static_assert failed due to requirement 'program_violates_type_safety_guarantee<long, double>' "No safe 'as' cast available please use optional cast `as std::optional<T>`"
```

The specialization of the `as()` functions try to match arithmetic types (algorithm based on the `gsl::narrow()` function). It also removes the version of the `as(...)` function that silently returns `nullptr` - now it fails at compile time thanks to `static_assert`.

After this change, the below code does not compile all narrowing cases, and will trigger static assertion with the information to use two other possible casts:

```cpp
main: () -> int = {
    max_uint8  := std::numeric_limits<std::uint8_t>::max();
    max_int8   := std::numeric_limits<std::int8_t>::max();
    max_double := std::numeric_limits<double>::max();
    max_float  := std::numeric_limits<float>::max();

    v1  := max_uint8  as std::int8_t;  // static_assert failure
    v2  := -1         as std::uint8_t; // static_assert failure
    v3  := -1.0       as std::uint8_t; // static_assert failure
    v4  := max_double as float;        // static_assert failure

    v5  := -1.0      as long;          // static_assert failure
    v6  := -1        as double;        // OK
    v7  := max_float as double;        // OK
    v8  := max_uint8 as std::uint16_t; // OK
    v9  := max_int8  as std::uint16_t; // static_assert failure
    v10 := 10        as std::size_t;   // OK
    v11 := "string"  as std::string;   // OK
    v12 := 'a'       as int;           // OK
    v13 := 36        as char;          // OK

    std::cout << " v6 = (v6)$" << std::endl;  //  v6 = -1.000000
    std::cout << " v7 = (v7)$" << std::endl;  //  v7 = 340282346638528859811704183484516925440.000000
    std::cout << " v8 = (v8)$" << std::endl;  //  v8 = 255
    std::cout << "v10 = (v10)$" << std::endl; // v10 = 10
    std::cout << "v11 = (v11)$" << std::endl; // v11 = string
    std::cout << "v12 = (v12)$" << std::endl; // v12 = 97
    std::cout << "v13 = (v13)$" << std::endl; // v13 = 36
}
```

Thanks to optional as `as std::optional<T>` we can rewrite it to:
```cpp
main: () -> int = {
    max_uint8  := std::numeric_limits<std::uint8_t>::max();
    max_int8   := std::numeric_limits<std::int8_t>::max();
    max_double := std::numeric_limits<double>::max();
    max_float  := std::numeric_limits<float>::max();

    v1  := max_uint8  as std::optional<std::int8_t>;  // OK
    v2  := -1         as std::optional<std::uint8_t>; // OK
    v3  := -1.0       as std::optional<std::uint8_t>; // OK
    v4  := max_double as std::optional<float>;        // OK

    v5  := -1.0      as std::optional<long>;          // OK
    v6  := -1        as std::optional<double>;        // OK
    v7  := max_float as std::optional<double>;        // OK
    v8  := max_uint8 as std::optional<std::uint16_t>; // OK
    v9  := max_int8  as std::optional<std::uint16_t>; // OK
    v10 := 10        as std::optional<std::size_t>;   // OK
    v11 := "string"  as std::optional<std::string>;   // OK
    v12 := 'a'       as std::optional<int>;           // OK
    v13 := 36        as std::optional<char>;          // OK

    std::cout << " v1 = (v1)$" << std::endl;  //  v1 = (empty) 
    std::cout << " v2 = (v2)$" << std::endl;  //  v2 = (empty)
    std::cout << " v3 = (v3)$" << std::endl;  //  v3 = (empty)
    std::cout << " v4 = (v4)$" << std::endl;  //  v4 = (empty)
    std::cout << " v5 = (v5)$" << std::endl;  //  v5 = (empty)
    std::cout << " v6 = (v6)$" << std::endl;  //  v6 = -1.000000
    std::cout << " v7 = (v7)$" << std::endl;  //  v7 = 340282346638528859811704183484516925440.000000
    std::cout << " v8 = (v8)$" << std::endl;  //  v8 = 255
    std::cout << " v9 = (v9)$" << std::endl;  //  v9 = 127
    std::cout << "v10 = (v10)$" << std::endl; // v10 = 10 
    std::cout << "v11 = (v11)$" << std::endl; // v11 = string
    std::cout << "v12 = (v12)$" << std::endl; // v12 = 97 
    std::cout << "v13 = (v13)$" << std::endl; // v13 = 36 
}
```

Thanks to `unsafe_narrow()`:

```cpp
main: () -> int = {
    max_uint8  := std::numeric_limits<std::uint8_t>::max();
    max_int8   := std::numeric_limits<std::int8_t>::max();
    max_double := std::numeric_limits<double>::max();
    max_float  := std::numeric_limits<float>::max();

    v1  := cpp2::unsafe_narrow<std::int8_t>(max_uint8);   // OK
    v2  := cpp2::unsafe_narrow<std::uint8_t>(-1);         // OK
    v3  := cpp2::unsafe_narrow<std::uint8_t>(-1.0);       // OK
    v4  := cpp2::unsafe_narrow<float>(max_double);        // OK

    v5  := cpp2::unsafe_narrow<long>(-1.0);               // OK
    v6  := cpp2::unsafe_narrow<double>(-1);               // OK
    v7  := cpp2::unsafe_narrow<double>(max_float);        // OK
    v8  := cpp2::unsafe_narrow<std::uint16_t>(max_uint8); // OK
    v9  := cpp2::unsafe_narrow<std::uint16_t>(max_int8);  // OK
    v10 := cpp2::unsafe_narrow<std::size_t>(10);          // OK
    v11 := cpp2::unsafe_narrow<std::string>("string");    // OK
    v12 := cpp2::unsafe_narrow<int>('a');                 // OK
    v13 := cpp2::unsafe_narrow<char>(36);                 // OK

    std::cout << " v1 = (v1)$" << std::endl;  //  v1 = -1
    std::cout << " v2 = (v2)$" << std::endl;  //  v2 = 255
    std::cout << " v3 = (v3)$" << std::endl;  //  v3 = 0
    std::cout << " v4 = (v4)$" << std::endl;  //  v4 = inf
    std::cout << " v5 = (v5)$" << std::endl;  //  v5 = -1
    std::cout << " v6 = (v6)$" << std::endl;  //  v6 = -1.000000
    std::cout << " v7 = (v7)$" << std::endl;  //  v7 = 340282346638528859811704183484516925440.000000
    std::cout << " v8 = (v8)$" << std::endl;  //  v8 = 255
    std::cout << "v10 = (v10)$" << std::endl; // v10 = 10
    std::cout << "v11 = (v11)$" << std::endl; // v11 = string
    std::cout << "v12 = (v12)$" << std::endl; // v12 = 97
    std::cout << "v13 = (v13)$" << std::endl; // v13 = 36
}
```

That will also fix below code:
```cpp
args : std::span<Arg> = (argv, (argc as std::optional<std::size_t>).value()); // using `argc as std::size_t` will fail with static_assert
c : std::ifstream = args.back(); // no crash, works as expected
```
Or with `unsafe_narrow`:
```cpp
args : std::span<Arg> = (argv, cpp2::unsafe_narrow<std::size_t>(argc));
c : std::ifstream = args.back(); // no crash, works as expected
```

Closes https://github.com/hsutter/cppfront/issues/104