### PR TITLE
Fix to_string(std::any) overload

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1114,7 +1114,7 @@ inline auto to_string(...) -> std::string {
     return "(customize me - no cpp2::to_string overload exists for this type)";
 }
 
-inline auto to_string(std::any const&) -> std::string {
+inline auto to_string(std::same_as<std::any> auto const&) -> std::string {
     return "std::any";
 }
 

--- a/regression-tests/test-results/clang-12/mixed-string-interpolation.cpp.execution
+++ b/regression-tests/test-results/clang-12/mixed-string-interpolation.cpp.execution
@@ -14,4 +14,4 @@ p = (first, (empty))
 t = (3.140000, (empty), (empty))
 vv = 0
 vv = (1, 2.300000)
-custom = std::any
+custom = (customize me - no cpp2::to_string overload exists for this type)


### PR DESCRIPTION
Closes #200 

Having the code

```cpp
struct X {};

main: () -> int = {
    x: X = ();

    std::cout << "x  = '(x)$'" << std::endl;
}
```
Currently, end with:
```
../tests/bug.cpp2... ok (mixed Cpp1/Cpp2, Cpp2 code passes safety checks)

x  = 'std::any'
```
But should with:
```
../tests/bug.cpp2... ok (mixed Cpp1/Cpp2, Cpp2 code passes safety checks)

x  = '(customize me - no cpp2::to_string overload exists for this type)'
```

This change replace the problematic `cpp2::to_string(std::any)z overload to:
```cpp
template<typename T>
    requires std::is_same_v<T, std::any>
inline auto to_string(T const&) -> std::string {
  return "std::any";
}
```

And fix one regression test.
