### PR TITLE
[Suggestion] Add a compile time flag to control the line error output format.

### DIFF
--- a/source/common.h
+++ b/source/common.h
@@ -104,15 +104,6 @@ struct comment
 //
 struct error
 {
-    // Controls whether we print `FILE:line:col: error:` or `FILE(line,col):
-    // error:`.  Need to integrate with editors that jump to errors, etc.
-    // TODO: This should become a compiler flag.
-#ifdef _MSC_VER
-    static constexpr bool print_colon_errors = false;
-#else
-    static constexpr bool print_colon_errors = true;
-#endif
-
     source_position where;
     std::string     msg;
     bool            internal = false;
@@ -121,30 +112,7 @@ struct error
         : where{w}, msg{m}, internal{i}
     { }
 
-    auto print(auto& o, std::string const& file) const -> void
-    {
-        o << file ;
-        if (where.lineno > 0) {
-            if (print_colon_errors) {
-                o << ":"<< (where.lineno);
-                if (where.colno >= 0) {
-                    o << ":" << where.colno;
-                }
-            }
-            else {
-                o << "("<< (where.lineno);
-                if (where.colno >= 0) {
-                    o << "," << where.colno;
-                }
-                o  << ")";
-            }
-        }
-        o << ":";
-        if (internal) {
-            o << " internal compiler";
-        }
-        o << " error: " << msg << "\n";
-    }
+    auto print(auto& o, std::string const& file) const -> void;
 };
 
 

--- a/source/common.h
+++ b/source/common.h
@@ -104,6 +104,15 @@ struct comment
 //
 struct error
 {
+    // Controls whether we print `FILE:line:col: error:` or `FILE(line,col):
+    // error:`.  Need to integrate with editors that jump to errors, etc.
+    // TODO: This should become a compiler flag.
+#ifdef _MSC_VER
+    static constexpr bool print_colon_errors = false;
+#else
+    static constexpr bool print_colon_errors = true;
+#endif
+
     source_position where;
     std::string     msg;
     bool            internal = false;
@@ -116,11 +125,19 @@ struct error
     {
         o << file ;
         if (where.lineno > 0) {
-            o << "("<< (where.lineno);
-            if (where.colno >= 0) {
-                o << "," << where.colno;
+            if (print_colon_errors) {
+                o << ":"<< (where.lineno);
+                if (where.colno >= 0) {
+                    o << ":" << where.colno;
+                }
             }
-            o  << ")";
+            else {
+                o << "("<< (where.lineno);
+                if (where.colno >= 0) {
+                    o << "," << where.colno;
+                }
+                o  << ")";
+            }
         }
         o << ":";
         if (internal) {

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -115,6 +115,13 @@ static cmdline_processor::register_flag cmd_cpp1_filename(
     [](std::string const& name) { flag_cpp1_filename = name; }
 );
 
+static auto flag_print_colon_errors = false;
+static cmdline_processor::register_flag cmd_print_colon_errors(
+    2,
+    "format-colon-errors",
+    "Emit ':line:col:' format for error messages",
+    []{ flag_print_colon_errors = true; }
+);
 
 struct text_with_pos{
     std::string     text;
@@ -122,6 +129,30 @@ struct text_with_pos{
     text_with_pos(std::string const& t, source_position p) : text{t}, pos{p} { }
 };
 
+// Defined out of line so we can use flag_print_colon_errors.
+auto error::print(auto& o, std::string const& file) const -> void {
+    o << file ;
+    if (where.lineno > 0) {
+        if (flag_print_colon_errors) {
+            o << ":"<< (where.lineno);
+            if (where.colno >= 0) {
+                o << ":" << where.colno;
+            }
+        }
+        else {
+            o << "("<< (where.lineno);
+            if (where.colno >= 0) {
+                o << "," << where.colno;
+            }
+            o  << ")";
+        }
+    }
+    o << ":";
+    if (internal) {
+        o << " internal compiler";
+    }
+    o << " error: " << msg << "\n";
+}
 
 class positional_printer
 {
@@ -1838,7 +1869,7 @@ public:
                 assert (i->expr_list);
                 if (!i->expr_list->expressions.empty()) {
                     local_args.text_chunks = print_to_text_chunks(*i->expr_list);
-                } 
+                }
 
                 flush_args();
                 args.emplace(std::move(local_args));
@@ -1940,7 +1971,7 @@ public:
 
                 if (i->expr_list) {
                     auto text = print_to_text_chunks(*i->expr_list);
-                    for (auto&& e: text) { 
+                    for (auto&& e: text) {
                         suffix.push_back(e);
                     }
                 }


### PR DESCRIPTION
Controls whether we print `FILE:line:col: error:` or `FILE(line,col): error:`. 


