### PR TITLE
Add diagnostics for bad semicolons errors, closes #352

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -4485,6 +4485,11 @@ private:
                 n->for_with_in = true;
             }
 
+            if (!done() && curr().type() == lexeme::Semicolon) {
+                error("a loop body may not be followed by a semicolon (empty statements are not allowed)");
+                return {};
+            }
+
             return n;
         }
 

--- a/source/parse.h
+++ b/source/parse.h
@@ -5690,6 +5690,21 @@ private:
             return {};
         }
 
+        if (
+            n->is_function()
+            && n->initializer
+            && !done() && curr().type() == lexeme::Semicolon
+            )
+        {
+            if (n->initializer->is_compound() && n->has_name()) {
+                error("a braced function body may not be followed by a semicolon (empty statements are not allowed)");
+                return {};
+            } else if (n->initializer->is_expression()) {
+                error("a single-expression function should end with a single semicolon");
+                return {};
+            }
+        }
+
         //  If this is an implicit constructor, it must have two parameters
         if (n->is_constructor())
         {

--- a/source/parse.h
+++ b/source/parse.h
@@ -4722,6 +4722,11 @@ private:
     )
         -> std::unique_ptr<statement_node>
     {
+        if (!done() && curr().type() == lexeme::Semicolon) {
+            error("empty statement is not allowed - remove extra semicolon");
+            return {};
+        }
+
         auto n = std::make_unique<statement_node>();
 
         //  Now handle the rest of the statement

--- a/source/parse.h
+++ b/source/parse.h
@@ -4423,6 +4423,10 @@ private:
             if (!handle_logical_expression  ()) { return {}; }
             if (!handle_optional_next_clause()) { return {}; }
             if (!handle_compound_statement  ()) { return {}; }
+            if (!done() && curr().type() == lexeme::Semicolon) {
+                error("a loop body may not be followed by a semicolon (empty statements are not allowed)");
+                return {};
+            }
             return n;
         }
 

--- a/source/parse.h
+++ b/source/parse.h
@@ -3068,15 +3068,15 @@ private:
         -> void
     {
         auto m = std::string{msg};
+        auto i = done() ? -1 : 0;
+        assert (peek(i));
         if (include_curr_token) {
-            m += std::string(" (at '") + curr().to_string(true) + "')";
+            m += std::string(" (at '") + peek(i)->to_string(true) + "')";
         }
         if (
             err_pos == source_position{}
-            && peek(0)
-            )
-        {
-            err_pos = peek(0)->position();
+        ) {
+            err_pos = peek(i)->position();
         }
         errors.emplace_back( err_pos, m, false, fallback );
     }
@@ -5093,7 +5093,8 @@ private:
 
         //  If there's no [ [ then this isn't a contract
         if (
-            curr().type() != lexeme::LeftBracket
+            done()
+            || curr().type() != lexeme::LeftBracket
             || !peek(1)
             || peek(1)->type() != lexeme::LeftBracket
             )

--- a/source/parse.h
+++ b/source/parse.h
@@ -3225,6 +3225,12 @@ private:
                     next();
                     return {};
                 }
+                if ( // check if a single-expression function is followed by an extra second semicolon
+                    decl->initializer && decl->initializer->is_expression()
+                    && !done() && curr().type() == lexeme::Semicolon
+                ) {
+                    error("a single-expression function should end with a single semicolon");
+                }
                 if (!(*func)->contracts.empty()) {
                     error("an unnamed function at expression scope currently cannot have contracts");
                     next();


### PR DESCRIPTION
The current cppfront (f83ca9) implementation provides unclear error messages - it is hard to find what causes the error.

This change introduces diagnostics for:
```cpp
f: () = {}; // error: a compound function body shall not end with a semicolon (at ';')
g: () -> int = 42;; // error: a short function syntax shall end with a single semicolon (at ';')

for v* | all next log() do :(e) = {
  foo();
  bar*;
}; // error: for..do loop body shall not end with a semicolon (at ';')

i := 0;
while i* < container.size() next i++ {
  std::cout << container[i] << std::endl;
}; // error: while loop body shall not end with a semicolon (at ';')

l2 := :() -> int = 24;; // error: a short function syntax shall end with a single semicolon (at ';')

; // error: empty statement is not allowed - remove extra semicolon (at ';')

i := 0;; // error: empty statement is not allowed - remove extra semicolon (at ';')
```

All regression tests pass. Closes #352 