### PR TITLE
refactor: work around sign conversion warning

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1526,9 +1526,7 @@ struct args_t : std::vector<std::string_view>
 inline auto make_args(int argc, char const* const* argv) -> args_t
 {
     auto ret = args_t{argc, argv};
-    for (auto i = 0; i < argc; ++i) {
-        ret[i] = std::string_view{argv[i]};
-    }
+    std::copy(argv, argv + argc, ret.data());
     return ret;
 }
 


### PR DESCRIPTION
<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 684

Total Test time (real) =  24.78 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
