### PR TITLE
FIX: casting variant for type on indexes from 10 to 19 fail with exception

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1071,16 +1071,16 @@ auto as( std::variant<Ts...> && x ) -> decltype(auto) {
     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 7>(x)), T >) { if (x.index() ==  7) return operator_as<7>(x); }
     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 8>(x)), T >) { if (x.index() ==  8) return operator_as<8>(x); }
     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 9>(x)), T >) { if (x.index() ==  9) return operator_as<9>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<0>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<11>(x)), T >) { if (x.index() == 11) return operator_as<1>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<12>(x)), T >) { if (x.index() == 12) return operator_as<2>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<3>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<14>(x)), T >) { if (x.index() == 14) return operator_as<4>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return operator_as<5>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<16>(x)), T >) { if (x.index() == 16) return operator_as<6>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<17>(x)), T >) { if (x.index() == 17) return operator_as<7>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<18>(x)), T >) { if (x.index() == 18) return operator_as<8>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<19>(x)), T >) { if (x.index() == 19) return operator_as<9>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<10>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<11>(x)), T >) { if (x.index() == 11) return operator_as<11>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<12>(x)), T >) { if (x.index() == 12) return operator_as<12>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<14>(x)), T >) { if (x.index() == 14) return operator_as<14>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return operator_as<15>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<16>(x)), T >) { if (x.index() == 16) return operator_as<16>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<17>(x)), T >) { if (x.index() == 17) return operator_as<17>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<18>(x)), T >) { if (x.index() == 18) return operator_as<18>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<19>(x)), T >) { if (x.index() == 19) return operator_as<19>(x); }
     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
 }
 
@@ -1096,16 +1096,16 @@ auto as( std::variant<Ts...> & x ) -> decltype(auto) {
     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 7>(x)), T >) { if (x.index() ==  7) return operator_as<7>(x); }
     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 8>(x)), T >) { if (x.index() ==  8) return operator_as<8>(x); }
     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 9>(x)), T >) { if (x.index() ==  9) return operator_as<9>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<0>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<11>(x)), T >) { if (x.index() == 11) return operator_as<1>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<12>(x)), T >) { if (x.index() == 12) return operator_as<2>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<3>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<14>(x)), T >) { if (x.index() == 14) return operator_as<4>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return operator_as<5>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<16>(x)), T >) { if (x.index() == 16) return operator_as<6>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<17>(x)), T >) { if (x.index() == 17) return operator_as<7>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<18>(x)), T >) { if (x.index() == 18) return operator_as<8>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<19>(x)), T >) { if (x.index() == 19) return operator_as<9>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<10>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<11>(x)), T >) { if (x.index() == 11) return operator_as<11>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<12>(x)), T >) { if (x.index() == 12) return operator_as<12>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<14>(x)), T >) { if (x.index() == 14) return operator_as<14>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return operator_as<15>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<16>(x)), T >) { if (x.index() == 16) return operator_as<16>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<17>(x)), T >) { if (x.index() == 17) return operator_as<17>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<18>(x)), T >) { if (x.index() == 18) return operator_as<18>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<19>(x)), T >) { if (x.index() == 19) return operator_as<19>(x); }
     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
 }
 
@@ -1121,16 +1121,16 @@ auto as( std::variant<Ts...> const& x ) -> decltype(auto) {
     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 7>(x)), T >) { if (x.index() ==  7) return operator_as<7>(x); }
     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 8>(x)), T >) { if (x.index() ==  8) return operator_as<8>(x); }
     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 9>(x)), T >) { if (x.index() ==  9) return operator_as<9>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<0>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<11>(x)), T >) { if (x.index() == 11) return operator_as<1>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<12>(x)), T >) { if (x.index() == 12) return operator_as<2>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<3>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<14>(x)), T >) { if (x.index() == 14) return operator_as<4>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return operator_as<5>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<16>(x)), T >) { if (x.index() == 16) return operator_as<6>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<17>(x)), T >) { if (x.index() == 17) return operator_as<7>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<18>(x)), T >) { if (x.index() == 18) return operator_as<8>(x); }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<19>(x)), T >) { if (x.index() == 19) return operator_as<9>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<10>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<11>(x)), T >) { if (x.index() == 11) return operator_as<11>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<12>(x)), T >) { if (x.index() == 12) return operator_as<12>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<14>(x)), T >) { if (x.index() == 14) return operator_as<14>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return operator_as<15>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<16>(x)), T >) { if (x.index() == 16) return operator_as<16>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<17>(x)), T >) { if (x.index() == 17) return operator_as<17>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<18>(x)), T >) { if (x.index() == 18) return operator_as<18>(x); }
