### PR TITLE
Fix binary or expression - closes #239

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -2015,7 +2015,7 @@ private:
     //G
     auto bit_or_expression(bool allow_angle_operators = true) {
         return binary_expression<bit_or_expression_node> (
-            [](token const& t){ return t.type() == lexeme::LogicalOr; },
+            [](token const& t){ return t.type() == lexeme::Pipe; },
             [=,this]{ return bit_xor_expression(allow_angle_operators); }
         );
     }


### PR DESCRIPTION
In current implementation in parsing `bit_or_expression` we checked against `lexeme::LogicalOr` instead of `lexeme::Pipe`