### PR TITLE
perf(io): excise last use of `std::regex`

### DIFF
--- a/source/io.h
+++ b/source/io.h
@@ -114,8 +114,8 @@ auto is_preprocessor(
 auto starts_with_import(std::string const& line)
     -> bool
 {
-    auto import_first = std::find_if_not(line.data(), &*line.end(), [](char c) { return std::isspace(c); });
-    auto import_last = std::find_if(import_first, &*line.end(), [](char c) { return std::isspace(c); });
+    auto import_first = std::find_if_not(line.data(), line.data()+line.length(), [](char c) { return std::isspace(c); });
+    auto import_last = std::find_if(import_first, line.data()+line.length(), [](char c) { return std::isspace(c); });
     return std::string_view{import_first, import_last} == "import";
 }
 

--- a/source/io.h
+++ b/source/io.h
@@ -22,7 +22,6 @@
 #include <fstream>
 #include <ostream>
 #include <iterator>
-#include <regex>
 #include <cctype>
 
 
@@ -115,16 +114,9 @@ auto is_preprocessor(
 auto starts_with_import(std::string const& line)
     -> bool
 {
-    const auto ws = std::regex("\\s+"); // whitespace
-    auto i = 1;
-    for (std::sregex_token_iterator iter(std::begin(line), std::end(line), ws, -1);
-        iter != std::sregex_token_iterator();
-        ++iter, ++i) {
-        if (iter->length() > 0) {
-            return *iter == "import";
-        }
-    }
-    return false;
+    auto import_first = std::find_if_not(line.data(), &*line.end(), [](char c) { return std::isspace(c); });
+    auto import_last = std::find_if(import_first, &*line.end(), [](char c) { return std::isspace(c); });
+    return std::string_view{import_first, import_last} == "import";
 }
 
 


### PR DESCRIPTION
On my system, with a GCC 13 Debug build of Cppfront,
lowering `passthrough-tests/clang-12-libstdc++-e.cpp2`
is reduced from 24 s to 0.4 s.
Lowering the other passthrough-tests also takes 0.4 s each.

The passthrough-tests pass, as do the regression-tests:
```output
100% tests passed, 0 tests failed out of 660

Total Test time (real) =  85.42 sec
```