### PR TITLE
Fix showing qualifier in missing return type error

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -4890,7 +4890,7 @@ private:
                 else {
                     auto msg = std::string("'");
                     msg += to_string_view(pass);
-                    error( + "'' must be followed by a type-id");
+                    error(msg + "' must be followed by a type-id");
                 }
             }
             else if (auto t = type_id()) {


### PR DESCRIPTION
Triggered by:
```cpp
f: (inout x: int) -> forward = x;
```
Currently:
```
retfwd.cpp2(1,24): error: ''' must be followed by a type-id (at '=')
```
Note: Not sure why unary `+""` is a valid expression in Cpp1 (or Cpp2).