### PR TITLE
Fix bug generating 'return;' for empty function

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -3347,8 +3347,14 @@ private:
 
             if (body->statements.empty() || body->statements.back()->statement.index() != statement_node::return_)
             {
-                auto last_pos = body->statements.back()->position();
-                ++last_pos.lineno;
+                auto last_pos = [&]{
+                    if (!body->statements.empty()) {
+                        auto pos = body->statements.back()->position();
+                        ++pos.lineno;
+                        return pos;
+                    }
+                    return body->close_brace;
+                }();
                 generated_tokens_->emplace_back( "return", last_pos, lexeme::Keyword);
 
                 auto ret = std::make_unique<return_statement_node>();


### PR DESCRIPTION
Closes https://github.com/hsutter/cppfront/issues/208

The current implementation of cppfront fails to compile
```cpp
fun: () -> (s : std::string = "Hello World!") = {}
```
as it calls `body->statements.back()->position();` on empty `body->statements`.

This change introduces a check if `body->statements` is empty and puts 'return' in the place of close braces.