### PR TITLE
Fix handling of escaped backslashes in expanded string (#464)

### DIFF
--- a/source/lex.h
+++ b/source/lex.h
@@ -429,9 +429,9 @@ auto expand_string_literal(
             //  Then put interpolated chunk into ret
             auto chunk = std::string{text.substr(open, pos - open)};
             { // unescape chunk string
-                auto last_it = std::copy_if(std::begin(chunk), std::end(chunk), std::begin(chunk), [escape = false](const auto& e) mutable {
+                auto last_it = std::remove_if(std::begin(chunk), std::end(chunk), [escape = false](const auto& e) mutable {
                     escape = !escape && e == '\\';
-                    return !escape;
+                    return escape;
                 });
                 chunk.erase(last_it, std::end(chunk));
             }


### PR DESCRIPTION
The original fix uses the `std::copy_if` algorithm with overlapping input and output ranges - that behavior is undefined.
After reviewing it with @Maiqel and @lukasz-matysiak, we have replaced it with the `std::remove_if` algorithm - which simplifies code and better describes what is happening, and does not exercise undefined behavior.

From https://en.cppreference.com/w/cpp/algorithm/copy:

> The behavior is undefined if d_first is within the range [first, last)

All regression tests pass.