### PR TITLE
Add `is` overload for free function predicate

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -894,6 +894,12 @@ inline constexpr auto is( auto const& x, auto const& value ) -> bool
     return false;
 }
 
+// Free function predicate case
+template< typename X >
+constexpr auto is( X const& x, bool (&value)(X const&) ) -> bool
+{
+    return value(x);
+}
 
 //-------------------------------------------------------------------------------------------------------------
 //  Built-in as

--- a/regression-tests/mixed-inspect-values-2.cpp2
+++ b/regression-tests/mixed-inspect-values-2.cpp2
@@ -16,6 +16,10 @@ constexpr auto empty = [](auto&& x){
     return std::empty(x);
 };
 
+auto negative(auto v) {
+    return v < 0;
+}
+
 main: () -> int = {
     i := 15;
 
@@ -31,6 +35,12 @@ main: () -> int = {
 
     if i is (in(10,30)) {
         std::cout << "i is between 10 and 30" << std::endl;
+    }
+
+    if i is (negative) {
+        std::cout << "i is negative" << std::endl;
+    } else {
+        std::cout << "i is not negative" << std::endl;
     }
 
     v : std::vector<int> = ();

--- a/regression-tests/test-results/apple-clang-14/mixed-inspect-values-2.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-inspect-values-2.cpp.execution
@@ -1,5 +1,6 @@
 i is between 11 and 20
 less than 20
 i is between 10 and 30
+i is not negative
 v is empty
 v is empty

--- a/regression-tests/test-results/clang-12/mixed-inspect-values-2.cpp.execution
+++ b/regression-tests/test-results/clang-12/mixed-inspect-values-2.cpp.execution
@@ -1,5 +1,6 @@
 i is between 11 and 20
 less than 20
 i is between 10 and 30
+i is not negative
 v is empty
 v is empty

--- a/regression-tests/test-results/mixed-inspect-values-2.cpp
+++ b/regression-tests/test-results/mixed-inspect-values-2.cpp
@@ -27,14 +27,18 @@ constexpr auto empty = [](auto&& x){
     return std::empty(x);
 };
 
-#line 19 "mixed-inspect-values-2.cpp2"
+auto negative(auto v) {
+    return v < 0;
+}
+
+#line 23 "mixed-inspect-values-2.cpp2"
 [[nodiscard]] auto main() -> int;
     
 
 //=== Cpp2 function definitions =================================================
 
 
-#line 19 "mixed-inspect-values-2.cpp2"
+#line 23 "mixed-inspect-values-2.cpp2"
 [[nodiscard]] auto main() -> int{
     auto i {15}; 
 
@@ -48,8 +52,14 @@ constexpr auto empty = [](auto&& x){
         std::cout << "less than 20" << std::endl;
     }
 
-    if (cpp2::is(std::move(i), (in(10, 30)))) {
+    if (cpp2::is(i, (in(10, 30)))) {
         std::cout << "i is between 10 and 30" << std::endl;
+    }
+
+    if (cpp2::is(std::move(i), (negative))) {
+        std::cout << "i is negative" << std::endl;
+    }else {
+        std::cout << "i is not negative" << std::endl;
     }
 
     std::vector<int> v {}; 


### PR DESCRIPTION
The current implementation of `is` does not handle generic functions as predicates.

The following case works:
```cpp
less_than_10_a: (i : int) -> bool = i < 10;

main: () = {
  12 is (less_than_10_a);
}
```

It works also when the function has a generic return type:
```cpp
less_than_10_b: (i : int) -> _ = i < 10;

main: () = {
  12 is (less_than_10_b);
}
```

But, it does not work when the function has a generic argument. The following case does not work:
```cpp
less_than_10_c: (i) -> _ = i < 10;

main: () = {
  12 is (less_than_10_c); // error
}
```

This change introduces additional overload for `is`, making the free function predicates acceptable by `is` (the function needs to return `bool` or generic type). That makes the following cases work:
```cpp
less_than_10_c: (i) -> _ = i < 10;
less_than_10_d: (i) -> bool = i < 10;

main: () = {
  5 is (less_than_10_c); // works
  2 is (less_than_10_d); // works
}
```

Functions that return other types than `bool` or `auto` do not work.

All regression tests pass. Add a test for this case and update the regression test results.