### PR TITLE
Add pointers deduced types

### DIFF
--- a/regression-tests/pure2-deducing-pointers.cpp2
+++ b/regression-tests/pure2-deducing-pointers.cpp2
@@ -1,0 +1,41 @@
+fun: (inout i:int) -> *int = {
+    return i&;
+}
+
+fun2: (inout i:int) -> (result : *int) = {
+    result = i&;
+}
+
+main: (argc : int, argv : **char) -> int = {
+    a:     int = 2;
+    pa:   *int = a&;
+    ppa: **int = pa&;
+
+    pa = 0;       // caught
+
+    pa2:= ppa*;
+    pa2 = 0;      // caught
+
+    pa3 := a&;
+    pa3 = 0;      // caught
+    pa3 += 2;     // caught
+
+    ppa2 := pa2&;
+    pa4 := ppa2*;
+    pa4 = 0;      // caught
+
+    pppa := ppa&;
+    pa5 := pppa**;
+    pa5 = 0;      // caught
+
+    fun(a)++;     // caught
+    fp := fun(a);
+    fp = 0;       // caught
+
+    f := fun(a)*;
+
+    fp2 := fun2(a).result;
+    fp2--;        // not caught :(
+
+    return a * pa* * ppa**; // 8
+}

--- a/regression-tests/test-results/pure2-deducing-pointers.cpp2.output
+++ b/regression-tests/test-results/pure2-deducing-pointers.cpp2.output
@@ -1,0 +1,12 @@
+pure2-deducing-pointers.cpp2...
+pure2-deducing-pointers.cpp2(14,8): error: = - pointer assignment from null or integer is illegal
+pure2-deducing-pointers.cpp2(17,9): error: = - pointer assignment from null or integer is illegal
+pure2-deducing-pointers.cpp2(20,9): error: = - pointer assignment from null or integer is illegal
+pure2-deducing-pointers.cpp2(21,9): error: += - pointer assignment from null or integer is illegal
+pure2-deducing-pointers.cpp2(25,9): error: = - pointer assignment from null or integer is illegal
+pure2-deducing-pointers.cpp2(29,9): error: = - pointer assignment from null or integer is illegal
+pure2-deducing-pointers.cpp2(31,11): error: ++ - pointer arithmetic is illegal - use std::span or gsl::span instead
+pure2-deducing-pointers.cpp2(33,8): error: = - pointer assignment from null or integer is illegal
+  ==> program violates lifetime safety guarantee - see previous errors
+  ==> program violates bounds safety guarantee - see previous errors
+

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1211,7 +1211,7 @@ public:
 
         in_definite_init = is_definite_initialization(n.identifier);
         if (!in_definite_init && !in_parameter_list) {
-            if (auto decl = sema.get_local_declaration_of(*n.identifier);
+            if (auto decl = sema.get_declaration_of(*n.identifier);
                 is_local_name &&
                 decl &&
                 //  note pointer equality: if we're not in the actual declaration of n.identifier
@@ -1735,6 +1735,86 @@ public:
         }
     }
 
+    // Don't work yet, TODO: finalize deducing pointer types from parameter lists
+    auto is_pointer_declaration(parameter_declaration_list_node const* decl_node, int deref_cnt, int addr_cnt) -> bool {
+        return false;
+    }
+
+    auto is_pointer_declaration(declaration_node const* decl_node, int deref_cnt, int addr_cnt) -> bool {
+        if (!decl_node) {
+            return false;
+        }
+        if (addr_cnt > deref_cnt) {
+            return true;
+        }
+
+        return std::visit([&](auto const& type){
+            return is_pointer_declaration(type.get(), deref_cnt, addr_cnt);
+        }, decl_node->type);
+    }
+
+    auto is_pointer_declaration(function_type_node const* fun_node, int deref_cnt, int addr_cnt) -> bool {
+        if (!fun_node) { 
+            return false;
+        }
+        if (addr_cnt > deref_cnt) {
+            return true;
+        }
+
+        return std::visit([&]<typename T>(T const& type){
+            if constexpr (std::is_same_v<T, std::monostate>) {
+                return false;
+            } else {
+                return is_pointer_declaration(type.get(),  deref_cnt, addr_cnt);
+            }
+        }, fun_node->returns);
+    }
+
+    auto is_pointer_declaration(type_id_node const* type_node, int deref_cnt, int addr_cnt) -> bool {
+        if (!type_node) { 
+            return false;
+        }
+        if (addr_cnt > deref_cnt) {
+            return true; 
+        }
+
+        if ( type_node->dereference_of ) {
+            return is_pointer_declaration(type_node->dereference_of, deref_cnt + type_node->dereference_cnt, addr_cnt);
+        } else if ( type_node->address_of ) {
+            return is_pointer_declaration(type_node->address_of, deref_cnt, addr_cnt + 1);
+        }
+
+        int pointer_declarators_cnt = std::count_if(std::cbegin(type_node->pc_qualifiers), std::cend(type_node->pc_qualifiers), [](auto* q) {
+            return q->type() == lexeme::Multiply;
+        });
+
+        if (pointer_declarators_cnt == 0 && type_node->suspicious_initialization) {
+            return is_pointer_declaration(type_node->suspicious_initialization, deref_cnt, addr_cnt);
+        }
+
+        return (pointer_declarators_cnt + addr_cnt - deref_cnt) > 0;
+    }
+
+    auto is_pointer_declaration(declaration_sym const* decl, int deref_cnt, int addr_cnt) -> bool {
+        if (!decl) {
+            return false;
+        }
+        if (addr_cnt > deref_cnt) {
+            return true;
+        }
+        return is_pointer_declaration(decl->declaration, deref_cnt, addr_cnt);
+    }
+
+    auto is_pointer_declaration(token const* t, int deref_cnt = 0, int addr_cnt = 0) -> bool {
+        if (!t) {
+            return false;
+        }
+        if (addr_cnt > deref_cnt) {
+            return true;
+        }
+        auto decl = sema.get_declaration_of(*t, true);
+        return is_pointer_declaration(decl, deref_cnt, addr_cnt);
+    }
 
     //-----------------------------------------------------------------------
     //
@@ -1754,7 +1834,7 @@ public:
             assert (n.expr->get_token());
             assert (!current_args.back().ptoken);
             current_args.back().ptoken = n.expr->get_token();
-            auto decl = sema.get_local_declaration_of(*current_args.back().ptoken);
+            auto decl = sema.get_declaration_of(*current_args.back().ptoken);
             if (!(decl && decl->parameter && decl->parameter->pass == passing_style::forward)) {
                 errors.emplace_back(
                     n.position(),
@@ -1773,32 +1853,38 @@ public:
             {
                 auto& unqual = std::get<id_expression_node::unqualified>(id->id);
                 assert(unqual);
-                auto decl = sema.get_local_declaration_of(*unqual->identifier);
-                //  TODO: Generalize this -- for now we detect only cases of the form "p: *int = ...;"
-                //        We don't recognize pointer types that are deduced, multi-level, or from Cpp1
-                if (decl) {
-                    if (auto t = std::get_if<declaration_node::object>(&decl->declaration->type); t && (*t)->is_pointer_qualified()) {
-                        if (n.ops.empty()) {
-                            last_postfix_expr_was_pointer = true;
+                //  TODO: Generalize this: 
+                //        - we don't recognize pointer types from Cpp1
+                //        - we don't deduce pointer types from parameter_declaration_list_node
+                if ( is_pointer_declaration(unqual->identifier) ) {
+                    if (n.ops.empty()) {
+                        last_postfix_expr_was_pointer = true;
+                    }
+                    else
+                    {
+                        auto op = [&](){
+                            if (n.ops.size() >= 2 && n.ops[0].op->type() == lexeme::LeftParen) {
+                                return n.ops[1].op;
+                            } else {
+                                return n.ops.front().op;
+                            }
+                        }();
+
+                        if (op->type() == lexeme::PlusPlus ||
+                            op->type() == lexeme::MinusMinus ||
+                            op->type() == lexeme::LeftBracket
+                            ) {
+                            errors.emplace_back(
+                                op->position(),
+                                op->to_string(true) + " - pointer arithmetic is illegal - use std::span or gsl::span instead"
+                            );
+                            violates_bounds_safety = true;
                         }
-                        else
-                        {
-                            if (n.ops.front().op->type() == lexeme::PlusPlus ||
-                                n.ops.front().op->type() == lexeme::MinusMinus ||
-                                n.ops.front().op->type() == lexeme::LeftBracket
-                                ) {
-                                errors.emplace_back(
-                                    n.ops.front().op->position(),
-                                    n.ops.front().op->to_string(true) + " - pointer arithmetic is illegal - use std::span or gsl::span instead"
-                                );
-                                violates_bounds_safety = true;
-                            }
-                            else if (n.ops.front().op->type() == lexeme::Tilde) {
-                                errors.emplace_back(
-                                    n.ops.front().op->position(),
-                                    n.ops.front().op->to_string(true) + " - pointer bitwise manipulation is illegal - use std::bit_cast to convert to raw bytes first"
-                                );
-                            }
+                        else if (op->type() == lexeme::Tilde) {
+                            errors.emplace_back(
+                                op->position(),
+                                op->to_string(true) + " - pointer bitwise manipulation is illegal - use std::bit_cast to convert to raw bytes first"
+                            );
                         }
                     }
                 }

--- a/source/parse.h
+++ b/source/parse.h
@@ -3314,19 +3314,24 @@ private:
                 }
             }
 
+            //  deduced_type == true means that the type will be deduced,
+            //  represented using an empty type-id
             if (deduced_type) {
                 auto& type = std::get<declaration_node::object>(n->type);
+                // object initialized by the address of the curr() object 
                 if (peek(1)->type() == lexeme::Ampersand) {
                     type->address_of = &curr();
                 }
+                // object initialized by (potentially multiple) dereference of the curr() object 
                 else if (peek(1)->type() == lexeme::Multiply) {
                     type->dereference_of = &curr();
                     for (int i = 1; peek(i)->type() == lexeme::Multiply; ++i)
                         type->dereference_cnt += 1;
                 }
                 else if (
+                    // object initialized by the result of the function call (and it is not unnamed function)
                     (peek(1)->type() == lexeme::LeftParen && curr().type() != lexeme::Colon)
-                    || curr().type() == lexeme::Identifier 
+                    || curr().type() == lexeme::Identifier // or by the object (variable that the type need to be checked)
                 ) {
                     type->suspicious_initialization = &curr();
                 }

--- a/source/sema.h
+++ b/source/sema.h
@@ -226,9 +226,9 @@ public:
     {
     }
 
-    //  Get the declaration of t within the same named function
+    //  Get the declaration of t within the same named function or beyound it
     //
-    auto get_local_declaration_of(token const& t) -> declaration_sym const*
+    auto get_declaration_of(token const& t, bool look_beyond_current_function = false) -> declaration_sym const*
     {
         //  First find the position the query is coming from
         //  and remember its depth
@@ -252,11 +252,12 @@ public:
             {
                 auto const& decl = std::get<symbol::active::declaration>(ri->sym);
 
-                //  Don't look beyond the start of the current named (has identifier) function
+                //  Conditionally look beyond the start of the current named (has identifier) function
                 //  (an unnamed function is ok to look beyond)
                 assert(decl.declaration);
                 if (decl.declaration->type.index() == declaration_node::function &&
-                    decl.declaration->identifier)
+                    decl.declaration->identifier &&
+                    !look_beyond_current_function)
                 {
                     return nullptr;
                 }
@@ -883,7 +884,7 @@ public:
             {
                 //  Put this into the table if it's a use of an object in scope
                 //  or it's a 'copy' parameter
-                if (auto decl = get_local_declaration_of(t);
+                if (auto decl = get_declaration_of(t);
                     decl
                     )
                 {


### PR DESCRIPTION
The current implementation has safety guarantees only for explicit pointers declaration. If the pointer type is deduced, cppfront does not provide a safety check.

This change introduces pointer type deduction for types defined in cpp2. After this change cppfront will process below code
```cpp
fun: (inout i:int) -> *int = {
    return i&;
}

fun2: (inout i:int) -> (result : *int) = {
    result = i&;
}

main: (argc : int, argv : **char) -> int = {
    a:     int = 2;
    pa:   *int = a&;
    ppa: **int = pa&;

    pa = 0;       // caught

    pa2:= ppa*;
    pa2 = 0;      // caught

    pa3 := a&;
    pa3 = 0;      // caught
    pa3 += 2;     // caught

    ppa2 := pa2&;
    pa4 := ppa2*;
    pa4 = 0;      // caught

    pppa := ppa&;
    pa5 := pppa**;
    pa5 = 0;      // caught

    fun(a)++;     // caught
    fp := fun(a);
    fp = 0;       // caught

    f := fun(a)*;

    fp2 := fun2(a).result;
    fp2--;        // not caught :(

    return a * pa* * ppa**; // 8
}
```

And will generate errors:
```
pure2-deducing-pointers.cpp2...
pure2-deducing-pointers.cpp2(14,8): error: = - pointer assignment from null or integer is illegal
pure2-deducing-pointers.cpp2(17,9): error: = - pointer assignment from null or integer is illegal
pure2-deducing-pointers.cpp2(20,9): error: = - pointer assignment from null or integer is illegal
pure2-deducing-pointers.cpp2(21,9): error: += - pointer assignment from null or integer is illegal
pure2-deducing-pointers.cpp2(25,9): error: = - pointer assignment from null or integer is illegal
pure2-deducing-pointers.cpp2(29,9): error: = - pointer assignment from null or integer is illegal
pure2-deducing-pointers.cpp2(31,11): error: ++ - pointer arithmetic is illegal - use std::span or gsl::span instead
pure2-deducing-pointers.cpp2(33,8): error: = - pointer assignment from null or integer is illegal
  ==> program violates lifetime safety guarantee - see previous errors
  ==> program violates bounds safety guarantee - see previous errors
```

Unfortunately, this implementation does not deduce pointer types from functions declared after the analyzed code. That means that defining `fun` and `fun2` functions after the `main` will block deducing pointer type for lines
```cpp
fun(a)++;     // not caught anymore
fp := fun(a);
fp = 0;       // not caught anymore

f := fun(a)*; // not deduced as pointer type anymore
```

This implementation also does not deduce pointer types returned as `parameter_declaration_list_node`
```cpp
fp2 := fun2(a).result; // not deduced as pointer
fp2--;        // not caught :(
```

This replaces: https://github.com/hsutter/cppfront/pull/93 & https://github.com/hsutter/cppfront/pull/94