### PR TITLE
Fix capture of same variable twice - closes #237

### DIFF
--- a/regression-tests/test-results/mixed-function-expression-with-repeated-capture.cpp
+++ b/regression-tests/test-results/mixed-function-expression-with-repeated-capture.cpp
@@ -22,7 +22,7 @@
 
     auto y {"\n"}; 
     std::ranges::for_each
-        ( view, [_0 = y, _1 = std::move(y)](auto const& x){std::cout << _0 << x << _1;});
+        ( view, [_0 = std::move(y)](auto const& x){std::cout << _0 << x << _0;});
 
     auto callback {[](auto& x) { return x += "-ish"; }}; 
     std::ranges::for_each( view, std::move(callback));

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1075,11 +1075,15 @@ public:
     //  is needed where Cpp1 and Cpp2 have different grammar orders
     //
 
-    auto print_to_string(auto& i, auto... more) -> std::string {
-        auto print = std::string{};
-        printer.emit_to_string(&print);
+    void print_to_string(std::string* str, auto& i, auto... more) {
+        printer.emit_to_string(str);
         emit(i, more...);
         printer.emit_to_string();
+    };
+
+    auto print_to_string(auto& i, auto... more) -> std::string {
+        auto print = std::string{};
+        print_to_string(&print, i, more...);
         return print;
     };
 
@@ -1716,9 +1720,27 @@ public:
         for (auto& cap : captures.members)
         {
             assert(cap.capture_expr->cap_grp == &captures);
-            printer.emit_to_string(&cap.str);
-            emit(*cap.capture_expr, true);
-            printer.emit_to_string();
+            print_to_string(&cap.str, *cap.capture_expr, true);
+            suppress_move_from_last_use = true;
+            print_to_string(&cap.str_suppressed_move, *cap.capture_expr, true);
+            suppress_move_from_last_use = false;
+        }
+
+        // If move from last use was used on the variable we need to rewrite the str to add std::move
+        // to earlier use of the variable. That will save us from capturing one variable two times
+        // (one with copy and one with std::move).
+        for (auto rit = captures.members.rbegin(); rit != captures.members.rend(); ++rit)
+        {
+            auto is_same_str_suppressed_move = [s=rit->str_suppressed_move](auto& cap){
+                return cap.str_suppressed_move == s;
+            };
+
+            auto rit2 = std::find_if(rit+1, captures.members.rend(), is_same_str_suppressed_move);
+            while (rit2 != captures.members.rend())
+            {
+                rit2->str = rit->str;
+                rit2 = std::find_if(rit2+1, captures.members.rend(), is_same_str_suppressed_move);
+            }
         }
 
         //  Then build the capture list, ignoring duplicated expressions
@@ -1739,8 +1761,8 @@ public:
                 if (num != 0) { // not first
                     lambda_intro += ", ";
                 }
-                printer.print_cpp2("_"+std::to_string(num)+" = ", pos);
-                emit(*cap.capture_expr, true);
+                cap.cap_sym = "_"+std::to_string(num);
+                printer.print_cpp2(cap.cap_sym + " = " + cap.str, pos);
             }
             ++num;
         }
@@ -1963,24 +1985,20 @@ public:
         if (n.cap_grp && !for_lambda_capture)
         {
             //  First stringize ourselves so that we compare equal against
-            //  the first *cap_grp .str that matches us (which is what the
+            //  the first *cap_grp .str_suppressed_move that matches us (which is what the
             //  lambda introducer generator used to create a lambda capture)
-            auto my_str = std::string{};
-            printer.emit_to_string(&my_str);
-            emit(n, true);  // reentrant, but not in this 'if' because for_lambda_capture == true
-            printer.emit_to_string();
+            suppress_move_from_last_use = true;
+            auto my_sym = print_to_string(n, true);
+            suppress_move_from_last_use = false;
 
-            //  Look in the capture group to see which capture # we are
-            auto mynum = 0;
-            for (auto const& cap : n.cap_grp->members) {
-                if (cap.str == my_str) {
-                    break;
-                }
-                ++mynum;
-            }
-            assert (mynum < std::ssize(n.cap_grp->members) && "could not find this postfix-expression in capture group");
-            //  And then emit that capture number
-            captured_part += "_" + std::to_string(mynum);
+            auto found = std::find_if(n.cap_grp->members.cbegin(), n.cap_grp->members.cend(), [my_sym](auto& cap) {
+                return cap.str_suppressed_move == my_sym;
+            });
+
+            assert (found != n.cap_grp->members.cend() && "could not find this postfix-expression in capture group");
+            //  And then emit that capture symbol with number
+            assert (!found->cap_sym.empty());
+            captured_part += found->cap_sym;
         }
 
         //  Otherwise, we're going to have to potentially do some work to change

--- a/source/parse.h
+++ b/source/parse.h
@@ -353,7 +353,9 @@ struct expression_statement_node
 
 struct capture {
     postfix_expression_node* capture_expr;
+    std::string              cap_sym = {};
     std::string              str = {};
+    std::string              str_suppressed_move = {};
     auto operator==(postfix_expression_node* p) { return capture_expr == p; }
 };
 


### PR DESCRIPTION
In the current implementation, when the move from the last use happens to a variable captured, it will be captured twice: one by copy and one moved.

That means that the following code:

```cpp
#include "boost/ut.hpp"
#include "html/html.h2"

using namespace boost::ut;
using namespace std::literals;

main: () -> int = {
    test("html::element") = :() = {
        e: html::element = ("tag");

        should("setting attribute") = :() = {
            mut(e$).set_attribute("name", "value");
            expect(eq(to_string(e$), std::string_view("<tag name=\"value\"></tag>")));
        };
    };
}
```
Will generate (skipping boilerplate):
```cpp
[[nodiscard]] auto main() -> int{
    test("html::element") = [](){
        html::element e {"tag"}; 

        should("setting attribute") = [_0 = e, _1 = std::move(e)](){
            CPP2_UFCS(set_attribute, mut(_0), "name", "value");
            expect(eq(to_string(_1), std::string_view("<tag name=\"value\"></tag>")));
        };
    };
}
```
This change makes cppfront identify that variable is moved, capture it once by the move, and use it multiple times. That means that the above code will generate the following:
```cpp
[[nodiscard]] auto main() -> int{
    test("html::element") = [](){
        html::element e {"tag"}; 

        should("setting attribute") = [_0 = std::move(e)](){
            CPP2_UFCS(set_attribute, mut(_0), "name", "value");
            expect(eq(to_string(_0), std::string_view("<tag name=\"value\"></tag>")));
        };
    };
}
```