### PR TITLE
refactor: work around string conversion warning

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -615,7 +615,7 @@ public:
                 *t = T(CPP2_FORWARD(args)...);
             }
             else {
-                Default.expects(!"attempted to copy assign, but copy assignment is not available");
+                Default.expects(false, "attempted to copy assign, but copy assignment is not available");
             }
         }
         else {
@@ -625,7 +625,7 @@ public:
                     dt->value() = T(CPP2_FORWARD(args)...);
                 }
                 else {
-                    Default.expects(!"attempted to copy assign, but copy assignment is not available");
+                    Default.expects(false, "attempted to copy assign, but copy assignment is not available");
                 }
             }
             else {
@@ -642,7 +642,7 @@ public:
                 *t = T{CPP2_FORWARD(args)...};
             }
             else {
-                Default.expects(!"attempted to copy assign, but copy assignment is not available");
+                Default.expects(false, "attempted to copy assign, but copy assignment is not available");
             }
         }
         else {
@@ -652,7 +652,7 @@ public:
                     dt->value() = T{CPP2_FORWARD(args)...};
                 }
                 else {
-                    Default.expects(!"attempted to copy assign, but copy assignment is not available");
+                    Default.expects(false, "attempted to copy assign, but copy assignment is not available");
                 }
             }
             else {


### PR DESCRIPTION
<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 684

Total Test time (real) =  27.69 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
