### PR TITLE
Add diagnostics for using auto as a type of variable and as function return type

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -4894,6 +4894,21 @@ private:
                 }
             }
             else if (auto t = type_id()) {
+                if (
+                    t->get_token()
+                    && t->get_token()->to_string(true) == "auto"
+                    )
+                {
+                    auto name = std::string{"v"};
+                    if (my_decl && my_decl->name()) {
+                        name = my_decl->name()->to_string(true);
+                    }
+                    errors.emplace_back(
+                        curr().position(),
+                        "to define a function " + name + " with deduced return type, write '" + name + ": ( /* arguments */ ) -> _ = { /* function body */ }'"
+                    );
+                    return {};
+                }
                 n->returns = function_type_node::single_type_id{ std::move(t), passing_style::move };
                 assert(n->returns.index() == function_type_node::id);
             }

--- a/source/parse.h
+++ b/source/parse.h
@@ -5128,6 +5128,22 @@ private:
 
         //  Or just a type-id, declaring a non-pointer object
         else if (auto t = type_id()) {
+            if (
+                t->get_token()
+                && t->get_token()->to_string(true) == "auto"
+                )
+            {
+                auto name = std::string{"v"};
+                if (n->name()) {
+                    name = n->name()->to_string(true);
+                }
+                errors.emplace_back(
+                    curr().position(),
+                    "to define a variable " + name + " with deduced type, write '" + name + " := /* initializer */;'"
+                );
+                return {};
+            }
+
             n->type = std::move(t);
             assert (n->is_object());
 


### PR DESCRIPTION
While parsing the following code:
```cpp
f: () -> auto = 42;
```
Rise an error with the following diagnostics:
```
error: to define a function f with deduced return type, write 'f : ( /* arguments / ) -> _ = { / function body */ }'
```

While parsing the following code:
```cpp
i : auto = 42;
```
Rise an error with the following diagnostics:
```
error: to define a variable i with deduced type, write 'i := /* initializer */;'
```

All regression tests pass. Continuation of #342 (increasing QoI)