+    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<19>(x)), T >) { if (x.index() == 19) return operator_as<19>(x); }
     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
 }
 

--- a/regression-tests/mixed-as-for-variant-20-types.cpp2
+++ b/regression-tests/mixed-as-for-variant-20-types.cpp2
@@ -1,0 +1,75 @@
+template<int I>
+struct X { operator int() const { return I; } };
+
+main: () -> int = {
+
+    v: std::variant<X< 0>, X< 1>, X< 2>, X< 3>, X< 4>, X< 5>, X< 6>, X< 7>, X< 8>, X< 9>, 
+                    X<10>, X<11>, X<12>, X<13>, X<14>, X<15>, X<16>, X<17>, X<18>, X<19>> = X<0>();
+
+    // lvalue reference
+    v = X< 0>(); std::cout << "v as X< 0> = (int(v as X< 0>))$" << std::endl;
+    v = X< 1>(); std::cout << "v as X< 1> = (int(v as X< 1>))$" << std::endl;
+    v = X< 2>(); std::cout << "v as X< 2> = (int(v as X< 2>))$" << std::endl;
+    v = X< 3>(); std::cout << "v as X< 3> = (int(v as X< 3>))$" << std::endl;
+    v = X< 4>(); std::cout << "v as X< 4> = (int(v as X< 4>))$" << std::endl;
+    v = X< 5>(); std::cout << "v as X< 5> = (int(v as X< 5>))$" << std::endl;
+    v = X< 6>(); std::cout << "v as X< 6> = (int(v as X< 6>))$" << std::endl;
+    v = X< 7>(); std::cout << "v as X< 7> = (int(v as X< 7>))$" << std::endl;
+    v = X< 8>(); std::cout << "v as X< 8> = (int(v as X< 8>))$" << std::endl;
+    v = X< 9>(); std::cout << "v as X< 9> = (int(v as X< 9>))$" << std::endl;
+    v = X<10>(); std::cout << "v as X<10> = (int(v as X<10>))$" << std::endl;
+    v = X<11>(); std::cout << "v as X<11> = (int(v as X<11>))$" << std::endl;
+    v = X<12>(); std::cout << "v as X<12> = (int(v as X<12>))$" << std::endl;
+    v = X<13>(); std::cout << "v as X<13> = (int(v as X<13>))$" << std::endl;
+    v = X<14>(); std::cout << "v as X<14> = (int(v as X<14>))$" << std::endl;
+    v = X<15>(); std::cout << "v as X<15> = (int(v as X<15>))$" << std::endl;
+    v = X<16>(); std::cout << "v as X<16> = (int(v as X<16>))$" << std::endl;
+    v = X<17>(); std::cout << "v as X<17> = (int(v as X<17>))$" << std::endl;
+    v = X<18>(); std::cout << "v as X<18> = (int(v as X<18>))$" << std::endl;
+    v = X<19>(); std::cout << "v as X<19> = (int(v as X<19>))$" << std::endl;
+
+    // const lvalue reference
+    v = X< 0>(); std::cout << "as_const(v) as X< 0> = (int(std::as_const(v) as X< 0>))$" << std::endl;
+    v = X< 1>(); std::cout << "as_const(v) as X< 1> = (int(std::as_const(v) as X< 1>))$" << std::endl;
+    v = X< 2>(); std::cout << "as_const(v) as X< 2> = (int(std::as_const(v) as X< 2>))$" << std::endl;
+    v = X< 3>(); std::cout << "as_const(v) as X< 3> = (int(std::as_const(v) as X< 3>))$" << std::endl;
+    v = X< 4>(); std::cout << "as_const(v) as X< 4> = (int(std::as_const(v) as X< 4>))$" << std::endl;
+    v = X< 5>(); std::cout << "as_const(v) as X< 5> = (int(std::as_const(v) as X< 5>))$" << std::endl;
+    v = X< 6>(); std::cout << "as_const(v) as X< 6> = (int(std::as_const(v) as X< 6>))$" << std::endl;
+    v = X< 7>(); std::cout << "as_const(v) as X< 7> = (int(std::as_const(v) as X< 7>))$" << std::endl;
+    v = X< 8>(); std::cout << "as_const(v) as X< 8> = (int(std::as_const(v) as X< 8>))$" << std::endl;
+    v = X< 9>(); std::cout << "as_const(v) as X< 9> = (int(std::as_const(v) as X< 9>))$" << std::endl;
+    v = X<10>(); std::cout << "as_const(v) as X<10> = (int(std::as_const(v) as X<10>))$" << std::endl;
+    v = X<11>(); std::cout << "as_const(v) as X<11> = (int(std::as_const(v) as X<11>))$" << std::endl;
+    v = X<12>(); std::cout << "as_const(v) as X<12> = (int(std::as_const(v) as X<12>))$" << std::endl;
+    v = X<13>(); std::cout << "as_const(v) as X<13> = (int(std::as_const(v) as X<13>))$" << std::endl;
+    v = X<14>(); std::cout << "as_const(v) as X<14> = (int(std::as_const(v) as X<14>))$" << std::endl;
+    v = X<15>(); std::cout << "as_const(v) as X<15> = (int(std::as_const(v) as X<15>))$" << std::endl;
+    v = X<16>(); std::cout << "as_const(v) as X<16> = (int(std::as_const(v) as X<16>))$" << std::endl;
+    v = X<17>(); std::cout << "as_const(v) as X<17> = (int(std::as_const(v) as X<17>))$" << std::endl;
+    v = X<18>(); std::cout << "as_const(v) as X<18> = (int(std::as_const(v) as X<18>))$" << std::endl;
+    v = X<19>(); std::cout << "as_const(v) as X<19> = (int(std::as_const(v) as X<19>))$" << std::endl;
+
+    // rvalue reference
+    v = X< 0>(); std::cout << "move(v) as X< 0> = (int((move v) as X< 0>))$" << std::endl;
+    v = X< 1>(); std::cout << "move(v) as X< 1> = (int((move v) as X< 1>))$" << std::endl;
+    v = X< 2>(); std::cout << "move(v) as X< 2> = (int((move v) as X< 2>))$" << std::endl;
+    v = X< 3>(); std::cout << "move(v) as X< 3> = (int((move v) as X< 3>))$" << std::endl;
+    v = X< 4>(); std::cout << "move(v) as X< 4> = (int((move v) as X< 4>))$" << std::endl;
+    v = X< 5>(); std::cout << "move(v) as X< 5> = (int((move v) as X< 5>))$" << std::endl;
+    v = X< 6>(); std::cout << "move(v) as X< 6> = (int((move v) as X< 6>))$" << std::endl;
+    v = X< 7>(); std::cout << "move(v) as X< 7> = (int((move v) as X< 7>))$" << std::endl;
+    v = X< 8>(); std::cout << "move(v) as X< 8> = (int((move v) as X< 8>))$" << std::endl;
+    v = X< 9>(); std::cout << "move(v) as X< 9> = (int((move v) as X< 9>))$" << std::endl;
+    v = X<10>(); std::cout << "move(v) as X<10> = (int((move v) as X<10>))$" << std::endl;
+    v = X<11>(); std::cout << "move(v) as X<11> = (int((move v) as X<11>))$" << std::endl;
+    v = X<12>(); std::cout << "move(v) as X<12> = (int((move v) as X<12>))$" << std::endl;
+    v = X<13>(); std::cout << "move(v) as X<13> = (int((move v) as X<13>))$" << std::endl;
+    v = X<14>(); std::cout << "move(v) as X<14> = (int((move v) as X<14>))$" << std::endl;
+    v = X<15>(); std::cout << "move(v) as X<15> = (int((move v) as X<15>))$" << std::endl;
+    v = X<16>(); std::cout << "move(v) as X<16> = (int((move v) as X<16>))$" << std::endl;
+    v = X<17>(); std::cout << "move(v) as X<17> = (int((move v) as X<17>))$" << std::endl;
+    v = X<18>(); std::cout << "move(v) as X<18> = (int((move v) as X<18>))$" << std::endl;
+    v = X<19>(); std::cout << "move(v) as X<19> = (int((move v) as X<19>))$" << std::endl;
+
+}


