### PR TITLE
Statements before and between member initializers in special member functions

### DIFF
--- a/regression-tests/pure2-types-smf-and-that-1-provide-everything.cpp2
+++ b/regression-tests/pure2-types-smf-and-that-1-provide-everything.cpp2
@@ -2,20 +2,24 @@
 myclass : type = {
 
     operator=: (out this, that) = {
+        this = that;
         std::cout << "ctor - copy (GENERAL)";
     }
 
     operator=: (out this, move that) = {
+        this = that;
         name = that.name + "(CM)";
         std::cout << "ctor - move          ";
     }
 
     operator=: (inout this,  that) = {
+        this = that;
         addr = that.addr + "(AC)";
         std::cout << "assign - copy        ";
     }
 
     operator=: (inout this, move that) = {
+        this = that;
         std::cout << "assign - move        ";
     }
 

--- a/regression-tests/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2
+++ b/regression-tests/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2
@@ -2,20 +2,24 @@
 myclass : type = {
 
     operator=: (out this, that) = {
+        this = that;
         std::cout << "ctor - copy (GENERAL)";
     }
 
     operator=: (out this, move that) = {
+        this = that;
         name = that.name + "(CM)";
         std::cout << "ctor - move          ";
     }
 
     operator=: (inout this,  that) = {
+        this = that;
         addr = that.addr + "(AC)";
         std::cout << "assign - copy        ";
     }
 
     // operator=: (inout this, move that) = {
+    //     this = that;
     //     std::cout << "assign - move        ";
     // }
 

--- a/regression-tests/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2
+++ b/regression-tests/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2
@@ -2,20 +2,24 @@
 myclass : type = {
 
     operator=: (out this, that) = {
+        this = that;
         std::cout << "ctor - copy (GENERAL)";
     }
 
     operator=: (out this, move that) = {
+        this = that;
         name = that.name + "(CM)";
         std::cout << "ctor - move          ";
     }
 
     // operator=: (inout this,  that) = {
+    //     this = that;
     //     addr = that.addr + "(AC)";
     //     std::cout << "assign - copy        ";
     // }
 
     operator=: (inout this, move that) = {
+        this = that;
         std::cout << "assign - move        ";
     }
 

--- a/regression-tests/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2
+++ b/regression-tests/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2
@@ -2,20 +2,24 @@
 myclass : type = {
 
     operator=: (out this, that) = {
+        this = that;
         std::cout << "ctor - copy (GENERAL)";
     }
 
     // operator=: (out this, move that) = {
+    //     this = that;
     //     name = that.name + "(CM)";
     //     std::cout << "ctor - move          ";
     // }
 
     operator=: (inout this,  that) = {
+        this = that;
         addr = that.addr + "(AC)";
         std::cout << "assign - copy        ";
     }
 
     operator=: (inout this, move that) = {
+        this = that;
         std::cout << "assign - move        ";
     }
 

--- a/regression-tests/pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2
+++ b/regression-tests/pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2
@@ -2,20 +2,24 @@
 myclass : type = {
 
     operator=: (out this, that) = {
+        this = that;
         std::cout << "ctor - copy (GENERAL)";
     }
 
     // operator=: (out this, move that) = {
+    //     this = that;
     //     name = that.name + "(CM)";
     //     std::cout << "ctor - move          ";
     // }
 
     // operator=: (inout this,  that) = {
+    //     this = that;
     //     addr = that.addr + "(AC)";
     //     std::cout << "assign - copy        ";
     // }
 
     // operator=: (inout this, move that) = {
+    //     this = that;
     //     std::cout << "assign - move        ";
     // }
 

--- a/regression-tests/pure2-types-smf-statements-between-member-inits.cpp2
+++ b/regression-tests/pure2-types-smf-statements-between-member-inits.cpp2
@@ -1,0 +1,158 @@
+f: (a1: i32) = {
+    _ = a1;
+}
+
+t1: type = {
+    m1: i32 = 123;
+    m2: i32 = 456;
+
+    operator=: (out this, that) = {
+        // m1 = 123 implied
+        // m2 = 456 implied
+        f(1);
+        f(2);
+    }
+}
+
+t2: type = {
+    m1: i32 = 123;
+    m2: i32 = 456;
+
+    operator=: (out this, that) = {
+        f(1);
+        f(2);
+        m1 = 3;
+        // m2 = 456 implied
+        f(4);
+        f(5);
+    }
+}
+
+t3: type = {
+    m1: i32 = 123;
+    m2: i32 = 456;
+
+    operator=: (out this, that) = {
+        // m1 = 123 implied
+        f(1);
+        f(2);
+        m2 = 3;
+        f(4);
+        f(5);
+    }
+}
+
+t4: type = {
+    m1: i32 = 123;
+    m2: i32 = 456;
+
+    operator=: (out this, that) = {
+        f(1);
+        f(2);
+        m1 = 3;
+        f(4);
+        f(5);
+        m2 = 6;
+        f(7);
+        f(8);
+    }
+}
+
+t5: type = {
+    m1: i32 = 123;
+    m2: i32 = 456;
+
+    operator=: (out this, that) = {
+        f(1);
+        f(2);
+        this = that;
+        // m1 = that.m1 implied
+        // m2 = that.m2 implied
+        // This comment should show up before f(3)
+        f(3);
+        f(4);
+    }
+}
+
+t6: type = {
+    m1: i32 = 123;
+    m2: i32 = 456;
+
+    operator=: (out this, that) = {
+        f(1);
+        f(2);
+        this = that;
+        f(3);
+        f(4);
+        m1 = 5;
+        // m2 = that.m2 implied
+        // This comment should show up before f(6)
+        f(6);
+        f(7);
+    }
+}
+
+t7: type = {
+    m1: i32 = 123;
+    m2: i32 = 456;
+
+    operator=: (out this, that) = {
+        f(1);
+        f(2);
+        this = that;
+        // m1 = that.m1 implied
+        f(3);
+        f(4);
+        m2 = 5;
+        // This comment should show up before f(6)
+        f(6);
+        f(7);
+    }
+}
+
+t8: type = {
+    m1: i32 = 123;
+    m2: i32 = 456;
+
+    operator=: (out this, that) = {
+        f(1);
+        f(2);
+        this = that;
+        f(3);
+        f(4);
+        m1 = 5;
+        f(6);
+        f(7);
+        m2 = 8;
+        // This comment should show up before f(9)
+        f(9);
+        f(10);
+    }
+}
+
+t9: type = {
+    m1: i32 = 123;
+    m2: i32 = 456;
+
+    operator=: (implicit out this, a1: i32) = {
+        _ = a1;
+        f(1);
+        f(2);
+        m1 = 3;
+        f(4);
+        f(5);
+        m2 = 6;
+        // This comment should show up before f(7)
+        f(7);
+        f(8);
+    }
+
+    operator=: (inout this, that) = {
+        // This function shouldn't contain any member assignments.
+        // While it's a special member function that uses 'that',
+        // it's explicitly an assignment operator because of 'inout this',
+        // so we let the programmer avoid member assignment if they choose.
+        f(1);
+        f(2);
+    }
+}

--- a/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
+++ b/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
@@ -114,7 +114,10 @@ namespace N {
 
 #line 10 "pure2-types-order-independence-and-nesting.cpp2"
     X::X(cpp2::out<Y> y)
-        : py{(y.construct(&(*this)), &y.value() )}
+        : py{ [&]() -> Y* {
+              y.construct(&(*this));
+              return &y.value();
+          }() }
 #line 10 "pure2-types-order-independence-and-nesting.cpp2"
     {
         //  === The following comments will stay close to, but not exactly at,

--- a/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
+++ b/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
@@ -114,7 +114,7 @@ namespace N {
 
 #line 10 "pure2-types-order-independence-and-nesting.cpp2"
     X::X(cpp2::out<Y> y)
-        : py{ [&]() -> Y* {
+        : py{ [&]() -> decltype(auto) {
               y.construct(&(*this));
               return &y.value();
           }() }

--- a/regression-tests/test-results/pure2-types-smf-and-that-1-provide-everything.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-1-provide-everything.cpp
@@ -20,26 +20,26 @@ class myclass {
     public: myclass(myclass const& that);
         
 
-#line 8 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 9 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     public: myclass(myclass&& that) noexcept;
         
 
-#line 13 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 15 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     public: auto operator=(myclass const& that) -> myclass& ;
         
 
-#line 18 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 21 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
-#line 22 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 26 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     public: explicit myclass(cpp2::in<std::string> x);
         
-#line 22 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 26 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     public: auto operator=(cpp2::in<std::string> x) -> myclass& ;
         
 
-#line 27 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 31 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     private: std::string name {"Henry"}; 
     private: std::string addr {"123 Ford Dr."}; 
 
@@ -49,7 +49,7 @@ class myclass {
         cpp2::in<std::string_view> suffix
         ) const -> void;
 
-#line 37 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 41 "pure2-types-smf-and-that-1-provide-everything.cpp2"
 };
 
 auto main() -> int;
@@ -64,15 +64,17 @@ auto main() -> int;
         , addr{ that.addr }
 #line 4 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     {
+
         std::cout << "ctor - copy (GENERAL)";
     }
 
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }
-#line 8 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 9 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     {
 
+#line 12 "pure2-types-smf-and-that-1-provide-everything.cpp2"
         std::cout << "ctor - move          ";
     }
 
@@ -80,40 +82,41 @@ auto main() -> int;
         name = that.name;
         addr = that.addr + "(AC)";
 
-#line 15 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 18 "pure2-types-smf-and-that-1-provide-everything.cpp2"
         std::cout << "assign - copy        ";
         return *this;
-#line 16 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 19 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     }
 
     auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
-#line 19 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+
+#line 23 "pure2-types-smf-and-that-1-provide-everything.cpp2"
         std::cout << "assign - move        ";
         return *this;
-#line 20 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 24 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     }
 
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }
-#line 22 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 26 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     {
 
         std::cout << "ctor - from string   ";
     }
-#line 22 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 26 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     auto myclass::operator=(cpp2::in<std::string> x) -> myclass& {
         name = x;
         addr = "123 Ford Dr.";
 
-#line 24 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 28 "pure2-types-smf-and-that-1-provide-everything.cpp2"
         std::cout << "ctor - from string   ";
         return *this;
-#line 25 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 29 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     }
 
-#line 30 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 34 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     auto myclass::print(
 
         cpp2::in<std::string_view> prefix, 
@@ -121,7 +124,7 @@ auto main() -> int;
         ) const -> void { 
     std::cout << prefix << "[ " + cpp2::to_string(name) + " | " + cpp2::to_string(addr) + " ]" << suffix;  }
 
-#line 39 "pure2-types-smf-and-that-1-provide-everything.cpp2"
+#line 43 "pure2-types-smf-and-that-1-provide-everything.cpp2"
 auto main() -> int{
     std::cout << "Function invoked        Call syntax   Results\n";
     std::cout << "----------------------  ------------  ------------------------------------------------------\n";

--- a/regression-tests/test-results/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp
@@ -20,29 +20,30 @@ class myclass {
     public: myclass(myclass const& that);
         
 
-#line 8 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 9 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     public: myclass(myclass&& that) noexcept;
         
 
-#line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 15 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     public: auto operator=(myclass const& that) -> myclass& ;
         
-#line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 15 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
-#line 18 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 21 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     // operator=: (inout this, move that) = {
+    //     this = that;
     //     std::cout << "assign - move        ";
     // }
 
     public: explicit myclass(cpp2::in<std::string> x);
         
-#line 22 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 26 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     public: auto operator=(cpp2::in<std::string> x) -> myclass& ;
         
 
-#line 27 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 31 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     private: std::string name {"Henry"}; 
     private: std::string addr {"123 Ford Dr."}; 
 
@@ -52,7 +53,7 @@ class myclass {
         cpp2::in<std::string_view> suffix
         ) const -> void;
 
-#line 37 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 41 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
 };
 
 auto main() -> int;
@@ -67,15 +68,17 @@ auto main() -> int;
         , addr{ that.addr }
 #line 4 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     {
+
         std::cout << "ctor - copy (GENERAL)";
     }
 
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }
-#line 8 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 9 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     {
 
+#line 12 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
         std::cout << "ctor - move          ";
     }
 
@@ -83,42 +86,42 @@ auto main() -> int;
         name = that.name;
         addr = that.addr + "(AC)";
 
-#line 15 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 18 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
         std::cout << "assign - copy        ";
         return *this;
-#line 16 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 19 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     }
-#line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 15 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr + "(AC)";
 
-#line 15 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 18 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
         std::cout << "assign - copy        ";
         return *this;
-#line 16 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 19 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     }
 
-#line 22 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 26 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }
-#line 22 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 26 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     {
 
         std::cout << "ctor - from string   ";
     }
-#line 22 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 26 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     auto myclass::operator=(cpp2::in<std::string> x) -> myclass& {
         name = x;
         addr = "123 Ford Dr.";
 
-#line 24 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 28 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
         std::cout << "ctor - from string   ";
         return *this;
-#line 25 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 29 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     }
 
-#line 30 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 34 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     auto myclass::print(
 
         cpp2::in<std::string_view> prefix, 
@@ -126,7 +129,7 @@ auto main() -> int;
         ) const -> void { 
     std::cout << prefix << "[ " + cpp2::to_string(name) + " | " + cpp2::to_string(addr) + " ]" << suffix;  }
 
