### PR TITLE
Add return forward passing style support

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -2921,7 +2921,11 @@ public:
             printer.print_cpp2( " -> ", n.position() );
             auto& r = std::get<function_type_node::id>(n.returns);
             assert(r);
-            emit(*r);
+            if (r->is_wildcard() && n.returns_passing == passing_style::forward) {
+                printer.print_cpp2( "decltype(auto)", n.position() );
+            } else {
+                emit(*r);
+            }
         }
 
         else {

--- a/source/parse.h
+++ b/source/parse.h
@@ -1045,6 +1045,7 @@ struct function_type_node
         std::unique_ptr<type_id_node>,
         std::unique_ptr<parameter_declaration_list_node>
     > returns;
+    passing_style returns_passing = passing_style::move;
 
     std::vector<std::unique_ptr<contract_node>> contracts;
 
@@ -3278,6 +3279,14 @@ private:
         if (curr().type() == lexeme::Arrow)
         {
             next();
+
+            if (auto pass = to_passing_style(curr()); pass != passing_style::invalid) {
+                n->returns_passing = pass;
+                if (pass != passing_style::forward && pass != passing_style::move) {
+                    error("only 'forward' and 'move' return passing style are allowed from functions");
+                }
+                next();
+            }
 
             if (auto t = type_id()) {
                 n->returns = std::move(t);


### PR DESCRIPTION
Based on chapter `1.5 Return values, D0708 R0` cppfront should support forward return passing style. The current implementeation makes it impossible to pass variable as a reference, or to forward value with preserving the return-expression’s cv-qualification and value category.

After this change it is possible to create the following function:
```cpp
first: (forward rng) -> forward _ = {
    [[assert Bounds: !std::empty(rng)]]
    return std::begin(rng)*;
}
```
that will (for lvalue rng) returns lvalue reference to the first element of the rng and will make the following code possible:
```cpp
main: () -> int = {
    v : std::vector = (1,2,3);
    first(v) = 4;
    std::cout << first(v) << std::endl; // prints: 4
}
```

Limitations:

* don't know if `passing_style::move` has a special way or is it current default one.
* the wildcar is used currently `forward _` to get `decltype(auto)`,
* wildcars make these function order dependent and need to be defined before it is used.