### PR TITLE
[FIX] is() function to handle polymorphic sidecast

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -531,13 +531,19 @@ auto is( X const& ) -> bool {
 }
 
 template< typename C, typename X >
-    requires (std::is_base_of_v<X, C> && !std::is_same_v<C,X>)
+    requires (
+        ( std::is_base_of_v<X, C> || 
+          ( std::is_polymorphic_v<C> && std::is_polymorphic_v<X>) 
+        ) && !std::is_same_v<C,X>)
 auto is( X const& x ) -> bool {
     return dynamic_cast<C const*>(&x) != nullptr;
 }
 
 template< typename C, typename X >
-    requires (std::is_base_of_v<X, C> && !std::is_same_v<C,X>)
+    requires (
+        ( std::is_base_of_v<X, C> || 
+          ( std::is_polymorphic_v<C> && std::is_polymorphic_v<X>) 
+        ) && !std::is_same_v<C,X>)
 auto is( X const* x ) -> bool {
     return dynamic_cast<C const*>(x) != nullptr;
 }


### PR DESCRIPTION
The current implementation is not handling sidecasts.

The code:
```cpp
struct B1 { virtual ~B1() = default; };

struct B2 { virtual ~B2() = default; };

struct D : B1, B2 {};

main: () -> int = {
    d: D = ();
    p: * B1 = d&;

    std::cout << p* is B2 << std::endl;
}
```
returns `false` - the current implementation of `is()` function is using `std::is_base_of` that blocks using `dynamic_cast` for sidecast. ~The current fix removes the requirement for `B2` being a base for `B1`.~ The current fix add a check if we are dealing with polymorpic types - if yes then the `dynamic_cast` is called.

This PR close `is()` part of the https://github.com/hsutter/cppfront/issues/127

`as()` will be fixed after finalizing discussion here: https://github.com/hsutter/cppfront/pull/106 (it requires handling case when `dynamic_cast` will return `nullptr` or throw `bad_cast`).