### PR TITLE
cpp2util.h: Fix typeid(T) -> Typeid<T> usage with -fno-rtti.

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -443,7 +443,7 @@ auto Typeid() -> decltype(auto) {
 
 //  We don't need typeid(expr) yet -- uncomment this if/when we need it
 //auto Typeid( [[maybe_unused]] auto&& x ) -> decltype(auto) {
-//#ifdef CPP2_DISABLE_RTTI
+//#ifdef CPP2_NO_RTTI
 //    Type.expects(
 //        !"<write appropriate error message here>"
 //    );
@@ -1144,7 +1144,7 @@ auto as( std::variant<Ts...> const& x ) -> decltype(auto) {
 template<typename T, typename X>
     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
 constexpr auto is( X const& x ) -> bool
-    { return x.type() == typeid(T); }
+    { return x.type() == Typeid<T>(); }
 
 template<typename T, typename X>
     requires (std::is_same_v<X,std::any> && std::is_same_v<T,empty>)


### PR DESCRIPTION
The no exception / no rtti modes seem to be working fine. Just this small fix needed.

Side note: I ended up defining CPP2_NO_EXCEPTIONS & CPP2_NO_RTTI in my build system. I did look at adding a preprocessor based auto-detection in cpp2util.h but it turns out that its compiler dependant so its a whole mess to do robustly, and it seems out of scope at least for now.