### PR TITLE
Fix unpublished comments ICE error

### DIFF
--- a/regression-tests/test-results/pure2-types-basics.cpp
+++ b/regression-tests/test-results/pure2-types-basics.cpp
@@ -14,7 +14,6 @@ class myclass;
 
 #line 60 "pure2-types-basics.cpp2"
 }
-
 //=== Cpp2 type definitions and function declarations ===========================
 
 

--- a/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
+++ b/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
@@ -26,7 +26,6 @@ template<typename T, typename U> class A;
 }
 
 }
-
 //=== Cpp2 type definitions and function declarations ===========================
 
 

--- a/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
+++ b/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
@@ -69,8 +69,8 @@ namespace M {
 template<typename T, typename U> class A {
     public: template<int I> class B {
         public: template<typename V, int J, typename W> static auto f(W const& w) -> void;
-public: B() = default; B(B const&) = delete; auto operator=(B const&) -> void = delete; };
-public: A() = default; A(A const&) = delete; auto operator=(A const&) -> void = delete; };
+public: B() = default; B(B const&) = delete; auto operator=(B const&) -> void = delete; };public: A() = default; A(A const&) = delete; auto operator=(A const&) -> void = delete; 
+};
 
 }
 

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -5003,7 +5003,7 @@ public:
                     );
                 }
 
-                printer.print_cpp2("};\n", compound_stmt->close_brace);
+                printer.print_cpp2("};", compound_stmt->close_brace);
             }
         }
 

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -5044,7 +5044,7 @@ public:
                 emit(*decl);
             }
 
-            printer.print_cpp2("}\n", compound_stmt->close_brace);
+            printer.print_cpp2("}", compound_stmt->close_brace);
         }
 
         //  Function


### PR DESCRIPTION
In the current implementation of cppfront (f83ca9b727e9c07f60a1933584a49a3d971936f5), the following code:
```cpp
a: type = { } // a
i : int = 42;
```
or
```cpp
a: namespace = { } // a
i : int = 42;
```
End with ICE `not all comments were printed` error.

This change removes extra new-line printed after namespace or UDT definition that solves this issue.

All regression tests pass (except for two files impacted by missing newlines - updated in this PR).