### PR TITLE
[FIX] Fix return value of main() if program failed

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -2670,10 +2670,11 @@ auto main(int argc, char* argv[]) -> int
 
     if (cmdline.arguments().empty()) {
         std::cout << "cppfront: error: no input files\n";
-        return 0;
+        return EXIT_FAILURE;
     }
 
     //  For each .cpp2 source file
+    int exit_status = EXIT_SUCCESS;
     for (auto const& arg : cmdline.arguments())
     {
         std::cout << arg.text << "...";
@@ -2701,6 +2702,7 @@ auto main(int argc, char* argv[]) -> int
             std::cout << "\n";
             c.print_errors();
             std::cout << "\n";
+            exit_status = EXIT_FAILURE;
         }
 
         //  In any case, emit the debug information (during early development this is
@@ -2709,4 +2711,5 @@ auto main(int argc, char* argv[]) -> int
             c.debug_print();
         }
     }
+    return exit_status;
 }

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -2665,7 +2665,7 @@ auto main(int argc, char* argv[]) -> int
     cmdline.process_flags();
 
     if (cmdline.help_was_requested()) {
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     if (cmdline.arguments().empty()) {


### PR DESCRIPTION
If *.cpp2 file contains any syntax error or in case if wrong arguments are specified, the `cppfront` will return success (main returns 0).

This patch propagates error code as a result of `cppfront` in case of wrong arguments or in case of syntax error in at least one input file.

It may allow to write scripts that runs build of resulting C++ output or any other steps such as [example for Bash]:
```cppfront main.cpp && echo OK``` 