-#line 39 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
+#line 43 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
 auto main() -> int{
     std::cout << "Function invoked        Call syntax   Results\n";
     std::cout << "----------------------  ------------  ------------------------------------------------------\n";

--- a/regression-tests/test-results/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp
@@ -23,12 +23,13 @@ class myclass {
     public: auto operator=(myclass const& that) -> myclass& ;
         
 
-#line 8 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 9 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     public: myclass(myclass&& that) noexcept;
         
 
-#line 13 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 15 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     // operator=: (inout this,  that) = {
+    //     this = that;
     //     addr = that.addr + "(AC)";
     //     std::cout << "assign - copy        ";
     // }
@@ -36,14 +37,14 @@ class myclass {
     public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
-#line 22 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 26 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     public: explicit myclass(cpp2::in<std::string> x);
         
-#line 22 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 26 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     public: auto operator=(cpp2::in<std::string> x) -> myclass& ;
         
 
-#line 27 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 31 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     private: std::string name {"Henry"}; 
     private: std::string addr {"123 Ford Dr."}; 
 
@@ -53,7 +54,7 @@ class myclass {
         cpp2::in<std::string_view> suffix
         ) const -> void;
 
-#line 37 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 41 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
 };
 
 auto main() -> int;
@@ -68,56 +69,60 @@ auto main() -> int;
         , addr{ that.addr }
 #line 4 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     {
+
         std::cout << "ctor - copy (GENERAL)";
     }
 #line 4 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     auto myclass::operator=(myclass const& that) -> myclass& {
         name = that.name;
         addr = that.addr;
-#line 5 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+
+#line 6 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
         std::cout << "ctor - copy (GENERAL)";
         return *this;
-#line 6 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 7 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     }
 
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }
-#line 8 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 9 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     {
 
