### PR TITLE
FIX: Remove next() on backtrack, fixes #404

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -5523,7 +5523,6 @@ private:
             else {
                 error("invalid parameter list", true, {}, true);
             }
-            next();
             return {};
         }
 


### PR DESCRIPTION
When trying to parse expressions like:
```cpp
(:() = 0) as t;
```

`parameter_declaration_list()` fail to succeed, which is expected but skips one symbol ('(') on returning, which makes the parser fail to process the expression successfully.

After this change above expression is parsed correctly. All regression tests pass.

Fixes #404