### PR TITLE
Add include of <type_traits> in common.h

### DIFF
--- a/source/common.h
+++ b/source/common.h
@@ -33,6 +33,7 @@
 #include <iomanip>
 #include <compare>
 #include <algorithm>
+#include <type_traits>
 
 namespace cpp2 {
 


### PR DESCRIPTION
For std::is_same_v (line 228)

Signed-off-by: Gabriel Gerlero <gerlero@users.noreply.github.com>

Found it accidentally while playing with my compiler settings..