### PR TITLE
Fix cppfront build error due to missing header (closes #659)

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -219,6 +219,7 @@
     #include <iterator>
     #include <concepts>
     #include <system_error>
+    #include <limits>
 
     #ifndef CPP2_NO_EXCEPTIONS
         #include <exception>


### PR DESCRIPTION
Add  missing header file `<limits>` in the else-branch of a conditionally compiled section; the condition being the definition of `CPP2_USE_MODULES`.