### PR TITLE
Add support for user-defined literals

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1123,6 +1123,21 @@ public:
         in_definite_init = is_definite_initialization(&n);
     }
 
+    //-----------------------------------------------------------------------
+    //
+    auto emit(literal_node const& n, source_position pos = {}) -> void
+    {
+        if (pos == source_position{}) {
+            pos = n.position();
+        }
+
+        assert(n.literal);
+        emit(*n.literal);
+        if (n.user_defined_suffix) {
+            emit(*n.user_defined_suffix);
+        }
+    }
+
 
     //-----------------------------------------------------------------------
     //
@@ -1744,6 +1759,7 @@ public:
         try_emit<primary_expression_node::expression_list>(n.expr);
         try_emit<primary_expression_node::id_expression  >(n.expr);
         try_emit<primary_expression_node::inspect        >(n.expr, true);
+        try_emit<primary_expression_node::literal        >(n.expr);
 
         if (n.expr.index() == primary_expression_node::declaration)
         {


### PR DESCRIPTION
Currently, cppfront is handling only literals and not user-defined literals. This change introduces support for user-defined literals, making it possible to use `std::literals` and some custom-made literals in libraries.

E.g. This change make it possible to use [`boost::ut` library](https://github.com/boost-ext/ut) in cppfront that uses UDL a lot:

```cpp
#include "boost/ut.hpp"

constexpr auto sum(auto... values) { return (values + ...); }

using namespace boost::ut;
using namespace std::literals;

main: () -> int = {
    "sum"_test = :() = {
        expect(sum(0) == 0_i);
        expect(sum(1, 2) == 3_i);
        expect(sum(1, 2) > 0 && 42_i == sum(40, 2));
    };

    "[vector]"_test = :() = {
        v := std::vector<int>(5);

        expect((5_ul == std::size(v)) >> fatal);

        should("resize bigger") = :() = { // or "resize bigger"_test
            mut(v$).resize(10);
            expect(10_ul == std::size(v$));
        };

        expect((5_ul == std::size(v)) >> fatal);
    };

    s := "my string view"sv; // creating string view also works

    std::cout << s << std::endl;
}
```
it generates:
```cpp
// ----- Cpp2 support -----
#include "cpp2util.h"

#line 1 "/Users/filipsajdak/dev/execspec/libs/html/tests/html_tests.cpp2"
#include "boost/ut.hpp"

constexpr auto sum(auto... values) { return (values + ...); }

using namespace boost::ut;
using namespace std::literals;

[[nodiscard]] auto main() -> int;

//=== Cpp2 definitions ==========================================================

#line 7 "/Users/filipsajdak/dev/execspec/libs/html/tests/html_tests.cpp2"

[[nodiscard]] auto main() -> int{
    "sum"_test = [](){
        expect(sum(0) == 0_i);
        expect(sum(1, 2) == 3_i);
        expect(cpp2::cmp_greater(sum(1, 2),0) && 41_i==sum(40, 2));
    };

    "[vector]"_test = [](){
        auto v {std::vector<int>(5)}; 

        expect((5_ul == std::size(v)) >> fatal);

        should("resize bigger") = [_0 = v](){// or "resize bigger"_test
            CPP2_UFCS(resize, mut(_0), 10);
            expect(10_ul == std::size(_0));
        };

        expect((5_ul == std::size(std::move(v))) >> fatal);
    };

    auto s {"my string view"sv}; // creating string view also works

    std::cout << std::move(s) << std::endl;
}
```
and after executing:
```
my string view
Running "sum"...
  tests.cpp2:12:FAILED [(true and 41 == 42)]
FAILED
Running "[vector]"...
 "resize bigger"...PASSED

===============================================================================
tests:   2 | 1 failed
asserts: 6 | 5 passed | 1 failed
```