### PR TITLE
[FIX] add additional parens for CPP2_TYPEOF macro used in inspect

### DIFF
--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -35,8 +35,8 @@ auto test_generic(auto const& x) -> void{
         << std::setw(30) << typeid(x).name() 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF("integer " + std::to_string(cpp2::as<int>(x))),std::string> ) return "integer " + std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
-            else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{'"' + cpp2::as<std::string>(x) + '"';} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF('"' + cpp2::as<std::string>(x) + '"'),std::string> ) return '"' + cpp2::as<std::string>(x) + '"'; else return std::string{}; else return std::string{}; }
+            if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + std::to_string(cpp2::as<int>(x)))),std::string> ) return "integer " + std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
+            else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{'"' + cpp2::as<std::string>(x) + '"';} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(('"' + cpp2::as<std::string>(x) + '"')),std::string> ) return '"' + cpp2::as<std::string>(x) + '"'; else return std::string{}; else return std::string{}; }
             else return "not an int or string"; }
         ()
         << "\n";

--- a/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
@@ -22,7 +22,7 @@ auto print_an_int(auto const& x) -> void{
         << std::setw(30) << typeid(x).name() 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(std::to_string(cpp2::as<int>(x))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
+            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
             else return "not an int"; }
         ()
         << "\n";

--- a/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
@@ -28,10 +28,10 @@ auto test_generic(auto const& x) -> void{
     std::cout 
         << "\n" << typeid(x).name() << "\n    ..." 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<std::string>(__expr)) { if constexpr( requires{" matches std::string";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(" matches std::string"),std::string> ) return " matches std::string"; else return std::string{}; else return std::string{}; }
-            else if (cpp2::is<std::variant<int,std::string>>(__expr)) { if constexpr( requires{" matches std::variant<int, std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(" matches std::variant<int, std::string>"),std::string> ) return " matches std::variant<int, std::string>"; else return std::string{}; else return std::string{}; }
-            else if (cpp2::is<std::any>(__expr)) { if constexpr( requires{" matches std::any";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(" matches std::any"),std::string> ) return " matches std::any"; else return std::string{}; else return std::string{}; }
-            else if (cpp2::is<std::optional<std::string>>(__expr)) { if constexpr( requires{" matches std::optional<std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(" matches std::optional<std::string>"),std::string> ) return " matches std::optional<std::string>"; else return std::string{}; else return std::string{}; }
+            if (cpp2::is<std::string>(__expr)) { if constexpr( requires{" matches std::string";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::string")),std::string> ) return " matches std::string"; else return std::string{}; else return std::string{}; }
+            else if (cpp2::is<std::variant<int,std::string>>(__expr)) { if constexpr( requires{" matches std::variant<int, std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::variant<int, std::string>")),std::string> ) return " matches std::variant<int, std::string>"; else return std::string{}; else return std::string{}; }
+            else if (cpp2::is<std::any>(__expr)) { if constexpr( requires{" matches std::any";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::any")),std::string> ) return " matches std::any"; else return std::string{}; else return std::string{}; }
+            else if (cpp2::is<std::optional<std::string>>(__expr)) { if constexpr( requires{" matches std::optional<std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::optional<std::string>")),std::string> ) return " matches std::optional<std::string>"; else return std::string{}; else return std::string{}; }
             else return " no match"; }
         ()
         << "\n";

--- a/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
@@ -32,7 +32,7 @@ auto test_generic(auto const& x) -> void{
     std::cout 
         << "\n" << typeid(x).name() << "\n    ..." 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<void>(__expr)) { if constexpr( requires{" VOYDE AND EMPTIE";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(" VOYDE AND EMPTIE"),std::string> ) return " VOYDE AND EMPTIE"; else return std::string{}; else return std::string{}; }
+            if (cpp2::is<void>(__expr)) { if constexpr( requires{" VOYDE AND EMPTIE";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" VOYDE AND EMPTIE")),std::string> ) return " VOYDE AND EMPTIE"; else return std::string{}; else return std::string{}; }
             else return " no match"; }
         ()
         << "\n";

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -35,7 +35,7 @@ auto test_generic(auto const& x) -> void{
         << std::setw(30) << typeid(x).name() 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(std::to_string(cpp2::as<int>(x))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
+            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
             else return "not an int"; }
         ()
         << "\n";

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1264,7 +1264,7 @@ public:
                 auto return_prefix = std::string{};
                 auto return_suffix = std::string{";"};   // use this to tack the ; back on in the alternative body
                 if (is_expression) {
-                    return_prefix = "{ if constexpr( requires{" + statement + ";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(" + statement + ")," + result_type + "> ) return ";
+                    return_prefix = "{ if constexpr( requires{" + statement + ";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" + statement + "))," + result_type + "> ) return ";
                     return_suffix += " }";
                 }
 


### PR DESCRIPTION
The current implementation of cppfront is using constexpr ifs with requires expressions and the `CPP2_TYPEOF` macro to eliminate the compilation of alternatives that did not match in inspect expression. It suffers from issues with using macros and commas.

The below code:
```cpp
template <int i, int j>
auto calc() {
    return i + j;
}

fun: (v : _) -> int = {
    return inspect v -> int {
        is int  = calc<1,2>();
        is _ = 0;
    };
}

main: () -> int = {
    return fun(42);
}
```
generates to (skipping boilerplate):
```cpp
[[nodiscard]] auto fun(auto const& v) -> int{
    return [&] () -> int { auto&& __expr = v;
        if (cpp2::is<int>(__expr)) { if constexpr( requires{calc<1,2>();} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(calc<1,2>()),int> ) return calc<1,2>(); else return int{}; else return int{}; }
        else return 0; }
    ()
; }

[[nodiscard]] auto main() -> int{
    return fun(42); 
}
```

The problematic part is `CPP2_TYPEOF(calc<1,2>())` that fails to compile (because of the coma) with the error:
```
tests/inspect_return_template.cpp2:12:132: error: too many arguments provided to function-like macro invocation
        if (cpp2::is<int>(__expr)) { if constexpr( requires{calc<1,2>();} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(calc<1,2>()),int> ) return calc<1,2>(); else return int{}; else return int{}; }
                                                                                                                                   ^
include/cpp2util.h:209:9: note: macro 'CPP2_TYPEOF' defined here
#define CPP2_TYPEOF(x)  std::remove_cvref_t<decltype(x)>
        ^
tests/inspect_return_template.cpp2:12:113: error: use of undeclared identifier 'CPP2_TYPEOF'
        if (cpp2::is<int>(__expr)) { if constexpr( requires{calc<1,2>();} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(calc<1,2>()),int> ) return calc<1,2>(); else return int{}; else return int{}; }
                                                                                                                ^
error: constexpr if condition is not a constant expression
tests/inspect_return_template.cpp2:18:12: note: in instantiation of function template specialization 'fun<int>' requested here
    return fun(42); 
           ^
3 errors generated.
```

This fix adds extra parens and produce:
```cpp
CPP2_TYPEOF((calc<1,2>()))
```

Closes: https://github.com/hsutter/cppfront/issues/147