### PR TITLE
Update otdated regression test results

### DIFF
--- a/regression-tests/test-results/pure2-types-smf-and-that-1-provide-everything.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-1-provide-everything.cpp
@@ -21,9 +21,7 @@ class myclass {
         
 
 #line 8 "pure2-types-smf-and-that-1-provide-everything.cpp2"
-    public: myclass(myclass&& that) noexcept
-#line 8 "pure2-types-smf-and-that-1-provide-everything.cpp2"
-    ;
+    public: myclass(myclass&& that) noexcept;
         
 
 #line 13 "pure2-types-smf-and-that-1-provide-everything.cpp2"
@@ -31,9 +29,7 @@ class myclass {
         
 
 #line 18 "pure2-types-smf-and-that-1-provide-everything.cpp2"
-    public: auto operator=(myclass&& that) noexcept
-#line 18 "pure2-types-smf-and-that-1-provide-everything.cpp2"
-     -> myclass& ;
+    public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
 #line 22 "pure2-types-smf-and-that-1-provide-everything.cpp2"
@@ -72,8 +68,6 @@ auto main() -> int;
     }
 
     myclass::myclass(myclass&& that) noexcept
-#line 8 "pure2-types-smf-and-that-1-provide-everything.cpp2"
-    
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }
 #line 8 "pure2-types-smf-and-that-1-provide-everything.cpp2"
@@ -92,9 +86,7 @@ auto main() -> int;
 #line 16 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     }
 
-    auto myclass::operator=(myclass&& that) noexcept
-#line 18 "pure2-types-smf-and-that-1-provide-everything.cpp2"
-     -> myclass& {
+    auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
 #line 19 "pure2-types-smf-and-that-1-provide-everything.cpp2"

--- a/regression-tests/test-results/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp
@@ -21,18 +21,14 @@ class myclass {
         
 
 #line 8 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
-    public: myclass(myclass&& that) noexcept
-#line 8 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
-    ;
+    public: myclass(myclass&& that) noexcept;
         
 
 #line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     public: auto operator=(myclass const& that) -> myclass& ;
         
 #line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
-    public: auto operator=(myclass&& that) noexcept
-#line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
-                -> myclass& ;
+    public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
 #line 18 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
@@ -75,8 +71,6 @@ auto main() -> int;
     }
 
     myclass::myclass(myclass&& that) noexcept
-#line 8 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
-    
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }
 #line 8 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
@@ -95,9 +89,7 @@ auto main() -> int;
 #line 16 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     }
 #line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
-    auto myclass::operator=(myclass&& that) noexcept
-#line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
-                -> myclass&        {
+    auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr + "(AC)";
 

--- a/regression-tests/test-results/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp
@@ -24,9 +24,7 @@ class myclass {
         
 
 #line 8 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
-    public: myclass(myclass&& that) noexcept
-#line 8 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
-    ;
+    public: myclass(myclass&& that) noexcept;
         
 
 #line 13 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
@@ -35,9 +33,7 @@ class myclass {
     //     std::cout << "assign - copy        ";
     // }
 
-    public: auto operator=(myclass&& that) noexcept
-#line 18 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
-     -> myclass& ;
+    public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
 #line 22 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
@@ -85,8 +81,6 @@ auto main() -> int;
     }
 
     myclass::myclass(myclass&& that) noexcept
-#line 8 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
-    
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }
 #line 8 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
@@ -96,9 +90,7 @@ auto main() -> int;
     }
 
 #line 18 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
-    auto myclass::operator=(myclass&& that) noexcept
-#line 18 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
-     -> myclass& {
+    auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
 #line 19 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"

--- a/regression-tests/test-results/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp
@@ -20,9 +20,7 @@ class myclass {
     public: myclass(myclass const& that);
         
 #line 4 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
-    public: myclass(myclass&& that) noexcept
-#line 4 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
-    ;
+    public: myclass(myclass&& that) noexcept;
         
 
 #line 8 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
@@ -35,9 +33,7 @@ class myclass {
         
 
 #line 18 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
-    public: auto operator=(myclass&& that) noexcept
-#line 18 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
-     -> myclass& ;
+    public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
 #line 22 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
@@ -76,8 +72,6 @@ auto main() -> int;
     }
 #line 4 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     myclass::myclass(myclass&& that) noexcept
-#line 4 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
-    
         : name{ std::move(that).name }
         , addr{ std::move(that).addr }
 #line 4 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
@@ -96,9 +90,7 @@ auto main() -> int;
 #line 16 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     }
 
-    auto myclass::operator=(myclass&& that) noexcept
-#line 18 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
-     -> myclass& {
+    auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
 #line 19 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"

--- a/regression-tests/test-results/pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp
@@ -23,14 +23,10 @@ class myclass {
     public: auto operator=(myclass const& that) -> myclass& ;
         
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
-    public: myclass(myclass&& that) noexcept
-#line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
-    ;
+    public: myclass(myclass&& that) noexcept;
         
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
-    public: auto operator=(myclass&& that) noexcept
-#line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
-     -> myclass& ;
+    public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
 #line 8 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
@@ -92,8 +88,6 @@ auto main() -> int;
     }
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     myclass::myclass(myclass&& that) noexcept
-#line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
-    
         : name{ std::move(that).name }
         , addr{ std::move(that).addr }
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
@@ -101,9 +95,7 @@ auto main() -> int;
         std::cout << "ctor - copy (GENERAL)";
     }
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
-    auto myclass::operator=(myclass&& that) noexcept
-#line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
-     -> myclass& {
+    auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
 #line 5 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"

--- a/regression-tests/test-results/pure2-types-that-parameters.cpp
+++ b/regression-tests/test-results/pure2-types-that-parameters.cpp
@@ -26,14 +26,10 @@ class myclass {
         
 
 #line 11 "pure2-types-that-parameters.cpp2"
-    public: myclass(myclass&& that) noexcept
-#line 11 "pure2-types-that-parameters.cpp2"
-    ;
+    public: myclass(myclass&& that) noexcept;
         
 #line 11 "pure2-types-that-parameters.cpp2"
-    public: auto operator=(myclass&& that) noexcept
-#line 11 "pure2-types-that-parameters.cpp2"
-     -> myclass& ;
+    public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
 #line 16 "pure2-types-that-parameters.cpp2"
@@ -73,8 +69,6 @@ auto main() -> int;
     }
 
     myclass::myclass(myclass&& that) noexcept
-#line 11 "pure2-types-that-parameters.cpp2"
-    
         : name{ std::move(that).name }
         , addr{ std::move(that).addr }
 #line 11 "pure2-types-that-parameters.cpp2"
@@ -83,9 +77,7 @@ auto main() -> int;
 #line 14 "pure2-types-that-parameters.cpp2"
     }
 #line 11 "pure2-types-that-parameters.cpp2"
-    auto myclass::operator=(myclass&& that) noexcept
-#line 11 "pure2-types-that-parameters.cpp2"
-     -> myclass& {
+    auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
         return *this;


### PR DESCRIPTION
The 6 regression tests whose results are updated fail for g++-10 and clang-12 on Ubuntu.
It seems a commit that cleaned up the cpp1 output of cppfront failed to update those test results.