### PR TITLE
Fix string literal parsing when \\ is on the end, closes #301

### DIFF
--- a/source/lex.h
+++ b/source/lex.h
@@ -380,7 +380,7 @@ auto expand_string_literal(
     //  Now we're on the first character of the string itself
     for (
         ;
-        pos < length && (text[pos] != '"' || text[pos-1] == '\\');
+        pos < length && (text[pos] != '"' || (text[pos-1] == '\\' && pos>=2 && text[pos-2] != '\\'));
         ++pos
         )
     {


### PR DESCRIPTION
The issue is that when there is '\\' on the end of the string `expand_string_literal()` function goes out of string range because for loop has a check
```cpp
pos < length && (text[pos] != '"' || text[pos-1] == '\\')
```
that is true when '\\' is before last '"' character that cause loop to go beyond it and cause assertion to fail.

The current change adds a check if the '\' character before last '"' is not escaped by the former '\' character.

Closes #301 - all regression tests pass