### PR TITLE
[REFACTOR] Define global new in terms of unique.new

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -352,7 +352,7 @@ struct {
 
 template<typename T, typename... Args>
 [[nodiscard]] auto cpp2_new(auto ...args) -> std::unique_ptr<T> {
-    return std::make_unique<T>(std::forward<decltype(args)>(args)...);
+    return unique.cpp2_new<T>(std::forward<decltype(args)>(args)...);
 }
 
 


### PR DESCRIPTION
More DRY and IMO makes the intent (i.e., plain `new` is a synonym of `unique.new`) clearer.