### PR TITLE
test: update to test what is intented and clarify with comments

### DIFF
--- a/regression-tests/pure2-bugfix-for-discard-precedence.cpp2
+++ b/regression-tests/pure2-bugfix-for-discard-precedence.cpp2
@@ -1,16 +1,11 @@
 quantity: type = {
   number: i32;
-  operator=: (out this, i: std::in_place_t, x: i32) = {
-    number = x;
-    _      = i;
-  }
-  operator+=: (inout this, that) -> forward quantity = {
-    number += that.number;
-    return this;
-  }
+  operator=: (out this, x: i32) = number    = x;
+  operator+: (inout this, that) -> quantity = quantity(number + that.number);
 }
 
-main: () = {
-  x: quantity = (std::in_place, 1729);
-  x += x;
+main: (args) = {
+  x: quantity = (1729);
+  _           = x + x; // Not `(void) x + x`; would attempt to add a `void` to `x`.
+  _           = args;  // Not `void(args)`; would attempt to declare `args` with `void` type.
 }

--- a/regression-tests/test-results/pure2-bugfix-for-discard-precedence.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-discard-precedence.cpp
@@ -15,41 +15,42 @@ class quantity;
 #line 1 "pure2-bugfix-for-discard-precedence.cpp2"
 class quantity {
   private: cpp2::i32 number; 
-  public: explicit quantity(cpp2::in<std::in_place_t> i, cpp2::in<cpp2::i32> x);
-    
+  public: explicit quantity(cpp2::in<cpp2::i32> x);
+  
+#line 3 "pure2-bugfix-for-discard-precedence.cpp2"
+  public: auto operator=(cpp2::in<cpp2::i32> x) -> quantity& ;
+  public: [[nodiscard]] auto operator+(quantity const& that) -> quantity;
 
-#line 7 "pure2-bugfix-for-discard-precedence.cpp2"
-  public: auto operator+=(quantity const& that) -> quantity&;
-    
   public: quantity(quantity const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(quantity const&) -> void = delete;
-
-
-#line 11 "pure2-bugfix-for-discard-precedence.cpp2"
+#line 5 "pure2-bugfix-for-discard-precedence.cpp2"
 };
 
-auto main() -> int;
+auto main(int const argc_, char const* const* const argv_) -> int;
   
 
 //=== Cpp2 function definitions =================================================
 
 
 #line 3 "pure2-bugfix-for-discard-precedence.cpp2"
-  quantity::quantity(cpp2::in<std::in_place_t> i, cpp2::in<cpp2::i32> x)
-    : number{ x }
+  quantity::quantity(cpp2::in<cpp2::i32> x)
+                                  : number{ x }
 #line 3 "pure2-bugfix-for-discard-precedence.cpp2"
-  {
+                                 {  }
+#line 3 "pure2-bugfix-for-discard-precedence.cpp2"
+  auto quantity::operator=(cpp2::in<cpp2::i32> x) -> quantity&  { 
+                                  number = x;
+                                  return *this;
+#line 3 "pure2-bugfix-for-discard-precedence.cpp2"
+                                 }
+  [[nodiscard]] auto quantity::operator+(quantity const& that) -> quantity { return quantity(number + that.number);  }
 
-    static_cast<void>(i);
-  }
-  auto quantity::operator+=(quantity const& that) -> quantity&{
-    number += that.number;
-    return (*this); 
-  }
-
-#line 13 "pure2-bugfix-for-discard-precedence.cpp2"
-auto main() -> int{
-  quantity x {std::in_place, 1729}; 
-  x += std::move(x);
+#line 7 "pure2-bugfix-for-discard-precedence.cpp2"
+auto main(int const argc_, char const* const* const argv_) -> int{
+  auto args = cpp2::make_args(argc_, argv_); 
+#line 8 "pure2-bugfix-for-discard-precedence.cpp2"
+  quantity x {1729}; 
+  static_cast<void>(x + std::move(x));// Not `(void) x + x`; would attempt to add a `void` to `x`.
+  static_cast<void>(args);// Not `void(args)`; would attempt to declare `args` with `void` type.
 }
 


### PR DESCRIPTION
As pointed out at <https://github.com/hsutter/cppfront/commit/db63152657031bdd127144750a3990b34105d8b9#r124283230> and <https://github.com/hsutter/cppfront/commit/6ce2643e3ae7f91d0b21bc574fc321f7f015a466#r124372924>,
those recent commits did or could change what the test was meant to test.
This PR realigns the test cases with their original intent,
and clarifies with comments the possible implementations it avoids.