### PR TITLE
Improve/update tests

### DIFF
--- a/regression-tests/mixed-fixed-type-aliases.cpp2
+++ b/regression-tests/mixed-fixed-type-aliases.cpp2
@@ -1,5 +1,6 @@
-#include <typeinfo>
+#include <filesystem>
 #include <iostream>
+#include <typeinfo>
 
 namespace my {
     using u16 = float;
@@ -20,5 +21,5 @@ main: (args) -> int = {
     test(z);
 
     for args do (arg)
-        std::cout << arg << "\n";
+        std::cout << std::filesystem::path(arg).filename() << "\n";
 }

--- a/regression-tests/pure2-stdio-with-raii.cpp2
+++ b/regression-tests/pure2-stdio-with-raii.cpp2
@@ -2,7 +2,7 @@
 //  "A better C than C" ... ?
 //
 main: () -> int = {
-    s: std::string = "Freddy";
+    s: std::string = "Fred";
     myfile := cpp2::fopen("xyzzy", "w");
     _ = myfile.fprintf( "Hello %s with UFCS!", s.c_str() );
 }

--- a/regression-tests/test-results/apple-clang-14/mixed-fixed-type-aliases.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-fixed-type-aliases.cpp.execution
@@ -1,3 +1,3 @@
 true
 false
-./test.exe
+"test.exe"

--- a/regression-tests/test-results/apple-clang-14/pure2-main-args.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/pure2-main-args.cpp.execution
@@ -1,1 +1,2 @@
-args.argc is 1, and args.argv[0] is ./test.exe
+args.argc            is 1
+args.argv[0]         is ./test.exe

--- a/regression-tests/test-results/apple-clang-14/pure2-types-basics.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/pure2-types-basics.cpp.execution
@@ -11,7 +11,7 @@ myclass: explicit from string
 myclass: default
     data: 504, more: 3.141590
 myclass: from int and string
-    data: 77, more: hair plugh
+    data: 77, more: hair1 plugh
 x's state before assignments:     data: 1, more: 504
 myclass: implicit from int
     data: 84, more: 504

--- a/regression-tests/test-results/clang-12/mixed-fixed-type-aliases.cpp.execution
+++ b/regression-tests/test-results/clang-12/mixed-fixed-type-aliases.cpp.execution
@@ -1,3 +1,3 @@
 true
 false
-./test.exe
+"test.exe"

--- a/regression-tests/test-results/gcc-13/mixed-fixed-type-aliases.cpp.execution
+++ b/regression-tests/test-results/gcc-13/mixed-fixed-type-aliases.cpp.execution
@@ -1,3 +1,3 @@
 true
 false
-./test.exe
+"test.exe"

--- a/regression-tests/test-results/gcc-13/xyzzy
+++ b/regression-tests/test-results/gcc-13/xyzzy
@@ -1,1 +1,1 @@
-Hello Freddy with UFCS!
+Hello Fred with UFCS!

--- a/regression-tests/test-results/mixed-fixed-type-aliases.cpp
+++ b/regression-tests/test-results/mixed-fixed-type-aliases.cpp
@@ -9,25 +9,26 @@
 
 //=== Cpp2 type definitions and function declarations ===========================
 
-#include <typeinfo>
+#include <filesystem>
 #include <iostream>
+#include <typeinfo>
 
 namespace my {
     using u16 = float;
 }
 
-#line 8 "mixed-fixed-type-aliases.cpp2"
+#line 9 "mixed-fixed-type-aliases.cpp2"
 auto test(auto const& x) -> void;
     
 
-#line 15 "mixed-fixed-type-aliases.cpp2"
+#line 16 "mixed-fixed-type-aliases.cpp2"
 [[nodiscard]] auto main(int const argc_, char** argv_) -> int;
     
 
 //=== Cpp2 function definitions =================================================
 
 
-#line 8 "mixed-fixed-type-aliases.cpp2"
+#line 9 "mixed-fixed-type-aliases.cpp2"
 auto test(auto const& x) -> void{
     std::cout 
         << std::boolalpha 
@@ -37,7 +38,7 @@ auto test(auto const& x) -> void{
 
 [[nodiscard]] auto main(int const argc_, char** argv_) -> int{
     auto args = cpp2::make_args(argc_, argv_); 
-#line 16 "mixed-fixed-type-aliases.cpp2"
+#line 17 "mixed-fixed-type-aliases.cpp2"
     my::u16 y {42}; 
     test(std::move(y));
 
@@ -45,6 +46,6 @@ auto test(auto const& x) -> void{
     test(std::move(z));
 
     for ( auto const& arg : args ) 
-        std::cout << arg << "\n";
+        std::cout << CPP2_UFCS_0(filename, std::filesystem::path(arg)) << "\n";
 }
 

--- a/regression-tests/test-results/msvc-2022/mixed-fixed-type-aliases.cpp.execution
+++ b/regression-tests/test-results/msvc-2022/mixed-fixed-type-aliases.cpp.execution
@@ -1,3 +1,3 @@
 true
 false
-test.exe
+"test.exe"

--- a/regression-tests/test-results/pure2-stdio-with-raii.cpp
+++ b/regression-tests/test-results/pure2-stdio-with-raii.cpp
@@ -22,7 +22,7 @@
 
 #line 4 "pure2-stdio-with-raii.cpp2"
 [[nodiscard]] auto main() -> int{
-    std::string s {"Freddy"}; 
+    std::string s {"Fred"}; 
     auto myfile {cpp2::fopen("xyzzy", "w")}; 
     static_cast<void>(CPP2_UFCS(fprintf, std::move(myfile), "Hello %s with UFCS!", CPP2_UFCS_0(c_str, std::move(s))));
 }


### PR DESCRIPTION
Minor changes/fixes in tests that makes automatic testing a bit easier:

- [mixed-fixed-type-aliases.cpp2](https://github.com/hsutter/cppfront/compare/main...jarzec:update-improve-tests?expand=1#diff-b9cf65fdfe61b48e04bd0fab1ebe1ad6bba24637829349b619c5e2d98b6986d0) - was updated not to depend on the exact command executing the test binary.

- [regression-tests/pure2-stdio-with-raii.cpp2](https://github.com/hsutter/cppfront/compare/main...jarzec:update-improve-tests?expand=1#diff-2f49ebf58c210ae8ebdff000eb131ebac33c53f6add5bf597cce42681bc3f52f) - was updated to make the content of the (commtied) xzyyz file the same for all tests that write into that file. [regression-tests/test-results/gcc-13/xyzzy](https://github.com/hsutter/cppfront/compare/main...jarzec:update-improve-tests?expand=1#diff-2a3b5ceb4dbbcc8d81fbde4368e0ac8cbee50b52279afafefcce5344882276d2) was updated accordingly.

- [pure2-types-basics.cpp.execution](https://github.com/hsutter/cppfront/compare/main...jarzec:update-improve-tests?expand=1#diff-994c62f808ac106428ad7b28e78c1731c50bf227473bbf4f26e924efe324d58b) - was not up to date,

Test results as indicated in [a PR into my regression test CI branch](https://github.com/jarzec/cppfront/pull/6). Some tests are skipped due to compiler issues:
- Ubuntu - none, all used versions of clang and gcc work just fine for all tests; GitHub Ubuntu runners do not have GCC 13 installed (current LTS Ubuntu doesn't provide it), but the available  version 12 works well using `regression-tests/gcc-13/*`.
- macOS - missing support for parts of C++20 in Apple's clang 14.
- Windows - the experimental std modules MSVC package is not installed in on GitHubs's Windows runners.
More details can e found in the outputs of the CI runs.