### PR TITLE
refactor: improve UFCS error messages

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -689,16 +689,13 @@ public:
     #define CPP2_FORCE_INLINE_LAMBDA __attribute__((always_inline))
 #endif
 
-#define CPP2_UFCS_ERROR_ID(X) X
-#define CPP2_UFCS_ERROR(FUNCNAME,PARAM1,COMMA,...) R"(
+#define CPP2_UFCS_REMPARENS(...) __VA_ARGS__
+#define CPP2_UFCS_REMPARENS_STR(...) #__VA_ARGS__
+#define CPP2_UFCS_ERROR(MEMBER_CALL,NONMEMBER_CALL) R"(
   UFCS candidates are invalid:
-    1) )" #PARAM1 "." CPP2_UFCS_ERROR_ID(FUNCNAME) "(" #__VA_ARGS__ R"()
-    2) )" CPP2_UFCS_ERROR_ID(FUNCNAME) "(" #PARAM1 COMMA #__VA_ARGS__ R"()
+    1) )" CPP2_UFCS_REMPARENS_STR MEMBER_CALL R"(
+    2) )" CPP2_UFCS_REMPARENS_STR NONMEMBER_CALL R"(
   Calling them unconditionally to have them diagnosed.)"
-#define CPP2_UFCS_ERROR_STR(...) #__VA_ARGS__
-#define CPP2_UFCS_ERROR_CAT(X, Y) #X CPP2_UFCS_ERROR_STR(Y)
-#define CPP2_UFCS_TEMPLATE_ERROR(FUNCNAME,TEMPARGS,PARAM1,COMMA,...) \
-    CPP2_UFCS_ERROR(CPP2_UFCS_ERROR_CAT(FUNCNAME, CPP2_UFCS_REMPARENS TEMPARGS), PARAM1, COMMA, __VA_ARGS__)
 
 //  Note: [&] is because a nested UFCS might be viewed as trying to capture 'this'
 
@@ -712,7 +709,7 @@ public:
         { \
             constexpr bool ufcs_invocable = std::is_void_v<CPP2_TYPEOF(obj)>; \
             static_assert(ufcs_invocable, \
-                CPP2_UFCS_ERROR(#FUNCNAME, PARAM1, ", ", __VA_ARGS__)); \
+                CPP2_UFCS_ERROR((PARAM1.FUNCNAME(__VA_ARGS__)), (FUNCNAME(PARAM1, __VA_ARGS__)))); \
         } \
         CPP2_FORWARD(obj).FUNCNAME(CPP2_FORWARD(params)...); \
         FUNCNAME(CPP2_FORWARD(obj), CPP2_FORWARD(params)...); \
@@ -729,14 +726,12 @@ public:
         { \
             constexpr bool ufcs_invocable = std::is_void_v<CPP2_TYPEOF(obj)>; \
             static_assert(ufcs_invocable, \
-                CPP2_UFCS_ERROR(#FUNCNAME, PARAM1, "")); \
+                CPP2_UFCS_ERROR((PARAM1.FUNCNAME()), (FUNCNAME(PARAM1)))); \
         } \
         CPP2_FORWARD(obj).FUNCNAME(); \
         FUNCNAME(CPP2_FORWARD(obj)); \
     } \
 }(PARAM1)
-
-#define CPP2_UFCS_REMPARENS(...) __VA_ARGS__
 
 #define CPP2_UFCS_TEMPLATE(FUNCNAME,TEMPARGS,PARAM1,...) \
 [&](auto&& obj, auto&& ...params) CPP2_FORCE_INLINE_LAMBDA -> decltype(auto) { \
@@ -748,7 +743,7 @@ public:
         { \
             constexpr bool ufcs_invocable = std::is_void_v<CPP2_TYPEOF(obj)>; \
             static_assert(ufcs_invocable, \
-                CPP2_UFCS_TEMPLATE_ERROR(FUNCNAME, TEMPARGS, PARAM1, ", ", __VA_ARGS__)); \
+                CPP2_UFCS_ERROR((PARAM1.template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS(__VA_ARGS__)), (FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS(PARAM1, __VA_ARGS__)))); \
         } \
         CPP2_FORWARD(obj).template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (CPP2_FORWARD(params)...); \
         FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (CPP2_FORWARD(obj), CPP2_FORWARD(params)...); \
@@ -765,7 +760,7 @@ public:
         { \
             constexpr bool ufcs_invocable = std::is_void_v<CPP2_TYPEOF(obj)>; \
             static_assert(ufcs_invocable, \
-                CPP2_UFCS_TEMPLATE_ERROR(FUNCNAME, TEMPARGS, PARAM1, "")); \
+                CPP2_UFCS_ERROR((PARAM1.template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS()), (FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS(PARAM1)))); \
         } \
         CPP2_FORWARD(obj).template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (); \
         FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (CPP2_FORWARD(obj)); \
