### PR TITLE
Add diagnostics for type alias to a wildcard, closes #357

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -5617,6 +5617,16 @@ private:
                 );
                 return {};
             }
+            if (
+                t->is_wildcard() 
+                || ( t->get_token() && t->get_token()->to_string(true) == "auto" )
+            ) {
+                errors.emplace_back(
+                    curr().position(),
+                    "a 'type ==' alias declaration must be followed by a type name (not a wildcard _ nor auto)"
+                );
+                return {};
+            }
             a->initializer = std::move(t);
         }
 


### PR DESCRIPTION
In the current implementation of cppfront (f83ca9), the following code:
```cpp
alias5: type == _;
alias6: type == auto;
```
Generates succesfuly:
```cpp
using alias5 = auto;
using alias6 = auto;
```
Which is an invalid cpp1 code.

After this change, the alias to wildcard will generate the following error:
```
error: a 'type ==' alias declaration must be followed by a type name (not a wildcard _ nor auto)
```

All regression tests pass. Closes #357