### PR TITLE
Correction for short function syntax, closes #356

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -3015,6 +3015,17 @@ private:
                     next();
                     return {};
                 }
+                if (
+                    peek(-1) && peek(-1)->type() != lexeme::RightBrace  // it is short function syntax
+                    && curr().type() != lexeme::LeftParen               // not imediatelly called
+                    && curr().type() != lexeme::RightParen              // not as a last argument to function
+                    && curr().type() != lexeme::Comma                   // not as first or in-the-middle, function argument
+                ) {
+                    // this is a fix for a short function syntax that should have double semicolon used
+                    // (check comment in expression_statement(bool semicolon_required))
+                    // We simulate double semicolon by moving back to single semicolon.
+                    next(-1);
+                }
             }
             else {
                 error("(temporary alpha limitation) an unnamed declaration at expression scope must be a function or an object");


### PR DESCRIPTION
The current implementation does not work for the following code:
```cpp
main: () = {
    :() = 1;
    [[assert: 1]]
}
```
It fails with the error:
```
error: subscript expression [ ] must not be empty (if you were trying to name a C-style array type, use 'std::array' instead) (at '[')
```

This change introduces a minor correction that moves back parsing to a semicolon (to simulate a double semicolon) for short syntax.

It is not done in the following cases:
```cpp
:() = 1;(); // immediately called lambda
f(a,b,:() = 1;); // last argument in function call
f(a,:() = 1;,c); // first or in the middle argument
```

After this change, the original issue is solved.
All regression tests pass. Closes #356