### PR TITLE
fix(cpp1): emit `concept` in Phase 1 "Cpp2 type declarations"

### DIFF
--- a/regression-tests/pure2-concept-definition.cpp2
+++ b/regression-tests/pure2-concept-definition.cpp2
@@ -1,5 +1,7 @@
-arithmetic: <T> concept = std::integral<T> || std::floating_point<T>;
-main: ()                = {
+arithmetic: <T> concept                          = std::integral<T> || std::floating_point<T>;
+t: @struct <T: type> type requires arithmetic<T> = { }
+main: ()                                         = {
   [[assert Testing: arithmetic<i32>]]
   [[assert Testing: arithmetic<float>]]
+  [[assert Testing: !arithmetic<t<i32>>]]
 }

--- a/regression-tests/test-results/pure2-concept-definition.cpp
+++ b/regression-tests/test-results/pure2-concept-definition.cpp
@@ -6,21 +6,26 @@
 
 #include "cpp2util.h"
 
-
+#line 1 "pure2-concept-definition.cpp2"
+template    <typename T> concept arithmetic = std::integral<T> || std::floating_point<T>; 
+template<typename T> requires( arithmetic<T> )
+class t;
 
 //=== Cpp2 type definitions and function declarations ===========================
 
-#line 1 "pure2-concept-definition.cpp2"
-template<typename T> concept arithmetic = std::integral<T> || std::floating_point<T>; 
-auto main() -> int;
+
+#line 2 "pure2-concept-definition.cpp2"
+template<typename T> requires( arithmetic<T> )
+class t {};auto main() -> int;
   
 
 //=== Cpp2 function definitions =================================================
 
 
-#line 2 "pure2-concept-definition.cpp2"
-  auto main() -> int    {
+#line 3 "pure2-concept-definition.cpp2"
+auto main() -> int                               {
   cpp2::Testing.expects(arithmetic<cpp2::i32>, "");
   cpp2::Testing.expects(arithmetic<float>, "");
+  cpp2::Testing.expects(!(arithmetic<t<cpp2::i32>>), "");
 }
 

--- a/regression-tests/test-results/pure2-statement-parse-error.cpp2.output
+++ b/regression-tests/test-results/pure2-statement-parse-error.cpp2.output
@@ -1,3 +1,3 @@
 pure2-statement-parse-error.cpp2...
-pure2-statement-parse-error.cpp2(3,9): error: Could not parse statement (at 'b')
+pure2-statement-parse-error.cpp2(3,9): error: Invalid statement encountered inside a compound-statement (at 'b')
 

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -4862,12 +4862,13 @@ public:
             return;
         }
 
-        //  In phase 0, only need to consider namespaces and types
+        //  In phase 0, only need to consider namespaces, types, and concepts
 
         if (
             printer.get_phase() == printer.phase0_type_decls
             && !n.is_namespace()
             && !n.is_type()
+            && !n.is_concept()
             )
         {
             return;
@@ -5135,7 +5136,7 @@ public:
                 )
             && (
                 !n.is_concept()
-                || printer.get_phase() == printer.phase1_type_defs_func_decls
+                || printer.get_phase() == printer.phase0_type_decls
                 )
             )
         {
@@ -5791,6 +5792,11 @@ public:
             n.is_object()
             && (
                 (
+                    n.is_concept()
+                    && printer.get_phase() == printer.phase0_type_decls
+                    )
+                ||
+                (
                     n.parent_is_namespace()
                     && printer.get_phase() >= printer.phase1_type_defs_func_decls
                     )
@@ -5809,7 +5815,7 @@ public:
         {
             auto& type = std::get<declaration_node::an_object>(n.type);
             if (
-                printer.get_phase() == printer.phase2_func_defs
+                printer.get_phase() != printer.phase0_type_decls
                 && type->is_concept()
                )
             {


### PR DESCRIPTION
This is generally more useful.
Mentioned at <https://github.com/hsutter/cppfront/issues/406#issuecomment-1674203366>.

<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 744

Total Test time (real) =  36.08 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
