### PR TITLE
Modify the scope_depth for variables in lambdas

### DIFF
--- a/source/sema.h
+++ b/source/sema.h
@@ -971,7 +971,9 @@ public:
             || n.pass == passing_style::forward
             )
         {
-            symbols.emplace_back( scope_depth, declaration_sym( true, n.declaration.get(), n.declaration->name(), n.declaration->initializer.get(), &n));
+            // Handle variables in unnamed functions. For such cases scope_depth is increased by +1
+            auto depth = scope_depth + ((n.declaration->parent_is_function() && n.declaration->parent_declaration->name() == nullptr) ? 1 : 0 );
+            symbols.emplace_back( depth, declaration_sym( true, n.declaration.get(), n.declaration->name(), n.declaration->initializer.get(), &n));
         }
     }
 


### PR DESCRIPTION
If a variable parent is a function without the name, the `scope_depth` is increased by `1`. Refrain from being mixed with variables from the scope where lambda was created.

After this change, the following code:
```cpp
f_inout: (inout x) -> _ = {
    x *= 2;
    return x;
}

main: () -> int = {
    x := 21;

    l1 := :(forward x) = {
        std::cout << f_inout(forward x) << std::endl;
    };

    l1(x);

    x++;
}
```
Will generate (skipping boilerplate):
```cpp
[[nodiscard]] auto f_inout(auto& x) -> auto{
    x *= 2;
    return x; 
}

[[nodiscard]] auto main() -> int{
    auto x {21}; 

    auto l1 {[](auto&& x) -> void{
        std::cout << f_inout(CPP2_FORWARD(x)) << std::endl;
    }}; 

    std::move(l1)(x);

    ++x;
}
```

Closes #295. All regression tests pass.