### PR TITLE
fix(cpp1): contract check invalid alternative

### DIFF
--- a/regression-tests/pure2-bugfix-for-runtime-invalid-alternative.cpp2
+++ b/regression-tests/pure2-bugfix-for-runtime-invalid-alternative.cpp2
@@ -1,0 +1,7 @@
+f: (x) = {
+  [[assert: inspect x -> i32 {
+    is 1 = :() -> bool = 2;("");
+    is _               = 1;
+  } == 1]]
+}
+main: () = f(1);

--- a/regression-tests/test-results/gcc-13/gcc-version.output
+++ b/regression-tests/test-results/gcc-13/gcc-version.output
@@ -1,0 +1,5 @@
+c++ (GCC) 13.1.1 20230429
+Copyright (C) 2023 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+

--- a/regression-tests/test-results/gcc-13/pure2-bugfix-for-runtime-invalid-alternative.cpp.execution
+++ b/regression-tests/test-results/gcc-13/pure2-bugfix-for-runtime-invalid-alternative.cpp.execution
@@ -1,0 +1,2 @@
+Type safety violation: Statement of chosen alternative is invalid.
+terminate called without an active exception

--- a/regression-tests/test-results/mixed-inspect-templates.cpp
+++ b/regression-tests/test-results/mixed-inspect-templates.cpp
@@ -37,7 +37,7 @@ struct my_type {};
         else if (cpp2::is<std::array>(__expr)) { if constexpr( requires{"std::array";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("std::array")),std::string> ) return "std::array"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
         else if (cpp2::is<std::variant>(__expr)) { if constexpr( requires{"std::variant";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("std::variant")),std::string> ) return "std::variant"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
         else if (cpp2::is<my_type>(__expr)) { if constexpr( requires{"my_type";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("my_type")),std::string> ) return "my_type"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-        else return "unknown"; }
+        return "unknown"; }
     (); 
 }
 

