### PR TITLE
[FIX] Fix infinite loop while parsing of string literal when there is missing closing `"` character

### DIFF
--- a/source/lex.h
+++ b/source/lex.h
@@ -403,7 +403,7 @@ auto lex_line(
             { return u; }
         if (auto e = peek_is_escape_sequence(offset))
             { return e; }
-        if (peek(offset) != quote && peek(offset) != '\\')
+        if (peek(offset) && peek(offset) != quote && peek(offset) != '\\')
             { return 1; }
         return 0;
     };


### PR DESCRIPTION
Close https://github.com/hsutter/cppfront/issues/117

The current implementation is not handling the parsing of a string literal. When the string has no matching `"` sign the cppfront parse the string infinitely. 

Example of problematic file:
```cpp
P:"P
```

This fix adds a check if cppfront is on the end of the line and returns:
```
tests/smallest_example.cpp2...
smallest_example.cpp2(1,2): error: string literal "Px00" is missing its closing "
smallest_example.cpp2(1,3): error: a deduced type must have an = initializer (at '"Px00')
smallest_example.cpp2(1,1): error: unexpected text at end of Cpp2 code section (at 'P')
smallest_example.cpp2(1,0): error: parse failed for section starting here
```