+#line 12 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
         std::cout << "ctor - move          ";
     }
 
-#line 18 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 21 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
-#line 19 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+
+#line 23 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
         std::cout << "assign - move        ";
         return *this;
-#line 20 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 24 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     }
 
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }
-#line 22 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 26 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     {
 
         std::cout << "ctor - from string   ";
     }
-#line 22 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 26 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     auto myclass::operator=(cpp2::in<std::string> x) -> myclass& {
         name = x;
         addr = "123 Ford Dr.";
 
-#line 24 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 28 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
         std::cout << "ctor - from string   ";
         return *this;
-#line 25 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 29 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     }
 
-#line 30 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 34 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     auto myclass::print(
 
         cpp2::in<std::string_view> prefix, 
@@ -125,7 +130,7 @@ auto main() -> int;
         ) const -> void { 
     std::cout << prefix << "[ " + cpp2::to_string(name) + " | " + cpp2::to_string(addr) + " ]" << suffix;  }
 
-#line 39 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
+#line 43 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
 auto main() -> int{
     std::cout << "Function invoked        Call syntax   Results\n";
     std::cout << "----------------------  ------------  ------------------------------------------------------\n";

--- a/regression-tests/test-results/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp
@@ -23,8 +23,9 @@ class myclass {
     public: myclass(myclass&& that) noexcept;
         
 
-#line 8 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 9 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     // operator=: (out this, move that) = {
+    //     this = that;
     //     name = that.name + "(CM)";
     //     std::cout << "ctor - move          ";
     // }
@@ -32,18 +33,18 @@ class myclass {
     public: auto operator=(myclass const& that) -> myclass& ;
         
 
-#line 18 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 21 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
-#line 22 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 26 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     public: explicit myclass(cpp2::in<std::string> x);
         
-#line 22 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 26 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     public: auto operator=(cpp2::in<std::string> x) -> myclass& ;
         
 
-#line 27 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 31 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     private: std::string name {"Henry"}; 
     private: std::string addr {"123 Ford Dr."}; 
 
@@ -53,7 +54,7 @@ class myclass {
         cpp2::in<std::string_view> suffix
         ) const -> void;
 
-#line 37 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 41 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
 };
 
 auto main() -> int;
@@ -68,6 +69,7 @@ auto main() -> int;
         , addr{ that.addr }
 #line 4 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     {
+
         std::cout << "ctor - copy (GENERAL)";
     }
 #line 4 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
@@ -76,48 +78,50 @@ auto main() -> int;
         , addr{ std::move(that).addr }
 #line 4 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     {
+
         std::cout << "ctor - copy (GENERAL)";
     }
 
-#line 13 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 15 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     auto myclass::operator=(myclass const& that) -> myclass& {
         name = that.name;
         addr = that.addr + "(AC)";
 
-#line 15 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 18 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
         std::cout << "assign - copy        ";
         return *this;
-#line 16 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 19 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     }
 
     auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
-#line 19 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+
+#line 23 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
         std::cout << "assign - move        ";
         return *this;
-#line 20 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 24 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     }
 
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }
-#line 22 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 26 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     {
 
         std::cout << "ctor - from string   ";
     }
-#line 22 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 26 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     auto myclass::operator=(cpp2::in<std::string> x) -> myclass& {
         name = x;
         addr = "123 Ford Dr.";
 
-#line 24 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 28 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
         std::cout << "ctor - from string   ";
         return *this;
-#line 25 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 29 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     }
 
-#line 30 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 34 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     auto myclass::print(
 
         cpp2::in<std::string_view> prefix, 
@@ -125,7 +129,7 @@ auto main() -> int;
         ) const -> void { 
     std::cout << prefix << "[ " + cpp2::to_string(name) + " | " + cpp2::to_string(addr) + " ]" << suffix;  }
 
