### PR TITLE
feat: allow authoring module units

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -191,7 +191,7 @@
         // in our -pure-cpp2 "import std;" simulation mode... if you need this,
         // use mixed mode (not -pure-cpp2) and #include all the headers you need
         // including this one
-        // 
+        //
         // #include <execution>
     #endif
 
@@ -464,7 +464,7 @@ template<typename T>
 auto Typeid() -> decltype(auto) {
 #ifdef CPP2_NO_RTTI
     Type.expects(
-        !"'any' dynamic casting is disabled with -fno-rtti", // more likely to appear on console 
+        !"'any' dynamic casting is disabled with -fno-rtti", // more likely to appear on console
          "'any' dynamic casting is disabled with -fno-rtti"  // make message available to hooked handlers
     );
 #else
@@ -854,8 +854,8 @@ auto is( X const& ) -> bool {
 
 template< typename C, typename X >
     requires (
-        ( std::is_base_of_v<X, C> || 
-          ( std::is_polymorphic_v<C> && std::is_polymorphic_v<X>) 
+        ( std::is_base_of_v<X, C> ||
+          ( std::is_polymorphic_v<C> && std::is_polymorphic_v<X>)
         ) && !std::is_same_v<C,X>)
 auto is( X const& x ) -> bool {
     return Dynamic_cast<C const*>(&x) != nullptr;
@@ -863,8 +863,8 @@ auto is( X const& x ) -> bool {
 
 template< typename C, typename X >
     requires (
-        ( std::is_base_of_v<X, C> || 
-          ( std::is_polymorphic_v<C> && std::is_polymorphic_v<X>) 
+        ( std::is_base_of_v<X, C> ||
+          ( std::is_polymorphic_v<C> && std::is_polymorphic_v<X>)
         ) && !std::is_same_v<C,X>)
 auto is( X const* x ) -> bool {
     return Dynamic_cast<C const*>(x) != nullptr;
@@ -1452,7 +1452,7 @@ inline auto to_string(std::string const& s) -> std::string const&
 
 template<typename T>
 inline auto to_string(T const& sv) -> std::string
-    requires (std::is_convertible_v<T, std::string_view> 
+    requires (std::is_convertible_v<T, std::string_view>
               && !std::is_convertible_v<T, const char*>)
 {
     return std::string{sv};

--- a/regression-tests/test-results/pure2-bugfix-for-requires-clause-unbraced-function-initializer.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-requires-clause-unbraced-function-initializer.cpp
@@ -11,7 +11,10 @@
 //=== Cpp2 type definitions and function declarations ===========================
 
 #line 1 "pure2-bugfix-for-requires-clause-unbraced-function-initializer.cpp2"
-template<typename T> auto f() -> void;
+template<typename T> auto f() -> void
+CPP2_REQUIRES (std::regular<T>)
+#line 1 "pure2-bugfix-for-requires-clause-unbraced-function-initializer.cpp2"
+;
 auto main() -> int;
 
 

--- a/source/common.h
+++ b/source/common.h
@@ -48,7 +48,7 @@ struct source_line
 {
     std::string text;
 
-    enum class category { empty, preprocessor, comment, import, cpp1, cpp2, rawstring };
+    enum class category { empty, preprocessor, comment, module_directive, module_declaration, import, cpp1, cpp2, rawstring };
     category cat;
 
     bool all_tokens_are_densely_spaced = true; // to be overridden in lexing if they're not
@@ -73,13 +73,15 @@ struct source_line
         -> std::string
     {
         switch (cat) {
-        break;case category::empty:         return "/*   */ ";
-        break;case category::preprocessor:  return "/* # */ ";
-        break;case category::comment:       return "/* / */ ";
-        break;case category::import:        return "/* i */ ";
-        break;case category::cpp1:          return "/* 1 */ ";
-        break;case category::cpp2:          return "/* 2 */ ";
-        break;case category::rawstring:     return "/* R */ ";
+        break;case category::empty:              return "/*   */ ";
+        break;case category::preprocessor:       return "/* # */ ";
+        break;case category::comment:            return "/* / */ ";
+        break;case category::module_directive:   return "/* m#*/ ";
+        break;case category::module_declaration: return "/* m */ ";
+        break;case category::import:             return "/* i */ ";
+        break;case category::cpp1:               return "/* 1 */ ";
+        break;case category::cpp2:               return "/* 2 */ ";
+        break;case category::rawstring:          return "/* R */ ";
         break;default: assert(!"illegal category"); abort();
         }
     }
@@ -127,7 +129,7 @@ struct string_parts {
 
     string_parts(const std::string& beginseq,
                  const std::string& endseq,
-                 adds_sequences     strateg) 
+                 adds_sequences     strateg)
      : begin_seq{beginseq}
      , end_seq{endseq}
      , strategy{strateg}
@@ -144,16 +146,16 @@ struct string_parts {
     void clear() { parts.clear(); }
 
     auto generate() const -> std::string {
-        
-        if (parts.empty()) { 
-            return (strategy & on_the_beginning ? begin_seq : std::string{}) 
-                 + (strategy & on_the_end ? end_seq : std::string{}); 
+
+        if (parts.empty()) {
+            return (strategy & on_the_beginning ? begin_seq : std::string{})
+                 + (strategy & on_the_end ? end_seq : std::string{});
         }
 
-        auto result = std::visit(begin_visit{begin_seq, strategy}, 
+        auto result = std::visit(begin_visit{begin_seq, strategy},
                                  parts.front());
 
-        if (std::ssize(parts) > 1) { 
+        if (std::ssize(parts) > 1) {
             auto it1 = parts.cbegin();
             auto it2 = parts.cbegin()+1;
             for(;it2 != parts.cend(); ++it1, ++it2) {

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -197,7 +197,7 @@ class positional_printer
     std::vector<comment> const* pcomments       = {}; // Cpp2 comments data
     source const*               psource         = {};
     parser const*               pparser         = {};
-                                                
+
     source_position curr_pos                    = {}; // current (line,col) in output
     lineno_t        generated_pos_line          = {}; // current line in generated output
     int             last_line_indentation       = {};
@@ -1226,7 +1226,7 @@ public:
 
         //---------------------------------------------------------------------
         //  Do lowered file prolog
-        // 
+        //
         //  Only emit extra lines if we actually have Cpp2, because
         //  we want pure-Cpp1 files to pass through with zero changes
         if (source.has_cpp2())
@@ -1284,7 +1284,7 @@ public:
             }
         }
 
-        
+
         //---------------------------------------------------------------------
         //  Do phase1_type_defs_func_decls
         //
@@ -1641,7 +1641,7 @@ public:
         {
             add_move = false;
         }
-    
+
         if (
             emitting_move_that_function
             && *n.identifier == "that"
@@ -2253,7 +2253,7 @@ public:
                     return;
                 } else if (
                     is_literal(tok->type()) || n.expression->expr->is_result_a_temporary_variable()
-                ) 
+                )
                 {
                     errors.emplace_back(
                         n.position(),
@@ -2545,7 +2545,7 @@ public:
     )
         -> bool
     {
-        if (!fun_node) { 
+        if (!fun_node) {
             return false;
         }
         if (addr_cnt > deref_cnt) {
@@ -2572,11 +2572,11 @@ public:
     )
         -> bool
     {
-        if (!type_id_node) { 
+        if (!type_id_node) {
             return false;
         }
         if (addr_cnt > deref_cnt) {
-            return true; 
+            return true;
         }
 
         if ( type_id_node->dereference_of ) {
@@ -2753,7 +2753,7 @@ public:
             {
                 auto& unqual = std::get<id_expression_node::unqualified>(id->id);
                 assert(unqual);
-                //  TODO: Generalize this: 
+                //  TODO: Generalize this:
                 //        - we don't recognize pointer types from Cpp1
                 //        - we don't deduce pointer types from parameter_declaration_list_node
                 if ( is_pointer_declaration(unqual->identifier) ) {
@@ -4817,7 +4817,7 @@ public:
         }
 
         //  If this is a generated declaration (negative source line number),
-        //  add a line break before 
+        //  add a line break before
         if (
             printer.get_phase() == printer.phase2_func_defs
             && n.position().lineno < 1
@@ -4860,6 +4860,8 @@ public:
                     else {
                         printer.print_cpp2("public: ", n.position());
                     }
+                } else if (n.is_export()) {
+                    printer.print_cpp2(to_string(n.access) + " ", n.position());
                 }
 
                 //  Emit template parameters if any
@@ -5014,11 +5016,32 @@ public:
             }
         }
 
+        //  Emit export on forward declaration.
+        if (
+            n.is_export()
+            && n.parent_is_namespace()
+           )
+        {
+            if (
+                printer.get_phase() == printer.phase0_type_decls
+                || (
+                    printer.get_phase() == printer.phase1_type_defs_func_decls
+                    && !n.is_type() // Done in phase 0.
+                    )
+                )
+            {
+                printer.print_cpp2(to_string(n.access) + " ", n.position());
+            }
+        }
         //  In class definitions, emit the explicit access specifier if there
         //  is one, or default to private for data and public for functions
-        if (printer.get_phase() == printer.phase1_type_defs_func_decls)
+        else if (printer.get_phase() == printer.phase1_type_defs_func_decls)
         {
-            if (!n.is_default_access()) {
+            if (
+                !n.is_default_access()
+                && !n.is_export()
+               )
+            {
                 assert (is_in_type);
                 printer.print_cpp2(to_string(n.access) + ": ", n.position());
             }
@@ -5453,7 +5476,7 @@ public:
                             //  A2) This is '(out   this, move that)'
                             //      and no  '(inout this, move that)' was written by the user
                             //  (*) and no  '(inout this,      that)' was written by the user (*)
-                            //  
+                            //
                             //  (*) This third test is to tie-break M2 and A2 in favor of M2. Both M2 and A2
                             //      can generate a missing '(inout this, move that)', and if we have both
                             //      options then we should prefer to use M2 (generate move assignment from

--- a/source/io.h
+++ b/source/io.h
@@ -958,22 +958,25 @@ public:
                 //
                 else
                 {
-                    if (!is_module() && starts_with_tokens(lines.back().text, {"module", ";"})) {
+                    if (starts_with_tokens(lines.back().text, {"module", ";"})) {
                         lines.back().cat = source_line::category::module_directive;
                         module_directive_found = true;
                     }
                     else if (
-                        !is_module()
-                        && (
-                            starts_with_tokens(lines.back().text, {"module"})
-                            || starts_with_tokens(lines.back().text, {"export", "module"})
-                            )
+                        starts_with_tokens(lines.back().text, {"module"})
+                        || starts_with_tokens(lines.back().text, {"export", "module"})
                     ) {
                         lines.back().cat = source_line::category::module_declaration;
                         module_lines = std::ssize(lines);
                     }
-                    else if (starts_with_tokens(lines.back().text, {"import"})) {
+                    else if (
+                        starts_with_tokens(lines.back().text, {"import"})
+                        || starts_with_tokens(lines.back().text, {"export", "import"})
+                    ) {
                         lines.back().cat = source_line::category::import;
+                        if (is_module()) {
+                            module_lines = std::ssize(lines);
+                        }
                     }
                     else {
                         auto stats = process_cpp_line(

--- a/source/io.h
+++ b/source/io.h
@@ -913,6 +913,11 @@ public:
             {
                 lines.push_back({ &buf[0], source_line::category::cpp1 });
 
+                auto starts_with_import = [&](auto& text) {
+                  return starts_with_tokens(text, {"import"})
+                         || starts_with_tokens(text, {"export", "import"});
+                };
+
                 //  Switch to cpp2 mode if we're not in a comment, not inside nested { },
                 //  and the line starts with "nonwhitespace :" but not "::"
                 //
@@ -920,6 +925,7 @@ public:
                     && !in_raw_string_literal
                     && braces.current_depth() < 1
                     && starts_with_identifier_colon(lines.back().text)
+                    && !starts_with_import(lines.back().text) // For a _module-partition_.
                     )
                 {
                     cpp2_found= true;
@@ -969,10 +975,7 @@ public:
                         lines.back().cat = source_line::category::module_declaration;
                         module_lines = std::ssize(lines);
                     }
-                    else if (
-                        starts_with_tokens(lines.back().text, {"import"})
-                        || starts_with_tokens(lines.back().text, {"export", "import"})
-                    ) {
+                    else if (starts_with_import(lines.back().text)) {
                         lines.back().cat = source_line::category::import;
                         if (is_module()) {
                             module_lines = std::ssize(lines);

--- a/source/io.h
+++ b/source/io.h
@@ -962,13 +962,15 @@ public:
                         lines.back().cat = source_line::category::module_directive;
                         module_directive_found = true;
                     }
-                    else if (!is_module() && starts_with_tokens(lines.back().text, {"module"})) {
+                    else if (
+                        !is_module()
+                        && (
+                            starts_with_tokens(lines.back().text, {"module"})
+                            || starts_with_tokens(lines.back().text, {"export", "module"})
+                            )
+                    ) {
                         lines.back().cat = source_line::category::module_declaration;
-                        module_lines = lines.size();
-                    }
-                    else if (!is_module() && starts_with_tokens(lines.back().text, {"export", "module"})) {
-                        lines.back().cat = source_line::category::module_declaration;
-                        module_lines = lines.size();
+                        module_lines = std::ssize(lines);
                     }
                     else if (starts_with_tokens(lines.back().text, {"import"})) {
                         lines.back().cat = source_line::category::import;
@@ -1045,14 +1047,14 @@ public:
         return lines;
     }
 
-    auto get_non_module_lines() const -> std::span<const source_line>
-    {
-      return std::span<const source_line>{lines.begin() + module_lines, lines.end()};
-    }
-
     auto get_module_lines() const -> std::span<const source_line>
     {
-      return std::span<const source_line>{lines.begin(), lines.begin() + module_lines};
+        return {lines.begin(), lines.begin() + module_lines};
+    }
+
+    auto get_non_module_lines() const -> std::span<const source_line>
+    {
+        return {lines.begin() + module_lines, lines.end()};
     }
 
     //-----------------------------------------------------------------------

--- a/source/parse.h
+++ b/source/parse.h
@@ -2234,7 +2234,7 @@ auto to_string(accessibility a)
     break;case accessibility::public_   : return "public";
     break;case accessibility::protected_: return "protected";
     break;case accessibility::private_  : return "private";
-    break;case accessibility::export_  : return "export";
+    break;case accessibility::export_   : return "export";
     break;default: assert(a == accessibility::default_);
     }
     return "default";

--- a/source/sema.h
+++ b/source/sema.h
@@ -1216,7 +1216,19 @@ public:
         }
 
         if (
-            n.access != accessibility::default_
+            n.is_export()
+            && !n.parent_is_namespace()
+            )
+        {
+            errors.emplace_back(
+                n.position(),
+                "an export declaration is only allowed at namespace scope"
+            );
+            return false;
+        }
+        else if (
+            !n.is_export()
+            && !n.is_default_access()
             && !n.parent_is_type()
             )
         {
@@ -1564,7 +1576,7 @@ public:
             //  Skip type scope (member) variables
             && !(n.parent_is_type() && n.is_object())
             //  Skip unnamed variables
-            && n.identifier 
+            && n.identifier
             //  Skip non-out parameters
             && (
                 !inside_parameter_list


### PR DESCRIPTION
Partially addresses #269.

- Emit the module directive, global module fragment, and module declaration at the top.
- Allow exporting declarations.

The above means that module units aren't affected by #470.

I started including an expensive header.
So I isolated the problem to a module.
And timeliness was restored.

Test it on a recent Clang version.

`hello.cpp2`:
```Cpp2
export module hello;
export hello: () -> std::string = "Hello";
```
`main.cpp2`:
```Cpp2
#include <iostream>
import hello;
t: @struct type = {}
main: () = std::cout << hello() << ", modules!\n";
```
Commands:
```bash
cppfront hello.cpp2
cppfront main.cpp2
clang++ -std=c++20 -stdlib=libc++ -fmodules -fbuiltin-module-map -fmodule-output=hello.pcm -I /path/to/cpp2util/ -c -x c++-module hello.cpp
clang++ -std=c++20 -stdlib=libc++ -fmodules -fbuiltin-module-map -fprebuilt-module-path=. -I /path/to/cpp2util/ main.cpp hello.o
./a.out
```
```output
Hello, modules!
```

<details><summary>

`hello.cpp`
</summary>

```C++

module;

#include "cpp2util.h"

export module hello;

//=== Cpp2 type declarations ====================================================



//=== Cpp2 type definitions and function declarations ===========================


#line 2 "hello.cpp2"
export [[nodiscard]] auto hello() -> std::string;


//=== Cpp2 function definitions =================================================


#line 2 "hello.cpp2"
[[nodiscard]] auto hello() -> std::string { return "Hello";  }


```
</details>

<details><summary>

`main.cpp`
</summary>

```C++


#include "cpp2util.h"


//=== Cpp2 type declarations ====================================================


#line 3 "main.cpp2"
class t;


//=== Cpp2 type definitions and function declarations ===========================

#include <iostream>
import hello;
#line 3 "main.cpp2"
class t {};
auto main() -> int;


//=== Cpp2 function definitions =================================================


#line 4 "main.cpp2"
auto main() -> int { std::cout << hello() << ", modules!\n";  }


```
</details>

<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 692

Total Test time (real) =  34.15 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
