### PR TITLE
Make include paths relative in run-tests scripts

### DIFF
--- a/regression-tests/test-results/clang-12/run-tests-clang-12.sh
+++ b/regression-tests/test-results/clang-12/run-tests-clang-12.sh
@@ -9,7 +9,7 @@ clang++-12 --version > clang-version.output 2>&1
 for f in *.cpp
 do
     printf "Starting clang++-12 %s\n" "$f"
-    clang++-12 -I/mnt/c/GitHub/cppfront/include -std=c++20 -pthread -o test.exe $f > $f.output 2>&1
+    clang++-12 -I../../../include -std=c++20 -pthread -o test.exe $f > $f.output 2>&1
     rm -f $f
     let count=count+1
     if test -f "test.exe"; then

--- a/regression-tests/test-results/gcc-10/run-tests-gcc-10.sh
+++ b/regression-tests/test-results/gcc-10/run-tests-gcc-10.sh
@@ -9,7 +9,7 @@ g++-10 --version > gcc-version.output 2>&1
 for f in *.cpp
 do
     printf "Starting g++-10 %s\n" "$f"
-    g++-10 -I/mnt/c/GitHub/cppfront/include -std=c++20 -pthread -o test.exe $f > $f.output 2>&1
+    g++-10 -I../../../include -std=c++20 -pthread -o test.exe $f > $f.output 2>&1
     rm -f $f
     let count=count+1
     if test -f "test.exe"; then


### PR DESCRIPTION
This PR makes the include paths relative in `run-tests-clang-12.sh` and `run-tests-gcc-10.sh`. This is already the case in `run-tests-apple-clang.sh` and makes the scripts independent of the way the project was checked out from git.