### PR TITLE
Add diagnostics for returning a temporary, closes #381

### DIFF
--- a/regression-tests/pure2-forward-return-diagnostics-error.cpp2
+++ b/regression-tests/pure2-forward-return-diagnostics-error.cpp2
@@ -1,0 +1,53 @@
+fun1:  () -> forward _ = { return global   / 1; } // error: a 'forward' return type cannot return a temporary variable
+fun4:  () -> forward _ = { return global  << 1; } // error: a 'forward' return type cannot return a temporary variable
+fun5:  () -> forward _ = { return global <=> 1; } // error: a 'forward' return type cannot return a temporary variable
+fun6:  () -> forward _ = { return global   < 1; } // error: a 'forward' return type cannot return a temporary variable
+fun7:  () -> forward _ = { return global  <= 1; } // error: a 'forward' return type cannot return a temporary variable
+fun9:  () -> forward _ = { return global  >> 1; } // error: a 'forward' return type cannot return a temporary variable
+fun10: () -> forward _ = { return global  >= 1; } // error: a 'forward' return type cannot return a temporary variable
+fun11: () -> forward _ = { return global   > 1; } // error: a 'forward' return type cannot return a temporary variable
+fun14: () -> forward _ = { return global   + 1; } // error: a 'forward' return type cannot return a temporary variable
+fun15: () -> forward _ = { return global   - 1; } // error: a 'forward' return type cannot return a temporary variable
+fun20: () -> forward _ = { return global  || 1; } // error: a 'forward' return type cannot return a temporary variable
+fun22: () -> forward _ = { return global   | 1; } // error: a 'forward' return type cannot return a temporary variable
+fun24: () -> forward _ = { return global  && 1; } // error: a 'forward' return type cannot return a temporary variable
+fun26: () -> forward _ = { return global   * 1; } // error: a 'forward' return type cannot return a temporary variable
+fun28: () -> forward _ = { return global   % 1; } // error: a 'forward' return type cannot return a temporary variable
+fun30: () -> forward _ = { return global   & 1; } // error: a 'forward' return type cannot return a temporary variable
+fun32: () -> forward _ = { return global   ^ 1; } // error: a 'forward' return type cannot return a temporary variable
+fun35: () -> forward _ = { return global  == 1; } // error: a 'forward' return type cannot return a temporary variable
+fun37: () -> forward _ = { return global  != 1; } // error: a 'forward' return type cannot return a temporary variable
+fun38: () -> forward _ = { return !ptr_g;       } // error: a 'forward' return type cannot return a temporary variable
+fun42: () -> forward _ = { return global&;      } // error: a 'forward' return type cannot return a temporary variable
+fun43: () -> forward _ = { return ptr_g~;       } // error: a 'forward' return type cannot return a temporary variable
+
+fun2:  () -> forward _ = { return global  /= 1; }
+fun3:  () -> forward _ = { return global <<= 1; }
+fun8:  () -> forward _ = { return global >>= 1; }
+fun12: () -> forward _ = { return global++;     }
+fun13: () -> forward _ = { return global  += 1; }
+fun16: () -> forward _ = { return global  -= 1; }
+fun17: () -> forward _ = { return ptr_g*.x;     }
+fun18: () -> forward _ = { return global--;     }
+fun21: () -> forward _ = { return global  |= 1; }
+fun25: () -> forward _ = { return global  *= 1; }
+fun27: () -> forward _ = { return global  %= 1; }
+fun29: () -> forward _ = { return global  &= 1; }
+fun31: () -> forward _ = { return global  ^= 1; }
+fun36: () -> forward _ = { return global   = 1; }
+fun39: () -> forward _ = { return g.x;          }
+fun41: () -> forward _ = { return ptr_g*;       }
+
+// fun19: () -> forward _ = { return global ||= 1;       } // not supported
+// fun23: () -> forward _ = { return global &&= 1;       } // not supported
+// fun33: () -> forward _ = { return global  ~= 1;       } // not supported
+// fun34: () -> forward _ = { return global   ~ 1;       } // not supported
+// fun40: () -> forward _ = { return ptr_g ? ptr_g* : g; } // not supported
+
+global: i32 = 42;
+t: type = {
+    public x : int = 42;
+}
+
+g: t = ();
+ptr_g: *t = g&;

--- a/regression-tests/test-results/pure2-forward-return-diagnostics-error.cpp2.output
+++ b/regression-tests/test-results/pure2-forward-return-diagnostics-error.cpp2.output
@@ -1,0 +1,24 @@
+pure2-forward-return-diagnostics-error.cpp2...
+pure2-forward-return-diagnostics-error.cpp2(1,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(2,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(3,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(4,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(5,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(6,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(7,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(8,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(9,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(10,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(11,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(12,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(13,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(14,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(15,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(16,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(17,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(18,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(19,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(20,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(21,28): error: a 'forward' return type cannot return a temporary variable
+pure2-forward-return-diagnostics-error.cpp2(22,28): error: a 'forward' return type cannot return a temporary variable
+

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -2206,6 +2206,15 @@ public:
                         "a 'forward' return type cannot return a local variable"
                     );
                     return;
+                } else if (
+                    is_literal(tok->type()) || n.expression->expr->is_result_a_temporary_variable()
+                ) 
+                {
+                    errors.emplace_back(
+                        n.position(),
+                        "a 'forward' return type cannot return a temporary variable"
+                    );
+                    return;
                 }
             }
 


### PR DESCRIPTION
The current implementation of cppfront (65fcd0f7cd7ccf07c4493d4f133505e3bab0b4fe) does not provide diagnostics for forward return temporary variables, e.g.:

```cpp
forward_return_literal: () -> forward _ = {
    return 1;
}

forward_return_rvalue: () -> forward _ = {
    return global + 1;
}
```
Generates:
```cpp
cpp2::i32 global {42}; 

[[nodiscard]] auto forward_return_literal() -> auto&&{
    return 1; // return reference to literal
}

[[nodiscard]] auto forward_return_rvalue() -> auto&&{
    return global + 1; // return reference to temporary variable
}
```

This change provides better diagnostics and handles most operators that might create a temporary variable:
* binary expression: `/`, `<<`, `<=>`, `<`, `<=`, `>>`, `>=`, `>`, `+`, `-`, `||`, `|`, `&&`, `*`, `%`, `&`, `^`, `==`, `!=`,
* prefix expression: `!`,
* postfix expression: `&`, `~`

All other operators that return references are accepted. 

All regression tests pass. Closes #381 

### Need to be checked

The below cases still might not be supported:

* using operators that return a reference on local variables,
* calling function that returns a non-reference,