### PR TITLE
Add cpp2::to_string(char const&) overload

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1078,6 +1078,11 @@ inline auto to_string(T const& t) -> std::string
     return std::to_string(t);
 }
 
+inline auto to_string(char const& t) -> std::string
+{
+    return std::string{t};
+}
+
 inline auto to_string(char const* s) -> std::string
 {
     return std::string{s};


### PR DESCRIPTION
In the current implementation, `cpp2::to_string` will treat the `char` variable as an integral type and will print the integer value of `char` instead of the character.
```cpp
main: () -> int = {
    c : char = 36;
    std::cout << "c = '(c)$'" << std::endl; // prints: c = '36'
}
```
after this change, it will print the character
```cpp
main: () -> int = {
    c : char = 36;
    std::cout << "c = '(c)$'" << std::endl; // prints: c = '$'
}
```