### PR DESCRIPTION
The current implementation has an error for indexes greater than 9 (copy and paste error). It makes casting variants with type for indexes from 10 to 19 fail with an exception.

The following code:
```cpp
template<int I>
struct X { operator int() const { return I; } };

main: () -> int = {

    v: std::variant<X< 0>, X< 1>, X< 2>, X< 3>, X< 4>, X< 5>, X< 6>, X< 7>, X< 8>, X< 9>, 
                    X<10>, X<11>, X<12>, X<13>, X<14>, X<15>, X<16>, X<17>, X<18>, X<19>> = X<0>();

    v = X< 0>(); std::cout << "v as X< 0> = (int(v as X< 0>))$" << std::endl;
    v = X< 1>(); std::cout << "v as X< 1> = (int(v as X< 1>))$" << std::endl;
    v = X< 2>(); std::cout << "v as X< 2> = (int(v as X< 2>))$" << std::endl;
    v = X< 3>(); std::cout << "v as X< 3> = (int(v as X< 3>))$" << std::endl;
    v = X< 4>(); std::cout << "v as X< 4> = (int(v as X< 4>))$" << std::endl;
    v = X< 5>(); std::cout << "v as X< 5> = (int(v as X< 5>))$" << std::endl;
    v = X< 6>(); std::cout << "v as X< 6> = (int(v as X< 6>))$" << std::endl;
    v = X< 7>(); std::cout << "v as X< 7> = (int(v as X< 7>))$" << std::endl;
    v = X< 8>(); std::cout << "v as X< 8> = (int(v as X< 8>))$" << std::endl;
    v = X< 9>(); std::cout << "v as X< 9> = (int(v as X< 9>))$" << std::endl;
    v = X<10>(); std::cout << "v as X<10> = (int(v as X<10>))$" << std::endl;
    v = X<11>(); std::cout << "v as X<11> = (int(v as X<11>))$" << std::endl;
    v = X<12>(); std::cout << "v as X<12> = (int(v as X<12>))$" << std::endl;
    v = X<13>(); std::cout << "v as X<13> = (int(v as X<13>))$" << std::endl;
    v = X<14>(); std::cout << "v as X<14> = (int(v as X<14>))$" << std::endl;
    v = X<15>(); std::cout << "v as X<15> = (int(v as X<15>))$" << std::endl;
    v = X<16>(); std::cout << "v as X<16> = (int(v as X<16>))$" << std::endl;
    v = X<17>(); std::cout << "v as X<17> = (int(v as X<17>))$" << std::endl;
    v = X<18>(); std::cout << "v as X<18> = (int(v as X<18>))$" << std::endl;
    v = X<19>(); std::cout << "v as X<19> = (int(v as X<19>))$" << std::endl;
}
```
Fail with an error:
```
../tests/mixed-as-for-variant-20-types.cpp2... ok (mixed Cpp1/Cpp2, Cpp2 code passes safety checks)

v as X< 0> = 0
v as X< 1> = 1
v as X< 2> = 2
v as X< 3> = 3
v as X< 4> = 4
v as X< 5> = 5
v as X< 6> = 6
v as X< 7> = 7
v as X< 8> = 8
v as X< 9> = 9
libc++abi: terminating with uncaught exception of type std::bad_variant_access: bad_variant_access
```

This commit fixes this error and adds tests that check casts of a variant with 20 types for all types and variants passed as:
* lvalue,
* const lvalue, and 
* rvalue.