### PR TITLE
Implement `sizeof<T>`

### DIFF
--- a/regression-tests/mixed-fixed-type-aliases.cpp2
+++ b/regression-tests/mixed-fixed-type-aliases.cpp2
@@ -1,5 +1,6 @@
 #include <typeinfo>
 #include <iostream>
+#include <cassert>
 
 namespace my {
     using u16 = float;
@@ -13,9 +14,11 @@ test: (x:_) = {
 }
 
 main: (args) -> int = {
+    assert(sizeof<my::u16> == 4);
     y: my::u16 = 42;
     test(y);
 
+    assert(sizeof<u16> == 2);
     z: u16 = 42;
     test(z);
 

--- a/regression-tests/pure2-sizeof-new-error.cpp2
+++ b/regression-tests/pure2-sizeof-new-error.cpp2
@@ -1,0 +1,6 @@
+main: () = {
+    p := new i32;
+    p = new(i32);
+    i := sizeof(i32);
+    i = sizeof i32;
+}

--- a/regression-tests/test-results/mixed-fixed-type-aliases.cpp
+++ b/regression-tests/test-results/mixed-fixed-type-aliases.cpp
@@ -11,23 +11,24 @@
 
 #include <typeinfo>
 #include <iostream>
+#include <cassert>
 
 namespace my {
     using u16 = float;
 }
 
-#line 8 "mixed-fixed-type-aliases.cpp2"
+#line 9 "mixed-fixed-type-aliases.cpp2"
 auto test(auto const& x) -> void;
     
 
-#line 15 "mixed-fixed-type-aliases.cpp2"
+#line 16 "mixed-fixed-type-aliases.cpp2"
 [[nodiscard]] auto main(int const argc_, char const* const* const argv_) -> int;
     
 
 //=== Cpp2 function definitions =================================================
 
 
-#line 8 "mixed-fixed-type-aliases.cpp2"
+#line 9 "mixed-fixed-type-aliases.cpp2"
 auto test(auto const& x) -> void{
     std::cout 
         << std::boolalpha 
@@ -37,10 +38,12 @@ auto test(auto const& x) -> void{
 
 [[nodiscard]] auto main(int const argc_, char const* const* const argv_) -> int{
     auto args = cpp2::make_args(argc_, argv_); 
-#line 16 "mixed-fixed-type-aliases.cpp2"
+#line 17 "mixed-fixed-type-aliases.cpp2"
+    assert(sizeof(my::u16)==4);
     my::u16 y {42}; 
     test(std::move(y));
 
+    assert(sizeof(cpp2::u16)==2);
     cpp2::u16 z {42}; 
     test(std::move(z));
 

--- a/regression-tests/test-results/pure2-sizeof-new-error.cpp2.output
+++ b/regression-tests/test-results/pure2-sizeof-new-error.cpp2.output
@@ -1,0 +1,5 @@
+pure2-sizeof-new-error.cpp2...
+pure2-sizeof-new-error.cpp2(2,14): error: use 'new<i32>', not 'new i32'
+pure2-sizeof-new-error.cpp2(3,12): error: use 'new<i32>', not 'new i32'
+pure2-sizeof-new-error.cpp2(4,16): error: use 'sizeof<i32>', not 'sizeof i32'
+pure2-sizeof-new-error.cpp2(5,16): error: use 'sizeof<i32>', not 'sizeof i32'

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1666,7 +1666,14 @@ public:
         assert(n.identifier);
         emit(*n.identifier, is_qualified);  // inform the identifier if we know this is qualified
 
-        if (n.open_angle != source_position{}) {
+        if (*n.identifier == "sizeof") {
+            printer.print_cpp2("(", n.open_angle);
+            auto& a = n.template_args[0];
+            try_emit<unqualified_id_node::expression>(a.arg);
+            try_emit<unqualified_id_node::type_id   >(a.arg);
+            printer.print_cpp2(")", n.close_angle);
+        }
+        else if (n.open_angle != source_position{}) {
             printer.print_cpp2("<", n.open_angle);
             auto first = true;
             for (auto& a : n.template_args) {

--- a/source/parse.h
+++ b/source/parse.h
@@ -4880,12 +4880,10 @@ private:
         }
 
         else {
-            if (*n->identifier == "new") {
-                error( "use 'new<" + curr().to_string(true) + ">', not 'new " + curr().to_string(true) + "'", false);
-                return {};
-            }
-            if (*n->identifier == "sizeof") {
-                error( "use 'sizeof(" + curr().to_string(true) + ")', not 'sizeof " + curr().to_string(true) + "'", false);
+            if (*n->identifier == "new" || *n->identifier == "sizeof") {
+                auto id = n->identifier->to_string(true);
+                auto& arg = (curr().type() == lexeme::LeftParen) ? *peek(1) : curr();
+                error( "use '" + id + "<" + arg.to_string(true) + ">', not '" + id + " " + arg.to_string(true) + "'", false);
                 return {};
             }
             if (*n->identifier == "co_await" || *n->identifier == "co_yield") {


### PR DESCRIPTION
Fix sizeof/new hints with parentheses.
Fixes #566.