-#line 39 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
+#line 43 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
 auto main() -> int{
     std::cout << "Function invoked        Call syntax   Results\n";
     std::cout << "----------------------  ------------  ------------------------------------------------------\n";

--- a/regression-tests/test-results/pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp
@@ -29,28 +29,31 @@ class myclass {
     public: auto operator=(myclass&& that) noexcept -> myclass& ;
         
 
-#line 8 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 9 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     // operator=: (out this, move that) = {
+    //     this = that;
     //     name = that.name + "(CM)";
     //     std::cout << "ctor - move          ";
     // }
 
     // operator=: (inout this,  that) = {
+    //     this = that;
     //     addr = that.addr + "(AC)";
     //     std::cout << "assign - copy        ";
     // }
 
     // operator=: (inout this, move that) = {
+    //     this = that;
     //     std::cout << "assign - move        ";
     // }
 
     public: explicit myclass(cpp2::in<std::string> x);
         
-#line 22 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 26 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     public: auto operator=(cpp2::in<std::string> x) -> myclass& ;
         
 
-#line 27 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 31 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     private: std::string name {"Henry"}; 
     private: std::string addr {"123 Ford Dr."}; 
 
@@ -60,7 +63,7 @@ class myclass {
         cpp2::in<std::string_view> suffix
         ) const -> void;
 
-#line 37 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 41 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
 };
 
 auto main() -> int;
@@ -75,16 +78,18 @@ auto main() -> int;
         , addr{ that.addr }
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     {
+
         std::cout << "ctor - copy (GENERAL)";
     }
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     auto myclass::operator=(myclass const& that) -> myclass& {
         name = that.name;
         addr = that.addr;
-#line 5 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+
+#line 6 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
         std::cout << "ctor - copy (GENERAL)";
         return *this;
-#line 6 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 7 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     }
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     myclass::myclass(myclass&& that) noexcept
@@ -92,38 +97,40 @@ auto main() -> int;
         , addr{ std::move(that).addr }
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     {
+
         std::cout << "ctor - copy (GENERAL)";
     }
 #line 4 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
-#line 5 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+
+#line 6 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
         std::cout << "ctor - copy (GENERAL)";
         return *this;
-#line 6 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 7 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     }
 
-#line 22 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 26 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }
-#line 22 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 26 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     {
 
         std::cout << "ctor - from string   ";
     }
-#line 22 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 26 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     auto myclass::operator=(cpp2::in<std::string> x) -> myclass& {
         name = x;
         addr = "123 Ford Dr.";
 
-#line 24 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 28 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
         std::cout << "ctor - from string   ";
         return *this;
-#line 25 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 29 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     }
 
-#line 30 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 34 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
     auto myclass::print(
 
         cpp2::in<std::string_view> prefix, 
@@ -131,7 +138,7 @@ auto main() -> int;
         ) const -> void { 
     std::cout << prefix << "[ " + cpp2::to_string(name) + " | " + cpp2::to_string(addr) + " ]" << suffix;  }
 
-#line 39 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
+#line 43 "pure2-types-smf-and-that-5-provide-nothing-but-general-case.cpp2"
 auto main() -> int{
     std::cout << "Function invoked        Call syntax   Results\n";
     std::cout << "----------------------  ------------  ------------------------------------------------------\n";

--- a/regression-tests/test-results/pure2-types-smf-statements-between-member-inits.cpp
+++ b/regression-tests/test-results/pure2-types-smf-statements-between-member-inits.cpp
@@ -1,0 +1,789 @@
+
+#define CPP2_USE_MODULES         Yes
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+
+#line 5 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t1;
+    
+
+#line 17 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t2;
+    
+
+#line 31 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t3;
+    
+
+#line 45 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t4;
+    
+
+#line 61 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t5;
+    
+
+#line 77 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t6;
+    
+
+#line 95 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t7;
+    
+
+#line 113 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t8;
+    
+
+#line 133 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t9;
+    
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-types-smf-statements-between-member-inits.cpp2"
+auto f(cpp2::in<cpp2::i32> a1) -> void;
+    
+
+#line 5 "pure2-types-smf-statements-between-member-inits.cpp2"
+class t1 {
+    private: cpp2::i32 m1 {123}; 
+    private: cpp2::i32 m2 {456}; 
+
+    public: t1(t1 const& that);
+        
+#line 9 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t1 const& that) -> t1& ;
+        
+#line 9 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: t1(t1&& that) noexcept;
+        
+#line 9 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t1&& that) noexcept -> t1& ;
+        
+
+#line 15 "pure2-types-smf-statements-between-member-inits.cpp2"
+};
+
+class t2 {
+    private: cpp2::i32 m1 {123}; 
+    private: cpp2::i32 m2 {456}; 
+
+    public: t2(t2 const& that);
+        
+#line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t2 const& that) -> t2& ;
+        
+#line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: t2(t2&& that) noexcept;
+        
+#line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t2&& that) noexcept -> t2& ;
+        
+
+#line 29 "pure2-types-smf-statements-between-member-inits.cpp2"
+};
+
+class t3 {
+    private: cpp2::i32 m1 {123}; 
+    private: cpp2::i32 m2 {456}; 
+
+    public: t3(t3 const& that);
+        
+#line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t3 const& that) -> t3& ;
+        
+#line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: t3(t3&& that) noexcept;
+        
+#line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t3&& that) noexcept -> t3& ;
+        
+
+#line 43 "pure2-types-smf-statements-between-member-inits.cpp2"
+};
+
+class t4 {
+    private: cpp2::i32 m1 {123}; 
+    private: cpp2::i32 m2 {456}; 
+
+    public: t4(t4 const& that);
+        
+#line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t4 const& that) -> t4& ;
+        
+#line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: t4(t4&& that) noexcept;
+        
+#line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t4&& that) noexcept -> t4& ;
+        
+
+#line 59 "pure2-types-smf-statements-between-member-inits.cpp2"
+};
+
+class t5 {
+    private: cpp2::i32 m1 {123}; 
+    private: cpp2::i32 m2 {456}; 
+
+    public: t5(t5 const& that);
+        
+#line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t5 const& that) -> t5& ;
+        
+#line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: t5(t5&& that) noexcept;
+        
+#line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t5&& that) noexcept -> t5& ;
+        
+
+#line 75 "pure2-types-smf-statements-between-member-inits.cpp2"
+};
+
+class t6 {
+    private: cpp2::i32 m1 {123}; 
+    private: cpp2::i32 m2 {456}; 
+
+    public: t6(t6 const& that);
+        
+#line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t6 const& that) -> t6& ;
+        
+#line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: t6(t6&& that) noexcept;
+        
+#line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t6&& that) noexcept -> t6& ;
+        
+
+#line 93 "pure2-types-smf-statements-between-member-inits.cpp2"
+};
+
+class t7 {
+    private: cpp2::i32 m1 {123}; 
+    private: cpp2::i32 m2 {456}; 
+
+    public: t7(t7 const& that);
+        
+#line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t7 const& that) -> t7& ;
+        
+#line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: t7(t7&& that) noexcept;
+        
+#line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t7&& that) noexcept -> t7& ;
+        
+
+#line 111 "pure2-types-smf-statements-between-member-inits.cpp2"
+};
+
+class t8 {
+    private: cpp2::i32 m1 {123}; 
+    private: cpp2::i32 m2 {456}; 
+
+    public: t8(t8 const& that);
+        
+#line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t8 const& that) -> t8& ;
+        
+#line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: t8(t8&& that) noexcept;
+        
+#line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t8&& that) noexcept -> t8& ;
+        
+
+#line 131 "pure2-types-smf-statements-between-member-inits.cpp2"
+};
+
+class t9 {
+    private: cpp2::i32 m1 {123}; 
+    private: cpp2::i32 m2 {456}; 
+
+    public: t9(cpp2::in<cpp2::i32> a1);
+        
+#line 137 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(cpp2::in<cpp2::i32> a1) -> t9& ;
+        
+
+#line 150 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t9 const& that) -> t9& ;
+        
+#line 150 "pure2-types-smf-statements-between-member-inits.cpp2"
+    public: auto operator=(t9&& that) noexcept -> t9& ;
+        
+    public: t9(t9 const&) = delete; /* No 'that' constructor, suppress copy */
+    public: auto operator=(t9 const&) -> void = delete;
+
+
+#line 158 "pure2-types-smf-statements-between-member-inits.cpp2"
+};
+
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-types-smf-statements-between-member-inits.cpp2"
+auto f(cpp2::in<cpp2::i32> a1) -> void{
+    (void) a1;
+}
+
+#line 9 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t1::t1(t1 const& that){
+        // m1 = 123 implied
+        // m2 = 456 implied
+        f(1);
+        f(2);
+    }
+#line 9 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t1::operator=(t1 const& that) -> t1& {
+        m1 = 123;
+        m2 = 456;
+
+#line 12 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(1);
+        f(2);
+        return *this;
+#line 14 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+#line 9 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t1::t1(t1&& that) noexcept{
+
+#line 12 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(1);
+        f(2);
+    }
+#line 9 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t1::operator=(t1&& that) noexcept -> t1& {
+        m1 = 123;
+        m2 = 456;
+
+#line 12 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(1);
+        f(2);
+        return *this;
+#line 14 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+
+#line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t2::t2(t2 const& that)
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return 3;
+          }() }
+#line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 25 "pure2-types-smf-statements-between-member-inits.cpp2"
+        // m2 = 456 implied
+        f(4);
+        f(5);
+    }
+#line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t2::operator=(t2 const& that) -> t2& {
+        f(1);
+        f(2);
+        m1 = 3;
+        m2 = 456;
+
+#line 26 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(4);
+        f(5);
+        return *this;
+#line 28 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+#line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t2::t2(t2&& that) noexcept
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return 3;
+          }() }
+#line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 26 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(4);
+        f(5);
+    }
+#line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t2::operator=(t2&& that) noexcept -> t2& {
+        f(1);
+        f(2);
+        m1 = 3;
+        m2 = 456;
+
+#line 26 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(4);
+        f(5);
+        return *this;
+#line 28 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+
+#line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t3::t3(t3 const& that)
+        : m2{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return 3;
+          }() }
+#line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+        // m1 = 123 implied
+
+#line 40 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(4);
+        f(5);
+    }
+#line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t3::operator=(t3 const& that) -> t3& {
+        m1 = 123;
+        f(1);
+        f(2);
+        m2 = 3;
+
+#line 40 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(4);
+        f(5);
+        return *this;
+#line 42 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+#line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t3::t3(t3&& that) noexcept
+        : m2{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return 3;
+          }() }
+#line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 40 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(4);
+        f(5);
+    }
+#line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t3::operator=(t3&& that) noexcept -> t3& {
+        m1 = 123;
+        f(1);
+        f(2);
+        m2 = 3;
+
+#line 40 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(4);
+        f(5);
+        return *this;
+#line 42 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+
+#line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t4::t4(t4 const& that)
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return 3;
+          }() }
+        , m2{ [&]() -> cpp2::i32 {
+              f(4);
+              f(5);
+              return 6;
+          }() }
+#line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 56 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(7);
+        f(8);
+    }
+#line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t4::operator=(t4 const& that) -> t4& {
+        f(1);
+        f(2);
+        m1 = 3;
+        f(4);
+        f(5);
+        m2 = 6;
+
+#line 56 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(7);
+        f(8);
+        return *this;
+#line 58 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+#line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t4::t4(t4&& that) noexcept
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return 3;
+          }() }
+        , m2{ [&]() -> cpp2::i32 {
+              f(4);
+              f(5);
+              return 6;
+          }() }
+#line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 56 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(7);
+        f(8);
+    }
+#line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t4::operator=(t4&& that) noexcept -> t4& {
+        f(1);
+        f(2);
+        m1 = 3;
+        f(4);
+        f(5);
+        m2 = 6;
+
+#line 56 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(7);
+        f(8);
+        return *this;
+#line 58 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+
+#line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t5::t5(t5 const& that)
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return that.m1;
+          }() }
+        , m2{ that.m2 }
+#line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 69 "pure2-types-smf-statements-between-member-inits.cpp2"
+        // m1 = that.m1 implied
+        // m2 = that.m2 implied
+        // This comment should show up before f(3)
+        f(3);
+        f(4);
+    }
+#line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t5::operator=(t5 const& that) -> t5& {
+        f(1);
+        f(2);
+        m1 = that.m1;
+        m2 = that.m2;
+
+#line 72 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(3);
+        f(4);
+        return *this;
+#line 74 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+#line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t5::t5(t5&& that) noexcept
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return std::move(that).m1;
+          }() }
+        , m2{ std::move(that).m2 }
+#line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 72 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(3);
+        f(4);
+    }
+#line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t5::operator=(t5&& that) noexcept -> t5& {
+        f(1);
+        f(2);
+        m1 = std::move(that).m1;
+        m2 = std::move(that).m2;
+
+#line 72 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(3);
+        f(4);
+        return *this;
+#line 74 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+
+#line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t6::t6(t6 const& that)
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              f(3);
+              f(4);
+              return 5;
+          }() }
+        , m2{ that.m2 }
+#line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 88 "pure2-types-smf-statements-between-member-inits.cpp2"
+        // m2 = that.m2 implied
+        // This comment should show up before f(6)
+        f(6);
+        f(7);
+    }
+#line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t6::operator=(t6 const& that) -> t6& {
+        f(1);
+        f(2);
+        f(3);
+        f(4);
+        m1 = 5;
+        m2 = that.m2;
+
+#line 90 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(6);
+        f(7);
+        return *this;
+#line 92 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+#line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t6::t6(t6&& that) noexcept
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              f(3);
+              f(4);
+              return 5;
+          }() }
+        , m2{ std::move(that).m2 }
+#line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 90 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(6);
+        f(7);
+    }
+#line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t6::operator=(t6&& that) noexcept -> t6& {
+        f(1);
+        f(2);
+        f(3);
+        f(4);
+        m1 = 5;
+        m2 = std::move(that).m2;
+
+#line 90 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(6);
+        f(7);
+        return *this;
+#line 92 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+
+#line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t7::t7(t7 const& that)
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return that.m1;
+          }() }
+        , m2{ [&]() -> cpp2::i32 {
+              f(3);
+              f(4);
+              return 5;
+          }() }
+#line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 103 "pure2-types-smf-statements-between-member-inits.cpp2"
+        // m1 = that.m1 implied
+
+#line 107 "pure2-types-smf-statements-between-member-inits.cpp2"
+        // This comment should show up before f(6)
+        f(6);
+        f(7);
+    }
+#line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t7::operator=(t7 const& that) -> t7& {
+        f(1);
+        f(2);
+        m1 = that.m1;
+        f(3);
+        f(4);
+        m2 = 5;
+
+#line 108 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(6);
+        f(7);
+        return *this;
+#line 110 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+#line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t7::t7(t7&& that) noexcept
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              return std::move(that).m1;
+          }() }
+        , m2{ [&]() -> cpp2::i32 {
+              f(3);
+              f(4);
+              return 5;
+          }() }
+#line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 108 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(6);
+        f(7);
+    }
+#line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t7::operator=(t7&& that) noexcept -> t7& {
+        f(1);
+        f(2);
+        m1 = std::move(that).m1;
+        f(3);
+        f(4);
+        m2 = 5;
+
+#line 108 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(6);
+        f(7);
+        return *this;
+#line 110 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+
+#line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t8::t8(t8 const& that)
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              f(3);
+              f(4);
+              return 5;
+          }() }
+        , m2{ [&]() -> cpp2::i32 {
+              f(6);
+              f(7);
+              return 8;
+          }() }
+#line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 127 "pure2-types-smf-statements-between-member-inits.cpp2"
+        // This comment should show up before f(9)
+        f(9);
+        f(10);
+    }
+#line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t8::operator=(t8 const& that) -> t8& {
+        f(1);
+        f(2);
+        f(3);
+        f(4);
+        m1 = 5;
+        f(6);
+        f(7);
+        m2 = 8;
+
+#line 128 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(9);
+        f(10);
+        return *this;
+#line 130 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+#line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t8::t8(t8&& that) noexcept
+        : m1{ [&]() -> cpp2::i32 {
+              f(1);
+              f(2);
+              f(3);
+              f(4);
+              return 5;
+          }() }
+        , m2{ [&]() -> cpp2::i32 {
+              f(6);
+              f(7);
+              return 8;
+          }() }
+#line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 128 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(9);
+        f(10);
+    }
+#line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t8::operator=(t8&& that) noexcept -> t8& {
+        f(1);
+        f(2);
+        f(3);
+        f(4);
+        m1 = 5;
+        f(6);
+        f(7);
+        m2 = 8;
+
+#line 128 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(9);
+        f(10);
+        return *this;
+#line 130 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+
+#line 137 "pure2-types-smf-statements-between-member-inits.cpp2"
+    t9::t9(cpp2::in<cpp2::i32> a1)
+        : m1{ [&]() -> cpp2::i32 {
+              (void) a1;
+              f(1);
+              f(2);
+              return 3;
+          }() }
+        , m2{ [&]() -> cpp2::i32 {
+              f(4);
+              f(5);
+              return 6;
+          }() }
+#line 137 "pure2-types-smf-statements-between-member-inits.cpp2"
+    {
+
+#line 145 "pure2-types-smf-statements-between-member-inits.cpp2"
+        // This comment should show up before f(7)
+        f(7);
+        f(8);
+    }
+#line 137 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t9::operator=(cpp2::in<cpp2::i32> a1) -> t9& {
+        (void) a1;
+        f(1);
+        f(2);
+        m1 = 3;
+        f(4);
+        f(5);
+        m2 = 6;
+
+#line 146 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(7);
+        f(8);
+        return *this;
+#line 148 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+
+    auto t9::operator=(t9 const& that) -> t9& {
+        // This function shouldn't contain any member assignments.
+        // While it's a special member function that uses 'that',
+        // it's explicitly an assignment operator because of 'inout this',
+        // so we let the programmer avoid member assignment if they choose.
+        f(1);
+        f(2);
+        return *this;
+#line 157 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+#line 150 "pure2-types-smf-statements-between-member-inits.cpp2"
+    auto t9::operator=(t9&& that) noexcept -> t9& {
+
+#line 155 "pure2-types-smf-statements-between-member-inits.cpp2"
+        f(1);
+        f(2);
+        return *this;
+#line 157 "pure2-types-smf-statements-between-member-inits.cpp2"
+    }
+

--- a/regression-tests/test-results/pure2-types-smf-statements-between-member-inits.cpp
+++ b/regression-tests/test-results/pure2-types-smf-statements-between-member-inits.cpp
@@ -272,7 +272,7 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
 
 #line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
     t2::t2(t2 const& that)
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return 3;
@@ -300,7 +300,7 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
     }
 #line 21 "pure2-types-smf-statements-between-member-inits.cpp2"
     t2::t2(t2&& that) noexcept
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return 3;
@@ -328,7 +328,7 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
 
 #line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
     t3::t3(t3 const& that)
