### PR TITLE
[FIX] Fix declarations of cpp2_new

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -338,20 +338,20 @@ auto assert_in_bounds(auto&& x, auto&& arg CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAU
 //
 struct {
     template<typename T>
-    [[nodiscard]] auto cpp2_new(auto ...args) const -> std::unique_ptr<T> {
+    [[nodiscard]] auto cpp2_new(auto&& ...args) const -> std::unique_ptr<T> {
         return std::make_unique<T>(std::forward<decltype(args)>(args)...);
     }
 } unique;
 
 struct {
     template<typename T>
-    [[nodiscard]] auto cpp2_new(auto ...args) const -> std::shared_ptr<T> {
+    [[nodiscard]] auto cpp2_new(auto&& ...args) const -> std::shared_ptr<T> {
         return std::make_shared<T>(std::forward<decltype(args)>(args)...);
     }
 } shared;
 
 template<typename T>
-[[nodiscard]] auto cpp2_new(auto ...args) -> std::unique_ptr<T> {
+[[nodiscard]] auto cpp2_new(auto&& ...args) -> std::unique_ptr<T> {
     return std::make_unique<T>(std::forward<decltype(args)>(args)...);
 }
 

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -337,20 +337,20 @@ auto assert_in_bounds(auto&& x, auto&& arg CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAU
 //-----------------------------------------------------------------------
 //
 struct {
-    template<typename T, typename... Args>
+    template<typename T>
     [[nodiscard]] auto cpp2_new(auto ...args) const -> std::unique_ptr<T> {
         return std::make_unique<T>(std::forward<decltype(args)>(args)...);
     }
 } unique;
 
 struct {
-    template<typename T, typename... Args>
+    template<typename T>
     [[nodiscard]] auto cpp2_new(auto ...args) const -> std::shared_ptr<T> {
         return std::make_shared<T>(std::forward<decltype(args)>(args)...);
     }
 } shared;
 
-template<typename T, typename... Args>
+template<typename T>
 [[nodiscard]] auto cpp2_new(auto ...args) -> std::unique_ptr<T> {
     return std::make_unique<T>(std::forward<decltype(args)>(args)...);
 }


### PR DESCRIPTION
Small fixes in the declarations of the `cpp2_new` functions:
* Take the argument packs by forwarding reference so that the arguments are actually forwarded
* Remove the `... Args` template parameter that is not used