### PR TITLE
Add initial CI: Build steps for supported compilers

### DIFF
--- a/.github/workflows/build-cppfront.yaml
+++ b/.github/workflows/build-cppfront.yaml
@@ -1,0 +1,45 @@
+name: Multi-platform Build of cppfront
+on: push
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Compiler name & version
+        run: cl.exe
+      - name: Build
+        run: cl.exe source/cppfront.cpp -std:c++latest -MD -EHsc -experimental:module -W4
+  build-unix-like:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-latest]
+        compiler: [g++-10, g++-11, g++-12, clang++-12, clang++-14]
+        cxx-std: ['c++20', 'c++2b']
+        exclude:
+          # GCC 10 doesn't have support for c++23
+          - compiler: g++-10
+            cxx-std: 'c++2b'
+          # Clang 12 and 14 do not compile on 'c++2b' due to llvm/llvm-project#58206
+          - compiler: clang++-12
+            cxx-std: 'c++2b'
+          - compiler: clang++-14
+            cxx-std: 'c++2b'
+        include:
+          - runs-on: macos-latest
+            compiler: clang++
+            cxx-std: 'c++20'
+    runs-on: ${{ matrix.runs-on }}
+    env:
+      CXX: ${{ matrix.compiler }}
+      CXXFLAGS: -std=${{ matrix.cxx-std }} -Wall -Wextra -Wold-style-cast -pthread
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install compiler
+      if: startsWith(matrix.runs-on, 'ubuntu')
+      run: sudo apt-get install -y $CXX
+    - name: Compiler name & version
+      run: $CXX --version
+    - name: Build
+      run: $CXX source/cppfront.cpp $CXXFLAGS -o cppfront


### PR DESCRIPTION
This PR adds a initial Github Actions workflow to compile cppfront for several platforms, compilers and compiler versions.

Compilers tested: gcc 10, gcc 11, gcc 12, clang 12, clang 14, Apple's clang 14 and Microsoft's vs2022.

Benefits of adopting CI right now:
 * Ensures that all supported compilers are actually tested (for build right now, for regressions/passthrough later)
 * Provides information to possible adopters that their compiler and compiler version is supported.
 * Eases the burden of test-building in different platforms for developers and contributors.

If interested we could move onto automating regression testing and passthrough testing next.