### PR TITLE
fix(cpp1): emit requires clause of variable template

### DIFF
--- a/regression-tests/pure2-bugfix-for-variable-template-requires-clause.cpp2
+++ b/regression-tests/pure2-bugfix-for-variable-template-requires-clause.cpp2
@@ -1,0 +1,4 @@
+v: <T> const T requires std::same_as<T, i32> = 0;
+
+main: () =
+  static_assert(!std::invocable<decltype(:<T> (_: T) -> std::type_identity_t<decltype(v<T>)> = { return v<T>; }), i16>);

--- a/regression-tests/test-results/clang-18/pure2-bugfix-for-variable-template-requires-clause.cpp.output
+++ b/regression-tests/test-results/clang-18/pure2-bugfix-for-variable-template-requires-clause.cpp.output
@@ -1,4 +1,0 @@
-pure2-bugfix-for-variable-template-requires-clause.cpp2:4:17: error: static assertion failed due to requirement '!(std::invocable<(lambda at /home/johel/tmp/cppfront/Clang-mainDebug/regression-tests/pure2-bugfix-for-variable-template-requires-clause/pure2-bugfix-for-variable-template-requires-clause.cpp2:4:43), short>)'
-    4 |   static_assert(!(std::invocable<decltype([]<typename T>([[maybe_unused]] T const& param1) -> std::type_identity_t<decltype(v<T>)>{return v<T>; }),cpp2::i16>));  }
-      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1 error generated.

--- a/regression-tests/test-results/clang-18/pure2-bugfix-for-variable-template-requires-clause.cpp.output
+++ b/regression-tests/test-results/clang-18/pure2-bugfix-for-variable-template-requires-clause.cpp.output
@@ -1,0 +1,4 @@
+pure2-bugfix-for-variable-template-requires-clause.cpp2:4:17: error: static assertion failed due to requirement '!(std::invocable<(lambda at /home/johel/tmp/cppfront/Clang-mainDebug/regression-tests/pure2-bugfix-for-variable-template-requires-clause/pure2-bugfix-for-variable-template-requires-clause.cpp2:4:43), short>)'
+    4 |   static_assert(!(std::invocable<decltype([]<typename T>([[maybe_unused]] T const& param1) -> std::type_identity_t<decltype(v<T>)>{return v<T>; }),cpp2::i16>));  }
+      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1 error generated.

--- a/regression-tests/test-results/pure2-bugfix-for-variable-template-requires-clause.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-variable-template-requires-clause.cpp
@@ -11,7 +11,10 @@
 //=== Cpp2 type definitions and function declarations ===========================
 
 #line 1 "pure2-bugfix-for-variable-template-requires-clause.cpp2"
-template<typename T> extern T const v;
+template<typename T> 
+CPP2_REQUIRES (std::same_as<T,cpp2::i32>)
+#line 1 "pure2-bugfix-for-variable-template-requires-clause.cpp2"
+extern T const v;
 
 auto main() -> int;
   
@@ -19,7 +22,10 @@ auto main() -> int;
 //=== Cpp2 function definitions =================================================
 
 #line 1 "pure2-bugfix-for-variable-template-requires-clause.cpp2"
-template<typename T> T const v {0}; 
+template<typename T> 
+requires (std::same_as<T,cpp2::i32>)
+#line 1 "pure2-bugfix-for-variable-template-requires-clause.cpp2"
+T const v {0}; 
 
 auto main() -> int { 
   static_assert(!(std::invocable<decltype([]<typename T>([[maybe_unused]] T const& param1) -> std::type_identity_t<decltype(v<T>)>{return v<T>; }),cpp2::i16>));  }

