### PR TITLE
When Clang defines _MSC_VER, prefer Clang versions of attribute macros

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -681,7 +681,7 @@ public:
 //
 //-----------------------------------------------------------------------
 //
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang_major__)
     #define CPP2_FORCE_INLINE        __forceinline
     #define CPP2_FORCE_INLINE_LAMBDA [[msvc::forceinline]]
     #define CPP2_LAMBDA_NO_DISCARD


### PR DESCRIPTION
WIthout this, compiling with Clang for Windows results in a lot of `warning: unknown attribute 'forceinline' ignored [-Wunknown-attributes]` warnings.