@@ -785,7 +780,7 @@ public:
         { \
             constexpr bool ufcs_invocable = std::is_void_v<CPP2_TYPEOF(obj)>; \
             static_assert(ufcs_invocable, \
-                CPP2_UFCS_ERROR(#FUNCNAME, PARAM1, ", ", __VA_ARGS__)); \
+                CPP2_UFCS_ERROR((PARAM1.FUNCNAME(__VA_ARGS__)), (FUNCNAME(PARAM1, __VA_ARGS__)))); \
         } \
         CPP2_FORWARD(obj).FUNCNAME(CPP2_FORWARD(params)...); \
         FUNCNAME(CPP2_FORWARD(obj), CPP2_FORWARD(params)...); \
@@ -802,7 +797,7 @@ public:
         { \
             constexpr bool ufcs_invocable = std::is_void_v<CPP2_TYPEOF(obj)>; \
             static_assert(ufcs_invocable, \
-                CPP2_UFCS_ERROR(#FUNCNAME, PARAM1, "")); \
+                CPP2_UFCS_ERROR((PARAM1.FUNCNAME()), (FUNCNAME(PARAM1)))); \
         } \
         CPP2_FORWARD(obj).FUNCNAME(); \
         FUNCNAME(CPP2_FORWARD(obj)); \
@@ -819,7 +814,7 @@ public:
         { \
             constexpr bool ufcs_invocable = std::is_void_v<CPP2_TYPEOF(obj)>; \
             static_assert(ufcs_invocable, \
-                CPP2_UFCS_TEMPLATE_ERROR(FUNCNAME, TEMPARGS, PARAM1, ", ", __VA_ARGS__)); \
+                CPP2_UFCS_ERROR((PARAM1.template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS(__VA_ARGS__)), (FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS(PARAM1, __VA_ARGS__)))); \
         } \
         CPP2_FORWARD(obj).template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (CPP2_FORWARD(params)...); \
         FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (CPP2_FORWARD(obj), CPP2_FORWARD(params)...); \
@@ -836,7 +831,7 @@ public:
         { \
             constexpr bool ufcs_invocable = std::is_void_v<CPP2_TYPEOF(obj)>; \
             static_assert(ufcs_invocable, \
-                CPP2_UFCS_TEMPLATE_ERROR(FUNCNAME, TEMPARGS, PARAM1, "")); \
+                CPP2_UFCS_ERROR((PARAM1.template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS()), (FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS(PARAM1)))); \
         } \
         CPP2_FORWARD(obj).template FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (); \
         FUNCNAME CPP2_UFCS_REMPARENS TEMPARGS (CPP2_FORWARD(obj)); \

--- a/regression-tests/pure2-bugfix-for-better-ufcs-error-messages.cpp2
+++ b/regression-tests/pure2-bugfix-for-better-ufcs-error-messages.cpp2
@@ -1,0 +1,13 @@
+vi: std::vector<int> = ();
+main: () = {
+  vi.push_back("oops");
+  vi.push_back();
+  vi.push_back<0>("oops");
+  vi.push_back<0>();
+  vi.push_back<0, 0>(0, 0);
+}
+i0: i32 = vi.push_back("oops");
+i1: i32 = vi.push_back();
+i2: i32 = vi.push_back<0>("oops");
+i3: i32 = vi.push_back<0>();
+i4: i32 = vi.push_back<0, 0>(0, 0);

