### PR TITLE
[FIX] fix test 'mixed-intro-example-three-loops.cpp2' for gcc 12

### DIFF
--- a/regression-tests/mixed-intro-example-three-loops.cpp2
+++ b/regression-tests/mixed-intro-example-three-loops.cpp2
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <span>
+#include <memory>
 
 auto print(auto const& thing) -> void { 
     std::cout << ">> " << thing << "\n";


### PR DESCRIPTION
Gcc 12 requires to specify header `<memory>` for using `std::make_unique`