### PR TITLE
Fix regression tests for apple-clang-14 y23w01b

### DIFF
--- a/regression-tests/test-results/apple-clang-14/mixed-captures-in-expressions-and-postconditions.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-captures-in-expressions-and-postconditions.cpp.execution
@@ -1,4 +1,0 @@
-hello
-2022
-hello-ish
-2022-ish

--- a/regression-tests/test-results/apple-clang-14/mixed-captures-in-expressions-and-postconditions.cpp.output
+++ b/regression-tests/test-results/apple-clang-14/mixed-captures-in-expressions-and-postconditions.cpp.output
@@ -1,0 +1,7 @@
+mixed-captures-in-expressions-and-postconditions.cpp2:12:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each( vec, callback );
+    ~~~~~~~~~~~~~^
+mixed-captures-in-expressions-and-postconditions.cpp2:14:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each( std::move(vec), std::move(callback));
+    ~~~~~~~~~~~~~^
+2 errors generated.

--- a/regression-tests/test-results/apple-clang-14/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp.execution
@@ -1,4 +1,0 @@
-hello
-2022
-hello-ish
-2022-ish

--- a/regression-tests/test-results/apple-clang-14/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp.output
+++ b/regression-tests/test-results/apple-clang-14/mixed-function-expression-and-std-ranges-for-each-with-capture.cpp.output
@@ -1,0 +1,7 @@
+mixed-function-expression-and-std-ranges-for-each-with-capture.cpp2:14:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each
+    ~~~~~~~~~~~~~^
+mixed-function-expression-and-std-ranges-for-each-with-capture.cpp2:18:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each( view, std::move(callback));
+    ~~~~~~~~~~~~~^
+2 errors generated.

--- a/regression-tests/test-results/apple-clang-14/mixed-function-expression-and-std-ranges-for-each.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-function-expression-and-std-ranges-for-each.cpp.execution
@@ -1,4 +1,0 @@
-hello
-2022
-hello-ish
-2022-ish

--- a/regression-tests/test-results/apple-clang-14/mixed-function-expression-and-std-ranges-for-each.cpp.output
+++ b/regression-tests/test-results/apple-clang-14/mixed-function-expression-and-std-ranges-for-each.cpp.output
@@ -1,0 +1,7 @@
+mixed-function-expression-and-std-ranges-for-each.cpp2:13:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each
+    ~~~~~~~~~~~~~^
+mixed-function-expression-and-std-ranges-for-each.cpp2:17:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each( view, std::move(callback));
+    ~~~~~~~~~~~~~^
+2 errors generated.

--- a/regression-tests/test-results/apple-clang-14/mixed-function-expression-with-pointer-capture.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-function-expression-with-pointer-capture.cpp.execution
@@ -1,6 +1,0 @@
-
-hello
-
-2023
-hello-ish
-2023-ish

--- a/regression-tests/test-results/apple-clang-14/mixed-function-expression-with-pointer-capture.cpp.output
+++ b/regression-tests/test-results/apple-clang-14/mixed-function-expression-with-pointer-capture.cpp.output
@@ -1,0 +1,7 @@
+mixed-function-expression-with-pointer-capture.cpp2:14:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each( view, [_0 = (&y)](auto const& x){
+    ~~~~~~~~~~~~~^
+mixed-function-expression-with-pointer-capture.cpp2:19:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each( view, std::move(callback));
+    ~~~~~~~~~~~~~^
+2 errors generated.

--- a/regression-tests/test-results/apple-clang-14/mixed-function-expression-with-repeated-capture.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-function-expression-with-repeated-capture.cpp.execution
@@ -1,6 +1,0 @@
-
-hello
-
-2022
-hello-ish
-2022-ish

--- a/regression-tests/test-results/apple-clang-14/mixed-function-expression-with-repeated-capture.cpp.output
+++ b/regression-tests/test-results/apple-clang-14/mixed-function-expression-with-repeated-capture.cpp.output
@@ -1,0 +1,7 @@
+mixed-function-expression-with-repeated-capture.cpp2:14:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each
+    ~~~~~~~~~~~~~^
+mixed-function-expression-with-repeated-capture.cpp2:18:18: error: no member named 'for_each' in namespace 'std::ranges'
+    std::ranges::for_each( view, std::move(callback));
+    ~~~~~~~~~~~~~^
+2 errors generated.


### PR DESCRIPTION
Apple clang 14 still has no ranges support - my test script error.

Sorry for trouble