### PR TITLE
Fix check of `typename C::value_type` where `C` is an `int`

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -880,7 +880,7 @@ auto as( X const& x ) -> auto
     //  Experiment: Recognize the nested `::value_type` pattern for some dynamic library types
     //  like std::optional, and try to prevent accidental narrowing conversions even when
     //  those types themselves don't defend against them
-    if constexpr( requires{ typename C::value_type; } && std::is_convertible_v<X, typename C::value_type> ) {
+    if constexpr( requires { requires std::is_convertible_v<X, typename C::value_type>; } ) {
         if constexpr( is_narrowing_v<typename C::value_type, X>) {
             return nonesuch;
         }


### PR DESCRIPTION
https://github.com/hsutter/cppfront/commit/4693e52341cfcbd10b23ce05da9fc029667b62be introduce a check `std::is_convertible_v<X, typename C::value_type>` that failed when `C` is an `int`.

The issue was discovered when trying to compile the following code:
```cpp
main: () -> int = {
    x := 'a';
    u := x as int;

    std::cout << "u = '(u)$'" << std::endl;
}
```
cppfront succeeds but the cpp1 compiler fails with the error:
```
In file included from ../tests/bug_value_type_check.cpp:2:
include/cpp2util.h:883:92: error: type 'int' cannot be used prior to '::' because it has no members
    if constexpr( requires{ typename C::value_type; } && std::is_convertible_v<X, typename C::value_type> ) {
                                                                                           ^
include/cpp2util.h:1474:52: note: in instantiation of function template specialization 'cpp2::as<int, char>' requested here
    else if constexpr( std::is_same_v< CPP2_TYPEOF(as<C>(CPP2_FORWARD(x))), nonesuch_ > ) {
                                                   ^
../tests/bug_value_type_check.cpp2:3:19: note: in instantiation of function template specialization 'cpp2::as_<int, char &>' requested here
    auto u {cpp2::as_<int>(x)}; 
                  ^
1 error generated.
```

This change corrects this error and makes the code compile and run successfully.