### PR TITLE
Provide hint for `auto` declaration in Cpp2 code

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -5453,9 +5453,13 @@ private:
                 && *id->get_token() == "auto"
                 )
             {
+                auto name = std::string{"v"};
+                if (peek(0) && peek(0)->type() == lexeme::Identifier) {
+                    name = peek(0)->to_string(true);
+                }
                 errors.emplace_back(
                     curr().position(),
-                    "unknown declaration (use `name: type = initializer` instead?)"
+                    "to define a variable " + name + " of type T, write '" + name + ": T = /* initializer */'"
                 );
                 return {};
             }

--- a/source/parse.h
+++ b/source/parse.h
@@ -5450,6 +5450,17 @@ private:
             //
             if (
                 id->get_token()
+                && *id->get_token() == "auto"
+                )
+            {
+                errors.emplace_back(
+                    curr().position(),
+                    "unknown declaration (use `name: type = initializer` instead?)"
+                );
+                return {};
+            }
+            if (
+                id->get_token()
                 && *id->get_token() == "namespace"
                 )
             {


### PR DESCRIPTION
AFAIK, no Cpp2 declaration starts with an `auto` keyword, so forbid it.
Like the hints for `namespace`/`class` keywords.

Without this:
```c++
f: () = {
    ...
    auto x = 1; // causes ill-formed initializer error but line is first line of `f`, not this line
    auto [x,y] = (1,2); // passes cppfront but errors in C++1
}
```
With this, both `auto` declarations are caught with correct line numbers:
```
test.cpp2(8,10): error: unknown declaration (use `name: type = initializer` instead?)
test.cpp2(9,10): error: unknown declaration (use `name: type = initializer` instead?)
```
BTW I have emailed Herb requesting a CLA form.