### PR TITLE
Fix removing parens for in-place objects - quick fix of #331

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -2882,7 +2882,12 @@ private:
             }
             expr_list->close_paren = &curr();
             next();
-            if (curr().type() != lexeme::Semicolon) {
+            if (
+                   curr().type() != lexeme::Semicolon
+                && curr().type() != lexeme::RightParen 
+                && curr().type() != lexeme::RightBracket 
+                && curr().type() != lexeme::Comma
+            ) {
                 expr_list->inside_initializer = false;
             } 
             n->expr = std::move(expr_list);


### PR DESCRIPTION
That should cover cases:
```cpp
    f1(:std::vector=(1,2,3));
    f2(:std::vector=(1,2,3),:std::vector=(4,5));
    ar[:index=(1,2)];
    ar2[:index=(1,2), :index=(2,1)];
```
that will generate:
```cpp
    f1(std::vector{1, 2, 3});
    f2(std::vector{1, 2, 3}, std::vector{4, 5});
    cpp2::assert_in_bounds(ar, index{1, 2});
    cpp2::assert_in_bounds(ar2, index{1, 2}, index{2, 1});
```