--- a/regression-tests/test-results/pure2-bugfix-for-variable-template-requires-clause.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-variable-template-requires-clause.cpp
@@ -1,0 +1,26 @@
+
+#define CPP2_USE_MODULES         Yes
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-bugfix-for-variable-template-requires-clause.cpp2"
+template<typename T> extern T const v;
+
+auto main() -> int;
+  
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-bugfix-for-variable-template-requires-clause.cpp2"
+template<typename T> T const v {0}; 
+
+auto main() -> int { 
+  static_assert(!(std::invocable<decltype([]<typename T>([[maybe_unused]] T const& param1) -> std::type_identity_t<decltype(v<T>)>{return v<T>; }),cpp2::i16>));  }
+

--- a/regression-tests/test-results/pure2-bugfix-for-variable-template-requires-clause.cpp2.output
+++ b/regression-tests/test-results/pure2-bugfix-for-variable-template-requires-clause.cpp2.output
@@ -1,0 +1,2 @@
+pure2-bugfix-for-variable-template-requires-clause.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -5315,6 +5315,44 @@ public:
             }
         }
 
+
+        auto const emit_requires_clause = [&]() {
+            if (
+                n.requires_clause_expression
+                || !function_requires_conditions.empty()
+                )
+            {
+                printer.print_extra("\n");
+                printer.ignore_alignment( true, n.position().colno + 4 );
+                if (printer.get_phase() == printer.phase1_type_defs_func_decls) {
+                    // Workaround GCC 10 not supporting requires in forward declarations in some cases.
+                    // See commit 5a0d77f8e297902c0b9712c5aafb6208cfa4c139.
+                    printer.print_extra("CPP2_REQUIRES (");
+                }
+                else {
+                    printer.print_extra("requires (");
+                }
+
+                if (n.requires_clause_expression) {
+                    emit(*n.requires_clause_expression);
+                    if (!function_requires_conditions.empty()) {
+                        printer.print_extra(" && ");
+                    }
+                }
+
+                if (!function_requires_conditions.empty()) {
+                    printer.print_extra(function_requires_conditions.front());
+                    for (auto it = std::cbegin(function_requires_conditions)+1; it != std::cend(function_requires_conditions); ++it) {
+                        printer.print_extra(" && " + *it);
+                    }
+                }
+
+                printer.print_extra(")");
+                function_requires_conditions = {};
+                printer.ignore_alignment( false );
+            }
+        };
+
         //  Namespace
         if (n.is_namespace())
         {
@@ -5624,43 +5662,6 @@ public:
                 }
             }
 
-            auto const emit_requires_clause = [&]() {
-                if (
-                    n.requires_clause_expression
-                    || !function_requires_conditions.empty()
-                    )
-                {
-                    printer.print_extra("\n");
-                    printer.ignore_alignment( true, n.position().colno + 4 );
-                    if (printer.get_phase() == printer.phase1_type_defs_func_decls) {
-                        // Workaround GCC 10 not supporting requires in forward declarations in some cases.
-                        // See commit 5a0d77f8e297902c0b9712c5aafb6208cfa4c139.
-                        printer.print_extra("CPP2_REQUIRES (");
-                    }
-                    else {
-                        printer.print_extra("requires (");
-                    }
-
-                    if (n.requires_clause_expression) {
-                        emit(*n.requires_clause_expression);
-                        if (!function_requires_conditions.empty()) {
-                            printer.print_extra(" && ");
-                        }
-                    }
-
-                    if (!function_requires_conditions.empty()) {
-                        printer.print_extra(function_requires_conditions.front());
-                        for (auto it = std::cbegin(function_requires_conditions)+1; it != std::cend(function_requires_conditions); ++it) {
-                            printer.print_extra(" && " + *it);
-                        }
-                    }
-
-                    printer.print_extra(")");
-                    function_requires_conditions = {};
-                    printer.ignore_alignment( false );
-                }
-            };
-
             //  If we're only emitting declarations, end the function declaration
             if (printer.get_phase() == printer.phase1_type_defs_func_decls)
             {
@@ -5833,6 +5834,8 @@ public:
             {
                 return;
             }
+
+            emit_requires_clause();
 
             if (
                 printer.get_phase() != printer.phase2_func_defs


### PR DESCRIPTION
Resolves #606.

<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 760

Total Test time (real) =  50.09 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
