### PR TITLE
perf(io): refactor to not read line beyond the end of "import"

### DIFF
--- a/source/io.h
+++ b/source/io.h
@@ -114,19 +114,22 @@ auto is_preprocessor(
 auto starts_with_import(std::string const& line)
     -> bool
 {
-    auto import_first =
-        std::find_if_not(
-            line.data(),
-            line.data()+line.length(),
-            [](char c) { return std::isspace(c); }
-        );
-    auto import_last =
-        std::find_if(
-            import_first,
-            line.data()+line.length(),
-            [](char c) { return std::isspace(c); }
-        );
-    return std::string_view{import_first, import_last} == "import";
+    auto i = 0;
+
+    //  find first non-whitespace character
+    if (!move_next(line, i, isspace)) {
+        return false;
+    }
+
+    static constexpr auto import_keyword = std::string_view{"import"};
+
+    // the first token must begin with 'import'
+    if (!std::string_view(line).substr(i).starts_with(import_keyword)) {
+        return false;
+    }
+
+    // and not be immediately followed by an _identifier-continue_
+    return !is_identifier_continue(line[i + import_keyword.size()]);
 }
 
 


### PR DESCRIPTION
Implements <https://github.com/hsutter/cppfront/pull/515#issuecomment-1595911187>.
Not a big deal, just optimizes the case where a line starts with a long identifier.

```output
100% tests passed, 0 tests failed out of 668

Total Test time (real) =  92.99 sec

clang-12-libstdc++-e.cpp2... ok (all Cpp1)

real 0.38
user 0.37
sys 0.01
gcc-10-libstdc++-e.cpp2... ok (all Cpp1)

real 0.39
user 0.37
sys 0.01
msvc-msstl-e.cpp2... ok (all Cpp1)

real 0.53
user 0.52
sys 0.01
```