### PR TITLE
fix(parse): requires clause on one-liner and add error when used on non-template

### DIFF
--- a/regression-tests/test-results/pure2-requires-clauses.cpp
+++ b/regression-tests/test-results/pure2-requires-clauses.cpp
@@ -11,8 +11,7 @@
 template<typename T, typename U> 
 
     requires( std::is_same_v<T,int> 
-              && std::is_same_v<U,int> )
-class X;
+              && std::is_same_v<U,int> )class X;
 
 //=== Cpp2 type definitions and function declarations ===========================
 
@@ -21,8 +20,8 @@ class X;
 template<typename T, typename U> 
 
     requires( std::is_same_v<T,int> 
-              && std::is_same_v<U,int> )
-class X {
+              && std::is_same_v<U,int> )class X
+ {
     public: explicit X();
 
     public: X(X const&) = delete; /* No 'that' constructor, suppress copy */

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -5094,7 +5094,7 @@ public:
                 if (n.requires_clause_expression) {
                     printer.print_cpp2("requires( ", n.requires_pos);
                     emit(*n.requires_clause_expression);
-                    printer.print_cpp2(" )\n\n", n.requires_pos);
+                    printer.print_cpp2(" )\n", n.requires_pos);
                 }
 
                 printer.print_cpp2("class ", n.position());

--- a/source/parse.h
+++ b/source/parse.h
@@ -6466,14 +6466,20 @@ private:
         }
 
         //  Next is optionally a requires clause
-        if (curr() == "requires") {
-            if (!n->template_parameters) {
-                error("'requires' only valid for a template");
+        if (curr() == "requires")
+        {
+            if (
+                n->is_type()
+                && !n->template_parameters
+                )
+            {
+                error("'requires' is only valid for a type with a template parameter list");
                 return {};
             }
+
             n->requires_pos = curr().position();
             next();
-            auto e = expression();
+            auto e = logical_or_expression();
             if (!e) {
                 error("'requires' must be followed by an expression");
                 return {};

--- a/source/parse.h
+++ b/source/parse.h
@@ -6467,6 +6467,10 @@ private:
 
         //  Next is optionally a requires clause
         if (curr() == "requires") {
+            if (!n->template_parameters) {
+                error("'requires' only valid for a template");
+                return {};
+            }
             n->requires_pos = curr().position();
             next();
             auto e = expression();


### PR DESCRIPTION
- Add handling of lack of empty line after oneliner.
- Add parsing error when requires is used on non-template

All regression tests pass.

Closes #472 