### PR TITLE
Fix duplicate symbol `cpp2::Uncaught_exceptions()`

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -408,7 +408,7 @@ auto assert_in_bounds(auto&& x, auto&& arg CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAU
 #endif
 }
 
-auto Uncaught_exceptions() -> int {
+inline auto Uncaught_exceptions() -> int {
 #ifdef CPP2_NO_EXCEPTIONS
     return 0;
 #else


### PR DESCRIPTION
https://github.com/hsutter/cppfront/commit/5575ec40ff94002cd537981bf0b14fa217036500 added new symbols to `cpp2util.h` that caused the linker to find a duplicate symbol of `cpp2::Uncaught_exceptions()`.

Linking multiple cpp2 files ends with:
```
[build] duplicate symbol 'cpp2::Uncaught_exceptions()' in:
[build]     libs/execspec/CMakeFiles/libexecspec.dir/src/application.cpp.o
[build]     libs/markdown/CMakeFiles/libmarkdown.dir/src/markdown.cpp.o
[build] duplicate symbol 'cpp2::Uncaught_exceptions()' in:
[build]     libs/execspec/CMakeFiles/libexecspec.dir/src/application.cpp.o
[build]     libs/execspec/CMakeFiles/libexecspec.dir/src/compile_cpp2.cpp.o
[build] duplicate symbol 'cpp2::Uncaught_exceptions()' in:
[build]     libs/execspec/CMakeFiles/libexecspec.dir/src/application.cpp.o
[build]     apps/execspec/CMakeFiles/execspec.dir/src/main.cpp.o
[build] ld: 3 duplicate symbols for architecture arm64
```

This change adds `inline` to `cpp2::Uncaught_exceptions()` function that fixes an error.