### PR TITLE
refactor: work around sign compare warning

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -398,15 +398,16 @@ auto assert_not_null(auto&& p CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT) -> declty
 //
 auto assert_in_bounds(auto&& x, auto&& arg CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT) -> decltype(auto)
     requires (std::is_integral_v<CPP2_TYPEOF(arg)> &&
-             requires { std::ssize(x); x[arg]; std::begin(x) + 2; })
+             requires { std::size(x); std::ssize(x); x[arg]; std::begin(x) + 2; })
 {
-    Bounds.expects(0 <= arg && arg < std::ssize(x), "out of bounds access attempt detected" CPP2_SOURCE_LOCATION_ARG);
+    Bounds.expects(0 <= arg && arg < [&]() -> auto {
+        if constexpr (std::is_signed_v<CPP2_TYPEOF(arg)>) { return std::ssize(x); }
+        else { return std::size(x); }
+    }(), "out of bounds access attempt detected" CPP2_SOURCE_LOCATION_ARG);
     return CPP2_FORWARD(x) [ CPP2_FORWARD(arg) ];
 }
 
 auto assert_in_bounds(auto&& x, auto&& arg CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT) -> decltype(auto)
-    requires (!(std::is_integral_v<CPP2_TYPEOF(arg)> &&
-             requires { std::ssize(x); x[arg]; std::begin(x) + 2; }))
 {
     return CPP2_FORWARD(x) [ CPP2_FORWARD(arg) ];
 }


### PR DESCRIPTION
<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 684

Total Test time (real) =  27.16 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
