### PR TITLE
g++12.2: cleanup compiler warnings

### DIFF
--- a/source/common.h
+++ b/source/common.h
@@ -396,7 +396,7 @@ public:
             }
             print("  -");
             auto n = flag.name.substr(0, flag.unique_prefix);
-            if (flag.unique_prefix < flag.name.length()) {
+            if (flag.unique_prefix < static_cast<ssize_t>(flag.name.length())) {
                 n += "[";
                 n += flag.name.substr(flag.unique_prefix);
                 n += "]";

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -191,7 +191,7 @@ class positional_printer
         //  and where the last one was which determines our current colno
         auto last_newline = std::string::npos;  // the last newline we found in the string
         auto newline_pos  = 0;                  // the current newline we found in the string
-        while ((newline_pos = s.find('\n', newline_pos)) != std::string::npos)
+        while ((newline_pos = s.find('\n', newline_pos)) != static_cast<ssize_t>(std::string::npos))
         {
             //  For each line break we find, reset pad and inc current lineno
             pad_for_this_line = 0;
@@ -1629,7 +1629,7 @@ public:
                 }
                 ++mynum;
             }
-            assert (mynum < n.cap_grp->size() && "could not find this postfix-expression in capture group");
+            assert (mynum < static_cast<ssize_t>(n.cap_grp->size()) && "could not find this postfix-expression in capture group");
             //  And then emit that capture number
             captured_part += "_" + std::to_string(mynum);
         }

--- a/source/lex.h
+++ b/source/lex.h
@@ -445,8 +445,8 @@ auto lex_line(
         if (std::regex_search(&line[i], m, keys)) {
             assert (m.position(0) == 0);
             //  If we matched and what's next is EOL or a non-identifier char, we matched!
-            if (i+m[0].length() == line.length() ||             // EOL
-                !is_identifier_continue(line[i+m[0].length()])  // non-identifier char
+            if (i+m[0].length() == static_cast<ssize_t>(line.length()) ||    // EOL
+                !is_identifier_continue(line[i+m[0].length()])               // non-identifier char
                 )
             {
                 return (int)(m[0].length());;
@@ -726,6 +726,7 @@ auto lex_line(
                     }
                 }
             }
+            [[fallthrough]];
 
             // NO BREAK: we want 0 to fall through to numeric literal case
             // (this will be less kludgy to write with pattern matching)


### PR DESCRIPTION
Here is a couple of small cleanups to reduce the noise from:
    g++ -W -Wall cppfront.cpp -std=c++20 -o cppfront

To aid seeing the wood for the trees, the actual invocation was:
   g++ -W -Wall -Wno-unused-parameter -Wno-unused-variable ....

Selectively drop those "-Wno-" options to get lots of noise.

That leaves 5 warnings for your consideration:

1)
   parse.h:1416:38: warning: missing initializer for member
       ‘cpp2::capture::str’ [-Wmissing-field-initializers]
   1416 |                 n->cap_grp->push_back({n.get()});

2)
  parse.h:1419:62: warning: missing initializer for member
       ‘cpp2::postfix_expression_node::term::id_expr’
       [-Wmissing-field-initializers]
  1419 |             auto term = postfix_expression_node::term{&curr()};

3)
  parse.h:1419:62: warning: missing initializer for member
       ‘cpp2::postfix_expression_node::term::op_close’
       [-Wmissing-field-initializers]

4)
  parse.h: In member function ‘std::unique_ptr<cpp2::declaration_node>
       cpp2::parser::unnamed_declaration(cpp2::source_position, bool, bool)’:

5)
  parse.h:2803:14: warning: variable ‘start_pos’ set but not used
       [-Wunused-but-set-variable]
  2803 |         auto start_pos = pos;

This was run on Ubuntu 22.10 .