### PR TITLE
Output the correct location when a statement can not be parsed.

### DIFF
--- a/regression-tests/pure2-statement-parse-error.cpp2
+++ b/regression-tests/pure2-statement-parse-error.cpp2
@@ -1,0 +1,5 @@
+func: () = {
+    a : int = 5;
+    int b = 4;
+    c: int = 3;
+}

--- a/regression-tests/test-results/pure2-statement-parse-error.cpp2.output
+++ b/regression-tests/test-results/pure2-statement-parse-error.cpp2.output
@@ -1,0 +1,3 @@
+pure2-statement-parse-error.cpp2...
+pure2-statement-parse-error.cpp2(3,9): error: Could not parse statement (at 'b')
+

--- a/source/parse.h
+++ b/source/parse.h
@@ -3521,6 +3521,10 @@ private:
         error( msg.c_str(), include_curr_token, err_pos, fallback );
     }
 
+    bool has_error() {
+        return !errors.empty();
+    }
+
 
     //-----------------------------------------------------------------------
     //  Token navigation: Only these functions should access this->token_
@@ -5372,6 +5376,11 @@ private:
             //  contained statement() may have parameters
             auto s = statement(true, source_position{}, true);
             if (!s) {
+
+                // Only add error when no specific one already exist
+                if(!has_error()) {
+                    error("Could not parse statement", true);
+                }
                 pos = start_pos;    // backtrack
                 return {};
             }

--- a/source/parse.h
+++ b/source/parse.h
@@ -5379,7 +5379,7 @@ private:
 
                 // Only add error when no specific one already exist
                 if(!has_error()) {
-                    error("Could not parse statement", true);
+                    error("Invalid statement encountered inside a compound-statement", true);
                 }
                 pos = start_pos;    // backtrack
                 return {};


### PR DESCRIPTION
Fixes #488 

With this fix the regression tests still run.

Previous output was:
```
pure2-statement-parse-error.cpp2...
pure2-statement-parse-error.cpp2(1,12): error: ill-formed initializer (at '{')
pure2-statement-parse-error.cpp2(1,1): error: unexpected text at end of Cpp2 code section (at 'func')
pure2-statement-parse-error.cpp2(1,0): error: parse failed for section starting here

```

Current output is:
```
pure2-statement-parse-error.cpp2...
pure2-statement-parse-error.cpp2(3,9): error: Could not parse statement (at 'b')

```