--- a/regression-tests/test-results/mixed-inspect-templates.cpp
+++ b/regression-tests/test-results/mixed-inspect-templates.cpp
@@ -33,10 +33,10 @@ struct my_type {};
 #line 8 "mixed-inspect-templates.cpp2"
 [[nodiscard]] auto fun(auto const& v) -> std::string{
     return [&] () -> std::string { auto&& __expr = v;
-        if (cpp2::is<std::vector>(__expr)) { if constexpr( requires{"std::vector";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("std::vector")),std::string> ) return "std::vector"; else return std::string{}; else return std::string{}; }
-        else if (cpp2::is<std::array>(__expr)) { if constexpr( requires{"std::array";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("std::array")),std::string> ) return "std::array"; else return std::string{}; else return std::string{}; }
-        else if (cpp2::is<std::variant>(__expr)) { if constexpr( requires{"std::variant";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("std::variant")),std::string> ) return "std::variant"; else return std::string{}; else return std::string{}; }
-        else if (cpp2::is<my_type>(__expr)) { if constexpr( requires{"my_type";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("my_type")),std::string> ) return "my_type"; else return std::string{}; else return std::string{}; }
+        if (cpp2::is<std::vector>(__expr)) { if constexpr( requires{"std::vector";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("std::vector")),std::string> ) return "std::vector"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+        else if (cpp2::is<std::array>(__expr)) { if constexpr( requires{"std::array";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("std::array")),std::string> ) return "std::array"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+        else if (cpp2::is<std::variant>(__expr)) { if constexpr( requires{"std::variant";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("std::variant")),std::string> ) return "std::variant"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+        else if (cpp2::is<my_type>(__expr)) { if constexpr( requires{"my_type";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("my_type")),std::string> ) return "my_type"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
         else return "unknown"; }
     (); 
 }

--- a/regression-tests/test-results/mixed-inspect-values-2.cpp
+++ b/regression-tests/test-results/mixed-inspect-values-2.cpp
@@ -39,8 +39,8 @@ constexpr auto empty = [](auto&& x){
     auto i {15}; 
 
     std::cout << [&] () -> std::string { auto&& __expr = i;
-        if (cpp2::is(__expr, (less_than(10)))) { if constexpr( requires{"i less than 10";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("i less than 10")),std::string> ) return "i less than 10"; else return std::string{}; else return std::string{}; }
-        else if (cpp2::is(__expr, in(11, 20))) { if constexpr( requires{"i is between 11 and 20";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("i is between 11 and 20")),std::string> ) return "i is between 11 and 20"; else return std::string{}; else return std::string{}; }
+        if (cpp2::is(__expr, (less_than(10)))) { if constexpr( requires{"i less than 10";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("i less than 10")),std::string> ) return "i less than 10"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+        else if (cpp2::is(__expr, in(11, 20))) { if constexpr( requires{"i is between 11 and 20";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("i is between 11 and 20")),std::string> ) return "i is between 11 and 20"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
         else return "i is out of our interest"; }
     () << std::endl;
 

--- a/regression-tests/test-results/mixed-inspect-values-2.cpp
+++ b/regression-tests/test-results/mixed-inspect-values-2.cpp
@@ -41,7 +41,7 @@ constexpr auto empty = [](auto&& x){
     std::cout << [&] () -> std::string { auto&& __expr = i;
         if (cpp2::is(__expr, (less_than(10)))) { if constexpr( requires{"i less than 10";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("i less than 10")),std::string> ) return "i less than 10"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
         else if (cpp2::is(__expr, in(11, 20))) { if constexpr( requires{"i is between 11 and 20";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("i is between 11 and 20")),std::string> ) return "i is between 11 and 20"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-        else return "i is out of our interest"; }
+        return "i is out of our interest"; }
     () << std::endl;
 
     if (cpp2::is(i, (less_than(20)))) {

--- a/regression-tests/test-results/mixed-inspect-values.cpp
+++ b/regression-tests/test-results/mixed-inspect-values.cpp
@@ -62,7 +62,7 @@ auto test(auto const& x) -> void{
         else if (cpp2::is(__expr, std::move(forty_two))) { if constexpr( requires{"the answer";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("the answer")),std::string> ) return "the answer"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
         else if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + cpp2::to_string(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + cpp2::to_string(x))),std::string> ) return "integer " + cpp2::to_string(x); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
         else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{cpp2::as<std::string>(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((cpp2::as<std::string>(x))),std::string> ) return cpp2::as<std::string>(x); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-        else return "(no match)"; }
+        return "(no match)"; }
     () << "\n";
 }
 

--- a/regression-tests/test-results/mixed-inspect-values.cpp
+++ b/regression-tests/test-results/mixed-inspect-values.cpp
@@ -56,12 +56,12 @@ auto test(auto const& x) -> void;
 auto test(auto const& x) -> void{
     auto forty_two {42}; 
     std::cout << [&] () -> std::string { auto&& __expr = x;
-        if (cpp2::is(__expr, 0)) { if constexpr( requires{"zero";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("zero")),std::string> ) return "zero"; else return std::string{}; else return std::string{}; }
-        else if (cpp2::is(__expr, (in(1, 2)))) { if constexpr( requires{"1 or 2";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("1 or 2")),std::string> ) return "1 or 2"; else return std::string{}; else return std::string{}; }
-        else if (cpp2::is(__expr, in_2_3)) { if constexpr( requires{"3";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("3")),std::string> ) return "3"; else return std::string{}; else return std::string{}; }
-        else if (cpp2::is(__expr, std::move(forty_two))) { if constexpr( requires{"the answer";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("the answer")),std::string> ) return "the answer"; else return std::string{}; else return std::string{}; }
-        else if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + cpp2::to_string(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + cpp2::to_string(x))),std::string> ) return "integer " + cpp2::to_string(x); else return std::string{}; else return std::string{}; }
-        else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{cpp2::as<std::string>(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((cpp2::as<std::string>(x))),std::string> ) return cpp2::as<std::string>(x); else return std::string{}; else return std::string{}; }
+        if (cpp2::is(__expr, 0)) { if constexpr( requires{"zero";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("zero")),std::string> ) return "zero"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+        else if (cpp2::is(__expr, (in(1, 2)))) { if constexpr( requires{"1 or 2";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("1 or 2")),std::string> ) return "1 or 2"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+        else if (cpp2::is(__expr, in_2_3)) { if constexpr( requires{"3";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("3")),std::string> ) return "3"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+        else if (cpp2::is(__expr, std::move(forty_two))) { if constexpr( requires{"the answer";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("the answer")),std::string> ) return "the answer"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+        else if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + cpp2::to_string(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + cpp2::to_string(x))),std::string> ) return "integer " + cpp2::to_string(x); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+        else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{cpp2::as<std::string>(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((cpp2::as<std::string>(x))),std::string> ) return cpp2::as<std::string>(x); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
         else return "(no match)"; }
     () << "\n";
 }

--- a/regression-tests/test-results/mixed-inspect-with-typeof-of-template-arg-list.cpp
+++ b/regression-tests/test-results/mixed-inspect-with-typeof-of-template-arg-list.cpp
@@ -30,7 +30,7 @@ auto calc() {
 [[nodiscard]] auto fun(auto const& v) -> int{
     return [&] () -> int { auto&& __expr = v;
         if (cpp2::is<int>(__expr)) { if constexpr( requires{calc<1,2>();} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((calc<1,2>())),int> ) return calc<1,2>(); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-        else return 0; }
+        return 0; }
     (); 
 }
 

--- a/regression-tests/test-results/mixed-inspect-with-typeof-of-template-arg-list.cpp
+++ b/regression-tests/test-results/mixed-inspect-with-typeof-of-template-arg-list.cpp
@@ -29,7 +29,7 @@ auto calc() {
 #line 7 "mixed-inspect-with-typeof-of-template-arg-list.cpp2"
 [[nodiscard]] auto fun(auto const& v) -> int{
     return [&] () -> int { auto&& __expr = v;
-        if (cpp2::is<int>(__expr)) { if constexpr( requires{calc<1,2>();} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((calc<1,2>())),int> ) return calc<1,2>(); else return int{}; else return int{}; }
+        if (cpp2::is<int>(__expr)) { if constexpr( requires{calc<1,2>();} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((calc<1,2>())),int> ) return calc<1,2>(); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
         else return 0; }
     (); 
 }

--- a/regression-tests/test-results/pure2-bugfix-for-runtime-invalid-alternative.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-runtime-invalid-alternative.cpp
@@ -24,7 +24,7 @@ auto main() -> int;
 auto f(auto const& x) -> void{
   cpp2::Default.expects([&] () -> cpp2::i32 { auto&& __expr = x;
     if (cpp2::is(__expr, 1)) { if constexpr( requires{[]() -> bool { return 2; }("");} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(([]() -> bool { return 2; }(""))),cpp2::i32> ) return []() -> bool { return 2; }(""); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-    else return 1; }
+    return 1; }
   ()==1, "");
 }
 auto main() -> int { f(1);  }

--- a/regression-tests/test-results/pure2-bugfix-for-runtime-invalid-alternative.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-runtime-invalid-alternative.cpp
@@ -1,0 +1,31 @@
+
+#define CPP2_USE_MODULES         Yes
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-bugfix-for-runtime-invalid-alternative.cpp2"
+auto f(auto const& x) -> void;
+  
+
+#line 7 "pure2-bugfix-for-runtime-invalid-alternative.cpp2"
+auto main() -> int;
+
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-bugfix-for-runtime-invalid-alternative.cpp2"
+auto f(auto const& x) -> void{
+  cpp2::Default.expects([&] () -> cpp2::i32 { auto&& __expr = x;
+    if (cpp2::is(__expr, 1)) { if constexpr( requires{[]() -> bool { return 2; }("");} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(([]() -> bool { return 2; }(""))),cpp2::i32> ) return []() -> bool { return 2; }(""); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+    else return 1; }
+  ()==1, "");
+}
+auto main() -> int { f(1);  }
+

--- a/regression-tests/test-results/pure2-bugfix-for-runtime-invalid-alternative.cpp2.output
+++ b/regression-tests/test-results/pure2-bugfix-for-runtime-invalid-alternative.cpp2.output
@@ -1,0 +1,2 @@
+pure2-bugfix-for-runtime-invalid-alternative.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -45,8 +45,8 @@ auto test_generic(auto const& x, auto const& msg) -> void{
         << std::setw(30) << msg 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + std::to_string(cpp2::as<int>(x)))),std::string> ) return "integer " + std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
-            else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{'"' + cpp2::as<std::string>(x) + '"';} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(('"' + cpp2::as<std::string>(x) + '"')),std::string> ) return '"' + cpp2::as<std::string>(x) + '"'; else return std::string{}; else return std::string{}; }
+            if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + std::to_string(cpp2::as<int>(x)))),std::string> ) return "integer " + std::to_string(cpp2::as<int>(x)); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+            else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{'"' + cpp2::as<std::string>(x) + '"';} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(('"' + cpp2::as<std::string>(x) + '"')),std::string> ) return '"' + cpp2::as<std::string>(x) + '"'; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
             else return "not an int or string"; }
         () 
         << "\n";

--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -47,7 +47,7 @@ auto test_generic(auto const& x, auto const& msg) -> void{
         << [&] () -> std::string { auto&& __expr = x;
             if (cpp2::is<int>(__expr)) { if constexpr( requires{"integer " + std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + std::to_string(cpp2::as<int>(x)))),std::string> ) return "integer " + std::to_string(cpp2::as<int>(x)); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
             else if (cpp2::is<std::string>(__expr)) { if constexpr( requires{'"' + cpp2::as<std::string>(x) + '"';} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(('"' + cpp2::as<std::string>(x) + '"')),std::string> ) return '"' + cpp2::as<std::string>(x) + '"'; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-            else return "not an int or string"; }
+            return "not an int or string"; }
         () 
         << "\n";
 }

--- a/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
@@ -32,7 +32,7 @@ auto print_an_int(auto const& x) -> void{
         << std::setw(30) << cpp2::to_string(x) 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
+            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
             else return "not an int"; }
         () 
         << "\n";

--- a/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
@@ -33,7 +33,7 @@ auto print_an_int(auto const& x) -> void{
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
             if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-            else return "not an int"; }
+            return "not an int"; }
         () 
         << "\n";
 }

--- a/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
@@ -39,10 +39,10 @@ auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << "\n" << msg << "\n    ..." 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<std::string>(__expr)) { if constexpr( requires{" matches std::string";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::string")),std::string> ) return " matches std::string"; else return std::string{}; else return std::string{}; }
-            else if (cpp2::is<std::variant<int,std::string>>(__expr)) { if constexpr( requires{" matches std::variant<int, std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::variant<int, std::string>")),std::string> ) return " matches std::variant<int, std::string>"; else return std::string{}; else return std::string{}; }
-            else if (cpp2::is<std::any>(__expr)) { if constexpr( requires{" matches std::any";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::any")),std::string> ) return " matches std::any"; else return std::string{}; else return std::string{}; }
-            else if (cpp2::is<std::optional<std::string>>(__expr)) { if constexpr( requires{" matches std::optional<std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::optional<std::string>")),std::string> ) return " matches std::optional<std::string>"; else return std::string{}; else return std::string{}; }
+            if (cpp2::is<std::string>(__expr)) { if constexpr( requires{" matches std::string";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::string")),std::string> ) return " matches std::string"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+            else if (cpp2::is<std::variant<int,std::string>>(__expr)) { if constexpr( requires{" matches std::variant<int, std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::variant<int, std::string>")),std::string> ) return " matches std::variant<int, std::string>"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+            else if (cpp2::is<std::any>(__expr)) { if constexpr( requires{" matches std::any";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::any")),std::string> ) return " matches std::any"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
+            else if (cpp2::is<std::optional<std::string>>(__expr)) { if constexpr( requires{" matches std::optional<std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::optional<std::string>")),std::string> ) return " matches std::optional<std::string>"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
             else return " no match"; }
         () 
         << "\n";

--- a/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
@@ -43,7 +43,7 @@ auto test_generic(auto const& x, auto const& msg) -> void{
             else if (cpp2::is<std::variant<int,std::string>>(__expr)) { if constexpr( requires{" matches std::variant<int, std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::variant<int, std::string>")),std::string> ) return " matches std::variant<int, std::string>"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
             else if (cpp2::is<std::any>(__expr)) { if constexpr( requires{" matches std::any";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::any")),std::string> ) return " matches std::any"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
             else if (cpp2::is<std::optional<std::string>>(__expr)) { if constexpr( requires{" matches std::optional<std::string>";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" matches std::optional<std::string>")),std::string> ) return " matches std::optional<std::string>"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-            else return " no match"; }
+            return " no match"; }
         () 
         << "\n";
 }

--- a/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
@@ -44,7 +44,7 @@ auto test_generic(auto const& x, auto const& msg) -> void{
         << "\n" << msg << "\n    ..." 
         << [&] () -> std::string { auto&& __expr = x;
             if (cpp2::is<void>(__expr)) { if constexpr( requires{" VOYDE AND EMPTIE";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" VOYDE AND EMPTIE")),std::string> ) return " VOYDE AND EMPTIE"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-            else return " no match"; }
+            return " no match"; }
         () 
         << "\n";
 }

--- a/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
@@ -43,7 +43,7 @@ auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << "\n" << msg << "\n    ..." 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<void>(__expr)) { if constexpr( requires{" VOYDE AND EMPTIE";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" VOYDE AND EMPTIE")),std::string> ) return " VOYDE AND EMPTIE"; else return std::string{}; else return std::string{}; }
+            if (cpp2::is<void>(__expr)) { if constexpr( requires{" VOYDE AND EMPTIE";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" VOYDE AND EMPTIE")),std::string> ) return " VOYDE AND EMPTIE"; cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
             else return " no match"; }
         () 
         << "\n";

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -46,7 +46,7 @@ auto test_generic(auto const& x, auto const& msg) -> void{
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
             if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
-            else return "not an int"; }
+            return "not an int"; }
         () 
         << "\n";
 }

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -45,7 +45,7 @@ auto test_generic(auto const& x, auto const& msg) -> void{
         << std::setw(30) << msg 
         << " value is " 
         << [&] () -> std::string { auto&& __expr = x;
-            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); else return std::string{}; else return std::string{}; }
+            if (cpp2::is<int>(__expr)) { if constexpr( requires{std::to_string(cpp2::as<int>(x));} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((std::to_string(cpp2::as<int>(x)))),std::string> ) return std::to_string(cpp2::as<int>(x)); cpp2::Type.expects(false, "Statement of chosen alternative is invalid."); }
             else return "not an int"; }
         () 
         << "\n";

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1991,8 +1991,10 @@ public:
                     )
                 {
                     assert(alt->statement->is_expression());
-                    printer.print_cpp2("; else return " + result_type + "{}", alt->position());
-                    printer.print_cpp2("; else return " + result_type + "{}", alt->position());
+                    printer.print_cpp2(
+                        "; cpp2::Type.expects(false, \"Statement of chosen alternative is invalid.\")",
+                        alt->position()
+                    );
                 }
 
                 printer.print_cpp2(return_suffix, alt->position());

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1911,10 +1911,6 @@ public:
         for (auto first = true; auto&& alt : n.alternatives)
         {
             assert(alt && alt->is_as_keyword);
-            if (!first) {
-                printer.print_cpp2("else ", alt->position());
-            }
-            first = false;
 
             auto id = std::string{};
             printer.emit_to_string(&id);
@@ -1972,6 +1968,10 @@ public:
                     }
                 }
                 else {
+                    if (!first) {
+                        printer.print_cpp2("else ", alt->position());
+                    }
+                    first = false;
                     printer.print_cpp2("if " + constexpr_qualifier, alt->position());
                     if (alt->type_id) {
                         printer.print_cpp2("(cpp2::is<" + id + ">(__expr)) ", alt->position());


### PR DESCRIPTION
Resolves #433.

I have some simplifications in store.
They might come in further commits,
because according to <https://github.com/hsutter/cppfront/issues/433#issuecomment-1537603929>,
they might not work.

<a id="test"/>
<details><summary>
<a href="#test">T</a>esting summary.
</summary>

```output
100% tests passed, 0 tests failed out of 508

Total Test time (real) = 111.30 sec
```

</details>

<a id="ack"/>
<details><summary>
<a href="#ack">A</a>cknowledgements.
</summary>

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- The commit message uses [Conventional Commits][] 1.0.0.

</details>

[Conventional Commits]: https://www.conventionalcommits.org/