-        : m2{ [&]() -> cpp2::i32 {
+        : m2{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return 3;
@@ -356,7 +356,7 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
     }
 #line 35 "pure2-types-smf-statements-between-member-inits.cpp2"
     t3::t3(t3&& that) noexcept
-        : m2{ [&]() -> cpp2::i32 {
+        : m2{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return 3;
@@ -384,12 +384,12 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
 
 #line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
     t4::t4(t4 const& that)
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return 3;
           }() }
-        , m2{ [&]() -> cpp2::i32 {
+        , m2{ [&]() -> decltype(auto) {
               f(4);
               f(5);
               return 6;
@@ -418,12 +418,12 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
     }
 #line 49 "pure2-types-smf-statements-between-member-inits.cpp2"
     t4::t4(t4&& that) noexcept
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return 3;
           }() }
-        , m2{ [&]() -> cpp2::i32 {
+        , m2{ [&]() -> decltype(auto) {
               f(4);
               f(5);
               return 6;
@@ -453,7 +453,7 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
 
 #line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
     t5::t5(t5 const& that)
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return that.m1;
@@ -484,7 +484,7 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
     }
 #line 65 "pure2-types-smf-statements-between-member-inits.cpp2"
     t5::t5(t5&& that) noexcept
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return std::move(that).m1;
@@ -513,7 +513,7 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
 
 #line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
     t6::t6(t6 const& that)
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               f(3);
@@ -547,7 +547,7 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
     }
 #line 81 "pure2-types-smf-statements-between-member-inits.cpp2"
     t6::t6(t6&& that) noexcept
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               f(3);
@@ -580,12 +580,12 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
 
 #line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
     t7::t7(t7 const& that)
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return that.m1;
           }() }
-        , m2{ [&]() -> cpp2::i32 {
+        , m2{ [&]() -> decltype(auto) {
               f(3);
               f(4);
               return 5;
@@ -618,12 +618,12 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
     }
 #line 99 "pure2-types-smf-statements-between-member-inits.cpp2"
     t7::t7(t7&& that) noexcept
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               return std::move(that).m1;
           }() }
-        , m2{ [&]() -> cpp2::i32 {
+        , m2{ [&]() -> decltype(auto) {
               f(3);
               f(4);
               return 5;
@@ -653,14 +653,14 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
 
 #line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
     t8::t8(t8 const& that)
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               f(3);
               f(4);
               return 5;
           }() }
-        , m2{ [&]() -> cpp2::i32 {
+        , m2{ [&]() -> decltype(auto) {
               f(6);
               f(7);
               return 8;
@@ -692,14 +692,14 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
     }
 #line 117 "pure2-types-smf-statements-between-member-inits.cpp2"
     t8::t8(t8&& that) noexcept
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               f(1);
               f(2);
               f(3);
               f(4);
               return 5;
           }() }
-        , m2{ [&]() -> cpp2::i32 {
+        , m2{ [&]() -> decltype(auto) {
               f(6);
               f(7);
               return 8;
@@ -731,13 +731,13 @@ auto f(cpp2::in<cpp2::i32> a1) -> void{
 
 #line 137 "pure2-types-smf-statements-between-member-inits.cpp2"
     t9::t9(cpp2::in<cpp2::i32> a1)
-        : m1{ [&]() -> cpp2::i32 {
+        : m1{ [&]() -> decltype(auto) {
               (void) a1;
               f(1);
               f(2);
               return 3;
           }() }
-        , m2{ [&]() -> cpp2::i32 {
+        , m2{ [&]() -> decltype(auto) {
               f(4);
               f(5);
               return 6;

--- a/regression-tests/test-results/pure2-types-smf-statements-between-member-inits.cpp2.output
+++ b/regression-tests/test-results/pure2-types-smf-statements-between-member-inits.cpp2.output
@@ -1,0 +1,2 @@
+pure2-types-smf-statements-between-member-inits.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -4749,28 +4749,23 @@ public:
 
                     //  If there are any pending statements, wedge them into
                     //  this initializer using an immediately invoked lambda
+                    auto& mem_inits = current_functions.back().prolog.mem_inits;
                     if (!pending_statements.empty())
                     {
                         auto object_type = print_to_string( *(*object)->get_object_type() );
-                        auto mem_init = separator + object_name + "{ [&]() -> " + object_type + " { ";
+                        mem_inits.push_back(separator + object_name + "{ [&]() -> " + object_type + " {");
                         for (auto& stmt : pending_statements) {
-                            mem_init += stmt + "; ";
+                            mem_inits.push_back("      " + stmt + ";");
                         }
                         pending_statements.clear();
-                        mem_init += "return " + initializer + "; }() }";
-                        current_functions.back().prolog.mem_inits.push_back(std::move(mem_init));
+                        mem_inits.push_back("      return " + initializer + ";");
+                        mem_inits.push_back("  }() }");
                     }
                     else {
                         if (initializer == "{}") {
                             initializer = "";
                         }
-                        current_functions.back().prolog.mem_inits.push_back(
-                            separator +
-                            object_name +
-                            "{ " +
-                            initializer +
-                            " }"
-                        );
+                        mem_inits.push_back(separator + object_name + "{ " + initializer + " }");
                     }
                     separator = ", ";
                 }

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -4700,7 +4700,7 @@ public:
 
                         //  Flush any pending statements
                         for (auto& stmt : pending_statements) {
-                            current_functions.back().prolog.statements.push_back(stmt);
+                            current_functions.back().prolog.statements.push_back(stmt + ";");
                         }
                         pending_statements.clear();
 
@@ -4754,7 +4754,7 @@ public:
                         auto object_type = print_to_string( *(*object)->get_object_type() );
                         auto mem_init = separator + object_name + "{ [&]() -> " + object_type + " { ";
                         for (auto& stmt : pending_statements) {
-                            mem_init += stmt;
+                            mem_init += stmt + "; ";
                         }
                         pending_statements.clear();
                         mem_init += "return " + initializer + "; }() }";

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -4757,8 +4757,7 @@ public:
                     auto& mem_inits = current_functions.back().prolog.mem_inits;
                     if (!pending_statements.empty())
                     {
-                        auto object_type = print_to_string( *(*object)->get_object_type() );
-                        mem_inits.push_back(separator + object_name + "{ [&]() -> " + object_type + " {");
+                        mem_inits.push_back(separator + object_name + "{ [&]() -> decltype(auto) {");
                         for (auto statement : pending_statements) {
                             mem_inits.push_back(
                                 "      " + print_to_string(*statement, false) + ";"

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -4582,8 +4582,8 @@ public:
                             {
                                 // All the statements before 'this = that' need to be inserted
                                 // before the first member initializer whether or not it's explicit
-                                pending_statements = deferred_statements;
-                                deferred_statements.clear();
+                                assert(pending_statements.empty());
+                                pending_statements.swap(deferred_statements);
 
                                 found_that_init = true;
                                 (*statement)->emitted = true;
@@ -4633,11 +4633,9 @@ public:
                 // If explicit, upgrade deferred statements to pending
                 if (found_explicit_init)
                 {
-                    pending_statements.insert(
-                        pending_statements.end(),
-                        deferred_statements.begin(),
-                        deferred_statements.end()
-                    );
+                    for (auto& stmt : deferred_statements) {
+                        pending_statements.push_back(std::move(stmt));
+                    }
                     deferred_statements.clear();
                 }
 

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -4666,6 +4666,7 @@ public:
                     !found_explicit_init
                     && !found_that_init
                     && !found_default_init
+                    && !n.is_assignment()
                     )
                 {
                     errors.emplace_back(
@@ -4679,6 +4680,7 @@ public:
                     found_explicit_init
                     || found_that_init
                     || found_default_init
+                    || n.is_assignment()
                 );
 
                 //  Emit the initializer...

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -4700,7 +4700,7 @@ public:
 
                         //  Flush any pending statements
                         for (auto& stmt : pending_statements) {
-                            current_functions.back().prolog.statements.push_back(stmt + ";");
+                            current_functions.back().prolog.statements.push_back(stmt);
                         }
                         pending_statements.clear();
 
@@ -4747,16 +4747,17 @@ public:
                             + "_as_base";
                     }
 
-                    //  If there are any pending statements, wedge them into this initializer
-                    //  using (holds nose) an immediately invoked lambda and the comma operator
+                    //  If there are any pending statements, wedge them into
+                    //  this initializer using an immediately invoked lambda
                     if (!pending_statements.empty())
                     {
-                        auto mem_init = separator + object_name + "{([&]{";
+                        auto object_type = print_to_string( *(*object)->get_object_type() );
+                        auto mem_init = separator + object_name + "{ [&]() -> " + object_type + " { ";
                         for (auto& stmt : pending_statements) {
-                            mem_init += stmt + ";";
+                            mem_init += stmt;
                         }
                         pending_statements.clear();
-                        mem_init += "}(), " + initializer + ")}";
+                        mem_init += "return " + initializer + "; }() }";
                         current_functions.back().prolog.mem_inits.push_back(std::move(mem_init));
                     }
                     else {

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -4582,7 +4582,8 @@ public:
                             {
                                 // All the statements before 'this = that' need to be inserted
                                 // before the first member initializer whether or not it's explicit
-                                pending_statements = std::move(deferred_statements);
+                                pending_statements = deferred_statements;
+                                deferred_statements.clear();
 
                                 found_that_init = true;
                                 (*statement)->emitted = true;

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -4633,9 +4633,11 @@ public:
                 // If explicit, upgrade deferred statements to pending
                 if (found_explicit_init)
                 {
-                    for (auto& stmt : deferred_statements) {
-                        pending_statements.push_back(std::move(stmt));
-                    }
+                    pending_statements.insert(
+                        pending_statements.end(),
+                        std::make_move_iterator(deferred_statements.begin()),
+                        std::make_move_iterator(deferred_statements.end())
+                    );
                     deferred_statements.clear();
                 }
 

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -1063,7 +1063,7 @@ auto copyable(meta::type_declaration& t) -> void
         CPP2_UFCS(error, t, "this type is partially copyable/movable - when you provide any of the more-specific operator= signatures, you must also provide the one with the general signature (out this, that); alternatively, consider removing all the operator= functions and let them all be generated for you with default memberwise semantics");
     }
     else {if (!(std::move(smfs).out_this_in_that)) {
-        CPP2_UFCS(require, t, CPP2_UFCS(add_member, t, "operator=: (out this, that) = { }"), 
+        CPP2_UFCS(require, t, CPP2_UFCS(add_member, t, "operator=: (out this, that) = { this = that; }"), 
                    "could not add general operator=:(out this, that)");
     }}
 }

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -597,7 +597,7 @@ copyable: (inout t: meta::type_declaration) =
         t.error( "this type is partially copyable/movable - when you provide any of the more-specific operator= signatures, you must also provide the one with the general signature (out this, that); alternatively, consider removing all the operator= functions and let them all be generated for you with default memberwise semantics" );
     }
     else if !smfs.out_this_in_that {
-        t.require( t.add_member( "operator=: (out this, that) = { }"),
+        t.require( t.add_member( "operator=: (out this, that) = { this = that; }"),
                    "could not add general operator=:(out this, that)");
     }
 }


### PR DESCRIPTION
This is a proposed solution for Issue https://github.com/hsutter/cppfront/issues/475

Instead of allowing only `out` parameter assignments before and between member initializers in special member functions, this change allows _all_ statements. When generating constructors, it uses IIFE's and the comma operator to insert statements in the member initializer list. And when generating assignment operators, it does exactly what you'd expect.

Since statements can now go before or after member initializers, it leads to the question: where do statements go in a function with only implicit member initializers? I came up with the following rules:

1. By default, statements are inserted as late as possible while still maintaining the given order relative to explicit member initializers. This means a function without any explicit member initializers will have its statements inserted after all the implicit initializers.
2. To insert statements before the implicit initializers, add a special `this = that` statement after the leading statements. Note: this only works for functions that include `that` as a parameter. If we want something similiar for functions without `that`, we could add a `this = {}` or `this = default` syntax, but I have a harder time imagining real-world use-cases for that.

This change also makes implicit `this.member = that.member` initialization opt-in. Without an explicit `this = that` statement in the body, `that` functions default to the same default initialization behavior as all the other special member functions. I personally find this more consistent with the rest of the language and less surprising, but I'm open to other ideas. I've updated the `copyable` metatype accordingly.

I've also gotten rid of implicit member assignment in explicit assignment (i.e. `inout this`) operators. The way I see it, if you're writing custom assignment operators, it's because there's something special about your type that can't be described by defaults. Implicit assignment operators (i.e. the ones that get generated alongside constructors when you write `out this`) still assign to every member to match the corresponding constructor, and you can still use `this = that` to opt-in to implicit memberwise copy or move.

This change is a work-in-progress. I'm still working on cleaning up the existing regression tests and adding new tests and will likely find a few more bugs or edge cases I hadn't considered. And if you accept this approach, I need to update the documentation.

One obvious design hole is: what should we do about declarations between initializers? They can't escape the IIFE's in the cpp1 initializer lists, but they're definitely useful in assignment operators (see the example in the linked issue).

Edit: `return` statements before and between member initialzers also raise some interesting questions.