### PR TITLE
Remove GCC warnings

### DIFF
--- a/source/common.h
+++ b/source/common.h
@@ -396,7 +396,7 @@ public:
             }
             print("  -");
             auto n = flag.name.substr(0, flag.unique_prefix);
-            if (flag.unique_prefix < flag.name.length()) {
+            if (flag.unique_prefix < std::ssize(flag.name)) {
                 n += "[";
                 n += flag.name.substr(flag.unique_prefix);
                 n += "]";

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -190,7 +190,7 @@ class positional_printer
         //  Update curr_pos by finding how many line breaks s contained,
         //  and where the last one was which determines our current colno
         auto last_newline = std::string::npos;  // the last newline we found in the string
-        auto newline_pos  = 0;                  // the current newline we found in the string
+        auto newline_pos  = std::size_t{};      // the current newline we found in the string
         while ((newline_pos = s.find('\n', newline_pos)) != std::string::npos)
         {
             //  For each line break we find, reset pad and inc current lineno
@@ -1629,7 +1629,7 @@ public:
                 }
                 ++mynum;
             }
-            assert (mynum < n.cap_grp->size() && "could not find this postfix-expression in capture group");
+            assert (mynum < std::ssize(*n.cap_grp) && "could not find this postfix-expression in capture group");
             //  And then emit that capture number
             captured_part += "_" + std::to_string(mynum);
         }
@@ -1705,7 +1705,6 @@ public:
         auto prefix            = std::vector<text_with_pos>{};
         auto suffix            = std::vector<text_with_pos>{};
 
-        auto emitted_n         = false;
         auto last_was_prefixed = false;
         auto saw_dollar        = false;
 

--- a/source/lex.h
+++ b/source/lex.h
@@ -445,7 +445,7 @@ auto lex_line(
         if (std::regex_search(&line[i], m, keys)) {
             assert (m.position(0) == 0);
             //  If we matched and what's next is EOL or a non-identifier char, we matched!
-            if (i+m[0].length() == line.length() ||             // EOL
+            if (i+m[0].length() == std::ssize(line) ||          // EOL
                 !is_identifier_continue(line[i+m[0].length()])  // non-identifier char
                 )
             {

--- a/source/parse.h
+++ b/source/parse.h
@@ -1876,7 +1876,6 @@ private:
 
         //  Reject "std" :: "move" / "forward"
         assert (term.id->identifier);
-        auto first_uid_was_std = (*term.id->identifier == "std");
         auto first_time_through_loop = true;
 
         n->ids.push_back( std::move(term) );
@@ -2798,9 +2797,6 @@ private:
             ? make_unique<capture_groups_stack_guard>(this, &n->captures)
             : std::unique_ptr<capture_groups_stack_guard>()
             ;
-
-        //  Remember current position, because we need to look ahead
-        auto start_pos = pos;
 
         //  Next is an an optional type
 

--- a/source/sema.h
+++ b/source/sema.h
@@ -209,7 +209,7 @@ class sema
 public:
     std::vector<error>&          errors;
     std::vector<symbol>          symbols;
-    std::vector<declaration_sym> partial_decl_stack;;
+    std::vector<declaration_sym> partial_decl_stack;
 
     std::vector<selection_statement_node const*> active_selections;
 


### PR DESCRIPTION
**Long story short:** This PR removes all GCC warnings from cppfront.

**The long story:** I love C++. I've been coding C++ since high school when c++11 was still c++0x. As with any true love you learn to put up with the flaws of a loved one. Nevertheless, with a language that allows you to shoot yourself in the foot you need to figure out good foot protection. One that I believe is very simple to use and has already helped me fix bugs in existing code is to ask the compiler to show all warnings, disallow them, and be pedantic about this.
When I recently saw the CppCon presentation of cppfront and I was somewhat ecstatic. Finally an attempt not to replace C++ but to just face-lift the syntax to make it modern while being faithful to the core of language itself. I had to give it a try. The first thing I did was compiling it using:
`g++-11 source/cppfront.cpp -I./include --std=c++20 -Wall -Werror --pedantic -o cppfront`

