### PR TITLE
Fix removing parentheses when using deducing assignement, closes #327

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -2852,7 +2852,9 @@ private:
             //      || curr().type() == lexeme::LeftBrace
             )
         {
-            bool inside_initializer = (peek(-1)->type() == lexeme::Assignment);
+            bool inside_initializer = ( 
+                peek(-1) && peek(-1)->type() == lexeme::Assignment
+            );
             auto open_paren = &curr();
             auto close = close_paren_type(open_paren->type());
             auto close_text = [&] () -> std::string { if (close == lexeme::RightParen) { return ")"; } return "}"; }();
@@ -2870,6 +2872,9 @@ private:
             }
             expr_list->close_paren = &curr();
             next();
+            if (curr().type() != lexeme::Semicolon) {
+                expr_list->inside_initializer = false;
+            } 
             n->expr = std::move(expr_list);
             return n;
         }


### PR DESCRIPTION
The issue is caused by `emit(expression_list_node)` that skips parentheses when a node is inside the initializer - that serves cases like:
```cpp
v : std::vector<int> = (1,2,3);
```
Where it generates:
```cpp
std::vector<int> v{1,2,3};
```

When `:=` is used in the following cases:
```cpp
d := (1 + 2) * (3 + 4) * (5 + 6);
```
It removes the first parentheses, and we end up with the following:
```cpp
auto d = {1 + 2 * (3 + 4) * ( 5 + 6)};
```

This change corrects this behavior on the parsing side. After parsing
the expression list it checks if the next lexeme is Semicolon. If it is it
means that we are on the initializer of the form:
```cpp
d1 := ((2 + 1) * (4 - 1) * (8 - 3));
d3 := (move d2);
v : std::vector<int> = ();
```
And we can suppress printing of parentheses - as there will be braces:
```cpp
auto d1 {(2 + 1) * (4 - 1) * (8 - 3)};
auto d3 {std::move(d2)};
std::vector<int> v {};
```

When the next lexeme is not `Semicolon` it means that we are in an initializer
of the form:
```cpp
d2 := (2 + 1) * (4 - 1) * (8 - 3);
d4 : _ = (1 + 2) * (3 + 4) * (5 + 6);
d5 : int = (1 + 2) * (3 + 4) * (5 + 6);
```
And we need to keep all the parentheses, and it will be generated to:
```cpp
auto d2 {(2 + 1) * (4 - 1) * (8 - 3)};
auto d4 {(1 + 2) * (3 + 4) * (5 + 6)};
int d5 {(1 + 2) * (3 + 4) * (5 + 6)};
```

Closes #327. All regression tests pass.

There is only one difference in generated code in `pure2-ufcs-member-access-and-chaining.cpp2` test. The following line:
```cpp
    res := (42).ufcs();
```
Generates after this change:
```cpp
    auto res {CPP2_UFCS_0(ufcs, (42))}; // previously: auto res {CPP2_UFCS_0(ufcs, 42)}; 
```

This is correct behavior, as the parentheses are not required in this context so they should be left. I have checked the following code:
```cpp
    r1 := 42.ufcs();
    r2 := (42).ufcs();
```
That will generate after this change:
```cpp
    auto r1 {CPP2_UFCS_0(ufcs, 42)}; 
    auto r2 {CPP2_UFCS_0(ufcs, (42))}; 
```