### PR TITLE
Fix for operator recognition in cpp2 code sections.

### DIFF
--- a/source/io.h
+++ b/source/io.h
@@ -221,6 +221,10 @@ auto starts_with_operator(std::string_view s)
         break;case '/':
               case '=':
               case '!':
+              case '*':
+              case '%':
+              case '^':
+              case '~':
             if (c2 == '=') { return j+2; }
             return j+1;
 
@@ -239,7 +243,7 @@ auto starts_with_operator(std::string_view s)
         break;case '|':
               case '&':
             if (c2 == c1 && c3 == '=') { return j+3; }
-            if (c2 == c1) { return j+2; }
+            if (c2 == c1 || c2 == '=') { return j+2; }
             return j+1;
 
             //  >>= >> >= >


### PR DESCRIPTION
For the cpp2 file:
```
operator*: (v1: double, v2: double) -> _ = v1 * v2;
```
The cppfront command `cppfront opMul.cpp2 -p` produces the error: 
```
opMul.cpp2(1,1): error: pure-cpp2 switch disables Cpp1 syntax
```

I took this as an opportunity to get familiar with the code of cppfront. The switch in `starts_with_operator` had the comments for the operators but the cases statements where missing.

With the missing cases added, the test file works now with cppfront.

I also checked all operators against the list in https://en.cppreference.com/w/cpp/language/operators
1. Additional missing operators: `&=`, `|=`
2. Operators that are checked but not defined: `&&=`, `||=`
3. Other missing operators: `,`, `->*`, `()`, `[]`

I added the operators in point 1. Should I remove the operators under point 2? Should I add the operators under point 3?

On a side note: Thanks for working on cpp2 and providing it to the public!
