### PR TITLE
Fix duplicate symbol of cpp2::args() function

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1419,7 +1419,7 @@ inline auto to_string(std::tuple<Ts...> const& t) -> std::string
 //
 //-----------------------------------------------------------------------
 //
-auto args(int argc, char **argv) -> std::vector<std::string_view> {
+inline auto args(int argc, char **argv) -> std::vector<std::string_view> {
     auto ret = std::vector<std::string_view>{(size_t)argc};
     for (auto i = 0; i < argc; ++i) {
         ret[i] = std::string_view{argv[i]};


### PR DESCRIPTION
When linking multiple cpp2 files `cpp2::args(int, char**)` symbol appears multiple times causing the followint error message:
```
[build] duplicate symbol 'cpp2::args(int, char**)' in:
[build]     libs/execspec/CMakeFiles/libexecspec.dir/src/application.cpp.o
[build]     libs/execspec/CMakeFiles/libexecspec.dir/src/compile_cpp2.cpp.o
```

This change makes `cpp2::args(int, char**)` an inline function.