### PR TITLE
Add support for ufcs chaining

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -536,21 +536,23 @@ public:
     } \
 }(PARAM1)
 
-#define CPP2_UFCS_TEMPLATE(FUNCNAME,PARAM1,...) \
+#define CPP2_UFCS_REMPARENS(...) __VA_ARGS__
+
+#define CPP2_UFCS_TEMPLATE(FUNCNAME,TEMPARGS,PARAM1,...) \
 [](auto&& obj, auto&& ...params) { \
-    if constexpr (requires{ std::forward<decltype(obj)>(obj).template FUNCNAME(std::forward<decltype(params)>(params)...); }) { \
-        return std::forward<decltype(obj)>(obj).template FUNCNAME(std::forward<decltype(params)>(params)...); \
+    if constexpr (requires{ std::forward<decltype(obj)>(obj).template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (std::forward<decltype(params)>(params)...); }) { \
+        return std::forward<decltype(obj)>(obj).template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (std::forward<decltype(params)>(params)...); \
     } else { \
-        return FUNCNAME(std::forward<decltype(obj)>(obj), std::forward<decltype(params)>(params)...); \
+        return FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (std::forward<decltype(obj)>(obj), std::forward<decltype(params)>(params)...); \
     } \
 }(PARAM1, __VA_ARGS__)
 
-#define CPP2_UFCS_TEMPLATE_0(FUNCNAME,PARAM1) \
+#define CPP2_UFCS_TEMPLATE_0(FUNCNAME,TEMPARGS,PARAM1) \
 [](auto&& obj) { \
-    if constexpr (requires{ std::forward<decltype(obj)>(obj).template FUNCNAME(); }) { \
-        return std::forward<decltype(obj)>(obj).template FUNCNAME(); \
+    if constexpr (requires{ std::forward<decltype(obj)>(obj).template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (); }) { \
+        return std::forward<decltype(obj)>(obj).template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (); \
     } else { \
-        return FUNCNAME(std::forward<decltype(obj)>(obj)); \
+        return FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (std::forward<decltype(obj)>(obj)); \
     } \
 }(PARAM1)
 //--------------------------------------------------------------------

--- a/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
@@ -22,7 +22,7 @@ auto call_my_framework(cpp2::in<const char *> msg) -> void;
 #line 5 "mixed-lifetime-safety-and-null-contracts.cpp2"
 
 [[nodiscard]] auto main() -> int{
-    cpp2::Null.set_handler(&call_my_framework);
+    CPP2_UFCS(set_handler, cpp2::Null, &call_my_framework);
     try_pointer_stuff();
     std::cout << "done\n";
 }

--- a/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
+++ b/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
@@ -17,11 +17,11 @@ auto call(auto const& v, auto const& w, auto const& x, auto const& y, auto const
 
 [[nodiscard]] auto test(auto const& a) -> std::string{
     return call( a, 
-        ++*cpp2::assert_not_null(a.b(a.c)), "hello", /* polite
+        ++*cpp2::assert_not_null(CPP2_UFCS(b, a, a.c)), "hello", /* polite
                           greeting
                           goes here */ " there", 
-        a.d.e( ++(*cpp2::assert_not_null(a.f)).g(), // because f is foobar
-              a.h.i(), 
+        CPP2_UFCS(e, a.d, ++CPP2_UFCS_0(g, *cpp2::assert_not_null(a.f)), // because f is foobar
+              CPP2_UFCS_0(i, a.h), 
               CPP2_UFCS(j, a, a.k, a.l))
         ); 
 }

--- a/regression-tests/test-results/mixed-ufcs-multiple-template-arguments.cpp
+++ b/regression-tests/test-results/mixed-ufcs-multiple-template-arguments.cpp
@@ -28,7 +28,7 @@ struct X {
     std::cout << substr<4,8>(test_string) << "\n";
 
     X x { test_string }; 
-    std::cout << std::move(x).substr<4,8>() << "\n";
+    std::cout << CPP2_UFCS_TEMPLATE_0(substr, (<4,8>), std::move(x)) << "\n";
         // for now this should not be UFCS-ized because of the multiple template arguments
 }
 

--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -21,7 +21,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(a,    "any");
     test_generic(o,    "optional<int>");
 
-    CPP2_UFCS_TEMPLATE(emplace<0>, v, 1);
+    CPP2_UFCS_TEMPLATE(emplace, (<0>), v, 1);
     a = 2;
     o = 3;
     test_generic(42,   "int");

--- a/regression-tests/test-results/pure2-type-safety-1.cpp
+++ b/regression-tests/test-results/pure2-type-safety-1.cpp
@@ -29,7 +29,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
 
     std::cout << "\n";
 
-    CPP2_UFCS_TEMPLATE(emplace<1>, v, 1);
+    CPP2_UFCS_TEMPLATE(emplace, (<1>), v, 1);
     a = 2;
     o = 3;
     test_generic(42,   "int");

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -21,7 +21,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(a,    "any");
     test_generic(o,    "optional<int>");
 
-    CPP2_UFCS_TEMPLATE(emplace<2>, v, 1);
+    CPP2_UFCS_TEMPLATE(emplace, (<2>), v, 1);
     a = 2;
     o = 3;
     test_generic(42,   "int");

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1789,10 +1789,7 @@ public:
             }
             // Going backwards if we found Dot and there is args variable
             // it means that it should be handled by UFCS
-            else if( i->op->type() == lexeme::Dot && args
-                        // don't use UFCS for methods with more than one template argument
-                        && i->id_expr && i->id_expr->template_args_count() < 2
-                    )
+            else if( i->op->type() == lexeme::Dot && args )
             {
                 auto funcname = print_to_string(*i->id_expr);
 
@@ -1805,8 +1802,14 @@ public:
                 //printer.print_cpp2("CPP2_UFCS(", n.position());
 
                 auto ufcs_string = std::string("CPP2_UFCS");
+
                 if (i->id_expr->template_args_count() > 0) {
                     ufcs_string += "_TEMPLATE";
+                    // we need to replace "fun<int,long,double>" to "fun, (<int,long,double>)" to be able to generate
+                    // from obj.fun<int, long, double>(1,2) this CPP2_UFCS_TEMPLATE(fun, (<int,long, double>), obj, 1, 2)
+                    auto split = funcname.find('<'); assert(split != std::string::npos);
+                    funcname.insert(split, ", (");
+                    funcname += ')';
                 }
                 //  If there are no additional arguments, use the _0 version
                 if (args.value().empty()) {

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1726,77 +1726,6 @@ public:
             captured_part += "_" + std::to_string(mynum);
         }
 
-        //  Check to see if it's just a function call with "." syntax,
-        //  and if so use this path to convert it to UFCS
-        if (// there's a single-token expression followed by . and (
-            n.expr->get_token() &&                      //  if the base expression is a single token
-            std::ssize(n.ops) >= 2 &&                   //  and we're of the form:
-            n.ops[0].op->type() == lexeme::Dot &&       //       token . id-expr ( expr-list )
-            n.ops[1].op->type() == lexeme::LeftParen &&
-            // alpha limitation: if it's a function call with more than one template argument (e.g., x.f<1,2>())
-            //                   the UFCS* macros can't handle that right now, so don't UFCS-size it
-            n.ops[0].id_expr->template_args_count() < 2 &&
-            // and either there's nothing after that, or there's just a $ after that
-            (
-                std::ssize(n.ops) == 2 ||
-                (std::ssize(n.ops) == 3 && n.ops[2].op->type() == lexeme::Dollar)
-            )
-            )
-        {
-            //  If we already replaced this with a capture (which contains the UFCS
-            //  work already done when the capture was computed), emit the capture
-            if (!captured_part.empty()) {
-                printer.print_cpp2(captured_part, n.position());
-                return;
-            }
-
-            //  Otherwise, do the UFCS work...
-
-            //  The . has its id_expr
-            assert (n.ops[0].id_expr);
-
-            //  The ( has its expr_list and op_close
-            assert (n.ops[1].expr_list && n.ops[1].op_close);
-
-            //--------------------------------------------------------------------
-            //  TODO: When MSVC supports __VA_OPT__ in standard mode without the
-            //        experimental /Zc:preprocessor switch, use this single line
-            //        instead of the dual lines below that special-case _0 args
-            //  AND:  Make the similarly noted change in cpp2util.h
-            //
-            //printer.print_cpp2("CPP2_UFCS(", n.position());
-
-            auto ufcs_string = std::string("CPP2_UFCS");
-            if (n.ops[0].id_expr->template_args_count() > 0) {
-                ufcs_string += "_TEMPLATE";
-            }
-            //  If there are no additional arguments, use the _0 version
-            if (n.ops[1].expr_list->expressions.empty()) {
-                ufcs_string += "_0";
-            }
-            printer.print_cpp2(ufcs_string+"(", n.position());
-            //--------------------------------------------------------------------
-
-            //  Make the "funcname" the first argument to CPP2_UFCS
-            emit(*n.ops[0].id_expr);
-            printer.print_cpp2(", ", n.position());
-
-            //  Then make the base expression the second argument
-            emit(*n.expr);
-
-            //  Then tack on any additional arguments
-            if (!n.ops[1].expr_list->expressions.empty()) {
-                printer.print_cpp2(", ", n.position());
-                push_need_expression_list_parens(false);
-                emit(*n.ops[1].expr_list);
-                pop_need_expression_list_parens();
-            }
-            printer.print_cpp2(")", n.position());
-
-            //  And we're done. This path has handled this node, so return...
-            return;
-        }
-
         //  Otherwise, we're going to have to potentially do some work to change
         //  some Cpp2 postfix operators to Cpp1 prefix operators, so let's set up...
         auto prefix            = std::vector<text_with_pos>{};
@@ -1804,6 +1733,25 @@ public:
 
         auto last_was_prefixed = false;
         auto saw_dollar        = false;
+
+        auto args = std::optional<std::vector<text_with_pos>>{};
+
+        auto print_to_string = [&](auto& i, auto... args) {
+            auto print = std::string{};
+            printer.emit_to_string(&print);
+            emit(i, args...);
+            printer.emit_to_string();
+            return print;
+        };
+        auto print_to_text_chunks = [&](auto& i, auto... args) {
+            auto text = std::vector<text_with_pos>{};
+            printer.emit_to_text_chunks(&text);
+            push_need_expression_list_parens(false);
+            emit(i, args...);
+            pop_need_expression_list_parens();
+            printer.emit_to_text_chunks();
+            return text;
+        };
 
         for (auto i = n.ops.rbegin(); i != n.ops.rend(); ++i)
         {
@@ -1828,9 +1776,57 @@ public:
                 }
             }
 
+            // Going backwards if we found LeftParen it might be UFCS
+            // expr_list is emited to args variable for future use
+            if (i->op->type() == lexeme::LeftParen) {
+
+                args.emplace();
+
+                if (!i->expr_list->expressions.empty()) {
+                    args.emplace(print_to_text_chunks(*i->expr_list));
+                } 
+                
+            }
+            // Going backwards if we found Dot and there is args variable
+            // it means that it should be handled by UFCS
+            else if( i->op->type() == lexeme::Dot && args
+                        // don't use UFCS for methods with more than one template argument
+                        && i->id_expr && i->id_expr->template_args_count() < 2
+                    )
+            {
+                auto funcname = print_to_string(*i->id_expr);
+
+                //--------------------------------------------------------------------
+                //  TODO: When MSVC supports __VA_OPT__ in standard mode without the
+                //        experimental /Zc:preprocessor switch, use this single line
+                //        instead of the dual lines below that special-case _0 args
+                //  AND:  Make the similarly noted change in cpp2util.h
+                //
+                //printer.print_cpp2("CPP2_UFCS(", n.position());
+
+                auto ufcs_string = std::string("CPP2_UFCS");
+                if (i->id_expr->template_args_count() > 0) {
+                    ufcs_string += "_TEMPLATE";
+                }
+                //  If there are no additional arguments, use the _0 version
+                if (args.value().empty()) {
+                    ufcs_string += "_0";
+                }
+
+                prefix.emplace_back(ufcs_string + "(" + funcname + ", ", i->op->position() );
+                suffix.emplace_back(")", i->op->position() );
+                if (!args.value().empty()) {
+                    for (auto&& e: args.value()) {
+                        suffix.push_back(e);
+                    }
+                    suffix.emplace_back(", ", i->op->position());
+                }
+                args.reset();
+            }
+
             //  Handle the Cpp2 postfix operators that are prefix in Cpp1
             //
-            if (i->op->type() == lexeme::MinusMinus ||
+            else if (i->op->type() == lexeme::MinusMinus ||
                 i->op->type() == lexeme::PlusPlus ||
                 i->op->type() == lexeme::Multiply ||
                 i->op->type() == lexeme::Ampersand ||
@@ -1874,21 +1870,25 @@ public:
                 }
 
                 if (i->id_expr) {
-                    auto print = std::string{};
-                    printer.emit_to_string(&print);
-                    emit(*i->id_expr, false /*not a local name*/);
-                    printer.emit_to_string();
+
+                    if (args) {
+                        // if args are stored it means that this is function or method
+                        // that is not handled by UFCS e.g. that has more than one template argument
+                        suffix.emplace_back(")", n.position());
+                        for (auto&& e: args.value()) {
+                            suffix.push_back(e);
+                        }
+                        suffix.emplace_back("(", n.position());
+                        args.reset();
+                    }
+
+                    auto print = print_to_string(*i->id_expr, false /*not a local name*/);
                     suffix.emplace_back( print, i->id_expr->position() );
                 }
 
                 if (i->expr_list) {
-                    auto text = std::vector<text_with_pos>{};
-                    printer.emit_to_text_chunks(&text);
-                    push_need_expression_list_parens(false);
-                    emit(*i->expr_list);
-                    pop_need_expression_list_parens();
-                    printer.emit_to_text_chunks();
-                    for (auto&& e: text) {
+                    auto text = print_to_text_chunks(*i->expr_list);
+                    for (auto&& e: text) { 
                         suffix.push_back(e);
                     }
                 }
@@ -1903,6 +1903,8 @@ public:
                 }
             }
         }
+
+
 
         //  Print the prefixes (in forward order)
         for (auto& e : prefix) {
@@ -1927,6 +1929,18 @@ public:
             printer.print_cpp2(captured_part, n.position());
         }
         suppress_move_from_last_use = false;
+
+        if (args) {
+            // if after printing core expression args is defined
+            // it means that the chaining started by function call
+            // we need to print its arguments
+            suffix.emplace_back(")", n.position());
+            for (auto&& e: args.value()) {
+                suffix.push_back(e);
+            }
+            suffix.emplace_back("(", n.position());
+            args.reset();
+        }
 
         //  Print the suffixes (in reverse order)
         while (!suffix.empty()) {


### PR DESCRIPTION
The chaining starts from the function call `fun().gun().bun()` or the method call `o.fun().gun()`.

It integrates chaining to part of the code that rewrites Cpp2 postfix operators to Cpp1 prefix operators. That allows the use of recurrency to go through the entire expression and insert UFCS in parts that need it.

After this change the Cpp2 code (taken from `mixed-postfix-expression-custom-formatting.cpp2`)
```cpp
test: (a:_) -> std::string = {
    return call( a,
        a.b(a.c)*++, "hello", /* polite
                          greeting
                          goes here */ " there",
        a.d.e( a.f*.g()++, // because f is foobar
              a.h.i(),
              a.j(a.k,a.l) )
        );
}
```
will generate
```cpp
[[nodiscard]] auto test(auto const& a) -> std::string{
    return call( a,
        ++*cpp2::assert_not_null(CPP2_UFCS(b, a, a.c)), "hello", /* polite
                          greeting
                          goes here */ " there",
        CPP2_UFCS(e, a.d, ++CPP2_UFCS_0(g, *cpp2::assert_not_null(a.f)), // because f is foobar
              CPP2_UFCS_0(i, a.h),
              CPP2_UFCS(j, a, a.k, a.l)));

}
```

~~The algorithm skips methods with more than one template argument (even when it happens inside chaining - it is done in a way that compiles fine).~~
This change is handling methods with more than one template arguments - already pushed to the PR.

This Cpp2 code:
```cpp
fun0()*.fun1(1)++.fun2<1,2>()++;
```
will generate:
```cpp
++CPP2_UFCS_TEMPLATE_0(fun2, (<1,2>), ++CPP2_UFCS(fun1, *cpp2::assert_not_null(fun0()), 1));
```

This change is not using UFCS for function calls with at least one argument. So, the functionality presented below is missing. 
```
fun() -> fun()
fun(a) -> CPP2_UFCS_0(fun, a)
fun(a, b) -> CPP2_UFCS(fun, a, b)
```

This change replaces: #17, #18
