### PR TITLE
[FIX] multi return values handling when lambda is used inside the function

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1086,15 +1086,12 @@ public:
         }
 
         in_definite_init = is_definite_initialization(n.identifier);
-        if (in_synthesized_multi_return) {
-            printer.print_cpp2(".value()", n.position());
-        }
-        else if (!in_definite_init && !in_parameter_list) {
+        if (!in_definite_init && !in_parameter_list) {
             if (auto decl = sema.get_declaration_of(*n.identifier);
                 is_local_name &&
                 decl &&
                 //  note pointer equality: if we're not in the actual declaration of n.identifier
-                decl->identifier != n.identifier &&
+                (in_synthesized_multi_return || decl->identifier != n.identifier) &&
                 //  and this variable was uninitialized
                 !decl->initializer &&
                 //  and it's either a non-parameter or an out parameter
@@ -1103,6 +1100,9 @@ public:
             {
                 printer.print_cpp2(".value()", n.position());
             }
+        }
+        else if (in_synthesized_multi_return) {
+            printer.print_cpp2(".value()", n.position());
         }
 
         if (add_std_move || add_std_forward) {

--- a/source/sema.h
+++ b/source/sema.h
@@ -250,9 +250,10 @@ public:
             {
                 auto const& decl = std::get<symbol::active::declaration>(i->sym);
 
-                //  Don't look beyond the current function
                 assert(decl.declaration);
-                if (decl.declaration->type.index() == declaration_node::function) {
+                if (
+                    decl.declaration->type.index() == declaration_node::function //  Don't look beyond the current function
+                ) {
                     return nullptr;
                 }
 

--- a/source/sema.h
+++ b/source/sema.h
@@ -253,6 +253,7 @@ public:
                 assert(decl.declaration);
                 if (
                     decl.declaration->type.index() == declaration_node::function //  Don't look beyond the current function
+                    && decl.declaration->identifier // nullptr if lambda
                 ) {
                     return nullptr;
                 }


### PR DESCRIPTION
Closes https://github.com/hsutter/cppfront/issues/112

The current implementation fails to handle cases when there is a lambda in the function where multi-return values are used. The issue is with the `get_declaration_of()` function that tries not to go beyond  the current function but is misled by a lambda function
```cpp
//  Don't look beyond the current function
assert(decl.declaration);
if (decl.declaration->type.index() == declaration_node::function) {
    return nullptr;
}
```
It makes it impossible to compile below code:
```cpp
fun: () -> (ri : int) = {
    ri = 0;

    pred := :(e:_) -> bool = { return e == 1; };

    ri = 42;

    return;
}
```
as the second call to `ri` variable is not getting a proper declaration from the `get_declaration_of()` function and it makes that cppfront generates:
```cpp
#line 1 "tests/get_declarations_return_vals.cpp2"
[[nodiscard]] auto fun() -> fun__ret{
        cpp2::deferred_init<int> ri;
#line 2 "tests/get_declarations_return_vals.cpp2"
    ri.construct(0);

    auto pred { [](auto const& e) -> bool{return e == 1; } }; 

    ri = 42; // <--- lack of call to .value() method

    return  { std::move(ri.value()) }; 
}
```

This fix makes cppfront compile the above code to:
```cpp
#line 1 "tests/get_declarations_return_vals.cpp2"
[[nodiscard]] auto fun() -> fun__ret{
        cpp2::deferred_init<int> ri;
#line 2 "tests/get_declarations_return_vals.cpp2"
    ri.construct(0);

    auto pred { [](auto const& e) -> bool{return e == 1; } }; 

    ri.value() = 42;

    return  { std::move(ri.value()) }; 
}
```

Also, this change fixes other issues when the multi-return values are initialized in the declaration place. The below code:
```cpp
fun: () -> (ri : int = 0) = {
    pred := :(e:_) -> bool = { return e == 1; };

    ri = 42;

    return;
}
```
now compiles to:
```cpp
#line 1 "/tests/get_declarations_return_vals.cpp2"
[[nodiscard]] auto fun() -> fun__ret{
    int ri = 0;
#line 2 "tests/get_declarations_return_vals.cpp2"
    auto pred { [](auto const& e) -> bool{return e == 1; } }; 

    ri = 42;

    return  { std::move(ri) }; // previously: return  { std::move(ri.value()) };
}
```