--- a/regression-tests/test-results/pure2-bugfix-for-better-ufcs-error-messages.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-better-ufcs-error-messages.cpp
@@ -1,0 +1,41 @@
+
+#define CPP2_USE_MODULES         Yes
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-bugfix-for-better-ufcs-error-messages.cpp2"
+extern std::vector<int> vi;
+auto main() -> int;
+  
+
+#line 9 "pure2-bugfix-for-better-ufcs-error-messages.cpp2"
+extern cpp2::i32 i0;
+extern cpp2::i32 i1;
+extern cpp2::i32 i2;
+extern cpp2::i32 i3;
+extern cpp2::i32 i4;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-bugfix-for-better-ufcs-error-messages.cpp2"
+std::vector<int> vi {}; 
+auto main() -> int{
+  CPP2_UFCS(push_back, vi, "oops");
+  CPP2_UFCS_0(push_back, vi);
+  CPP2_UFCS_TEMPLATE(push_back, (<0>), vi, "oops");
+  CPP2_UFCS_TEMPLATE_0(push_back, (<0>), vi);
+  CPP2_UFCS_TEMPLATE(push_back, (<0,0>), vi, 0, 0);
+}
+cpp2::i32 i0 {CPP2_UFCS_NONLOCAL(push_back, vi, "oops")}; 
+cpp2::i32 i1 {CPP2_UFCS_0_NONLOCAL(push_back, vi)}; 
+cpp2::i32 i2 {CPP2_UFCS_TEMPLATE_NONLOCAL(push_back, (<0>), vi, "oops")}; 
+cpp2::i32 i3 {CPP2_UFCS_TEMPLATE_0_NONLOCAL(push_back, (<0>), vi)}; 
+cpp2::i32 i4 {CPP2_UFCS_TEMPLATE_NONLOCAL(push_back, (<0,0>), vi, 0, 0)}; 
+

--- a/regression-tests/test-results/pure2-bugfix-for-better-ufcs-error-messages.cpp2.output
+++ b/regression-tests/test-results/pure2-bugfix-for-better-ufcs-error-messages.cpp2.output
@@ -1,0 +1,2 @@
+pure2-bugfix-for-better-ufcs-error-messages.cpp2... ok (all Cpp2, passes safety checks)
+


### PR DESCRIPTION
Resolves #439.

See it working at <https://compiler-explorer.com/z/7asaMGY9o>.

<details><summary>
Before and after
</summary>

<details><summary>
Clang before
</summary>

```output
build/_cppfront/main.cpp:185:13: error: use of undeclared identifier 'push_back'
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |             ^
build/_cppfront/main.cpp:185:3: note: in instantiation of function template specialization 'main()::(anonymous class)::operator()<std::vector<int> &, const char (&)[5]>' requested here
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |   ^
raw.githubusercontent.com/hsutter/cppfront/main/include/cpp2util.h:702:2: note: expanded from macro 'CPP2_UFCS'
  702 | }(PARAM1, __VA_ARGS__)
      |  ^
1 error generated.
```

</details>

<details><summary>
Clang after
</summary>

```output
build/_cppfront/main.cpp:185:3: error: static assertion failed due to requirement 'ufcs_invocable': 
  UFCS candidates are invalid:
    1) vi.push_back("oops")
    2) push_back(vi, "oops")
  Calling them unconditionally to have them diagnosed.
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
build/_cppfront/main.cpp:40:27: note: expanded from macro 'CPP2_UFCS'
   40 |             static_assert(ufcs_invocable, \
      |                           ^~~~~~~~~~~~~~
build/_cppfront/main.cpp:185:3: note: in instantiation of function template specialization 'main()::(anonymous class)::operator()<std::vector<int> &, const char (&)[5]>' requested here
build/_cppfront/main.cpp:46:2: note: expanded from macro 'CPP2_UFCS'
   46 | }(PARAM1, __VA_ARGS__)
      |  ^
build/_cppfront/main.cpp:185:13: error: no matching member function for call to 'push_back'
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |   ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
build/_cppfront/main.cpp:43:27: note: expanded from macro 'CPP2_UFCS'
   43 |         CPP2_FORWARD(obj).FUNCNAME(CPP2_FORWARD(params)...); \
      |         ~~~~~~~~~~~~~~~~~~^~~~~~~~
/opt/compiler-explorer/clang-trunk-20230602/bin/../include/c++/v1/vector:650:62: note: candidate function not viable: no known conversion from 'const char[5]' to 'const value_type' (aka 'const int') for 1st argument
  650 |     _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void push_back(const_reference __x);
      |                                                              ^
/opt/compiler-explorer/clang-trunk-20230602/bin/../include/c++/v1/vector:652:62: note: candidate function not viable: no known conversion from 'const char[5]' to 'value_type' (aka 'int') for 1st argument
  652 |     _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void push_back(value_type&& __x);
      |                                                              ^
build/_cppfront/main.cpp:185:13: error: use of undeclared identifier 'push_back'
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |             ^
3 errors generated.
```

</details>

<details><summary>
GCC before
</summary>

```output
In file included from /app/cpp2util.h:1,
                 from /app/build/_cppfront/main.cpp:3:
build/_cppfront/main.cpp: In instantiation of 'main()::<lambda(auto:85&&, auto:86&& ...)> [with auto:85 = std::vector<int>&; auto:86 = {const char (&)[5]}]':
build/_cppfront/main.cpp:185:3:   required from here
build/_cppfront/main.cpp:185:3: error: 'push_back' was not declared in this scope
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |   ^
```

