### PR TITLE
Update tests missed in PR #203

### DIFF
--- a/regression-tests/test-results/apple-clang-14/mixed-string-interpolation.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-string-interpolation.cpp.execution
@@ -14,4 +14,4 @@ p = (first, (empty))
 t = (3.140000, (empty), (empty))
 vv = 0
 vv = (1, 2.300000)
-custom = std::any
+custom = (customize me - no cpp2::to_string overload exists for this type)

--- a/regression-tests/test-results/gcc-10/mixed-string-interpolation.cpp.execution
+++ b/regression-tests/test-results/gcc-10/mixed-string-interpolation.cpp.execution
@@ -14,4 +14,4 @@ p = (first, (empty))
 t = (3.140000, (empty), (empty))
 vv = 0
 vv = (1, 2.300000)
-custom = std::any
+custom = (customize me - no cpp2::to_string overload exists for this type)

--- a/regression-tests/test-results/msvc-2022/mixed-string-interpolation.cpp.execution
+++ b/regression-tests/test-results/msvc-2022/mixed-string-interpolation.cpp.execution
@@ -14,4 +14,4 @@ p = (first, (empty))
 t = (3.140000, (empty), (empty))
 vv = 0
 vv = (1, 2.300000)
-custom = std::any
+custom = (customize me - no cpp2::to_string overload exists for this type)


### PR DESCRIPTION
This PR updates tests that were missed in [PR #203](https://github.com/hsutter/cppfront/pull/203).
In the mentioned PR only the `clang-10` test was updated.