</details>

<details><summary>
GCC after
</summary>

```output
build/_cppfront/main.cpp: In instantiation of 'main()::<lambda(auto:85&&, auto:86&& ...)> [with auto:85 = std::vector<int>&; auto:86 = {const char (&)[5]}]':
build/_cppfront/main.cpp:185:3:   required from here
build/_cppfront/main.cpp:40:27: error: static assertion failed: 
  UFCS candidates are invalid:
    1) vi.push_back("oops")
    2) push_back(vi, "oops")
  Calling them unconditionally to have them diagnosed.
   40 |             static_assert(ufcs_invocable, \
      |                           ^~~~~~~~~~~~~~
build/_cppfront/main.cpp:185:3: note: in expansion of macro 'CPP2_UFCS'
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |   ^~~~~~~~~
build/_cppfront/main.cpp:40:27: note: 'ufcs_invocable' evaluates to false
   40 |             static_assert(ufcs_invocable, \
      |                           ^~~~~~~~~~~~~~
build/_cppfront/main.cpp:185:3: note: in expansion of macro 'CPP2_UFCS'
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |   ^~~~~~~~~
build/_cppfront/main.cpp:43:35: error: no matching function for call to 'push_back(const char [5])'
   43 |         CPP2_FORWARD(obj).FUNCNAME(CPP2_FORWARD(params)...); \
      |                                   ^
build/_cppfront/main.cpp:185:3: note: in expansion of macro 'CPP2_UFCS'
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |   ^~~~~~~~~
In file included from /opt/compiler-explorer/gcc-trunk-20230602/include/c++/14.0.0/vector:66,
                 from /app/raw.githubusercontent.com/hsutter/cppfront/main/include/cpp2util.h:206,
                 from /app/cpp2util.h:1,
                 from /app/build/_cppfront/main.cpp:3:
/opt/compiler-explorer/gcc-trunk-20230602/include/c++/14.0.0/bits/stl_vector.h:1281:7: note: candidate: 'constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = int; _Alloc = std::allocator<int>; value_type = int]' (near match)
 1281 |       push_back(const value_type& __x)
      |       ^~~~~~~~~
/opt/compiler-explorer/gcc-trunk-20230602/include/c++/14.0.0/bits/stl_vector.h:1281:7: note:   conversion of argument 1 would be ill-formed:
/opt/compiler-explorer/gcc-trunk-20230602/include/c++/14.0.0/bits/stl_vector.h:1281:7: error: invalid conversion from 'const char*' to 'std::vector<int>::value_type' {aka 'int'} [-fpermissive]
 1281 |       push_back(const value_type& __x)
      |       ^~~~~~~~~
      |       |
      |       const char*
/opt/compiler-explorer/gcc-trunk-20230602/include/c++/14.0.0/bits/stl_vector.h:1298:7: note: candidate: 'constexpr void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = int; _Alloc = std::allocator<int>; value_type = int]' (near match)
 1298 |       push_back(value_type&& __x)
      |       ^~~~~~~~~
/opt/compiler-explorer/gcc-trunk-20230602/include/c++/14.0.0/bits/stl_vector.h:1298:7: note:   conversion of argument 1 would be ill-formed:
/opt/compiler-explorer/gcc-trunk-20230602/include/c++/14.0.0/bits/stl_vector.h:1298:7: error: invalid conversion from 'const char*' to 'std::vector<int>::value_type' {aka 'int'} [-fpermissive]
 1298 |       push_back(value_type&& __x)
      |       ^~~~~~~~~
      |       |
      |       const char*
build/_cppfront/main.cpp:44:17: error: 'push_back' was not declared in this scope
   44 |         FUNCNAME(CPP2_FORWARD(obj), CPP2_FORWARD(params)...); \
      |                 ^
build/_cppfront/main.cpp:185:3: note: in expansion of macro 'CPP2_UFCS'
  185 |   CPP2_UFCS(push_back, vi, "oops");
      |   ^~~~~~~~~
```

</details>

</details>

<a id="test"/>
<details><summary>
<a href="#test">T</a>esting summary.
</summary>

```output
99% tests passed, 1 tests failed out of 253

Total Test time (real) = 114.06 sec

The following tests FAILED:
  122 - build/pure2-bugfix-for-better-ufcs-error-messages (Failed)
Errors while running CTest
```

</details>

<a id="ack"/>
<details><summary>
<a href="#ack">A</a>cknowledgements.
</summary>

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- The commit message uses [Conventional Commits][] 1.0.0.

</details>

[Conventional Commits]: https://www.conventionalcommits.org/
