### PR TITLE
fix: emit requires clause of alias

### DIFF
--- a/regression-tests/pure2-requires-clauses.cpp2
+++ b/regression-tests/pure2-requires-clauses.cpp2
@@ -16,6 +16,8 @@ f:  <T: type, U: type>
 }
 
 v: <T> const T requires std::same_as<T, i32> = 0;
+v2: <T> T requires std::same_as<T, i32> == 0;
+t: <T> type requires std::same_as<T, i32> == T;
 
 main: () = {
     x: X<int,int> = ();

--- a/regression-tests/test-results/clang-18/clang-version.output
+++ b/regression-tests/test-results/clang-18/clang-version.output
@@ -1,4 +1,4 @@
-clang version 18.0.0 (https://git.uplinklabs.net/mirrors/llvm-project.git c0abd3814564a568dfc607c216e6407eaa314f46)
+clang version 18.0.0 (https://github.com/llvm/llvm-project.git 3723ede3cf5324827f8fbbe7f484c2ee4d7a7204)
 Target: x86_64-pc-linux-gnu
 Thread model: posix
 InstalledDir: /home/johel/root/clang-main/bin

--- a/regression-tests/test-results/pure2-requires-clauses.cpp
+++ b/regression-tests/test-results/pure2-requires-clauses.cpp
@@ -41,6 +41,8 @@ template<typename T>
 CPP2_REQUIRES_ (std::same_as<T,cpp2::i32>)
 #line 18 "pure2-requires-clauses.cpp2"
 extern T const v;
+template<typename T> T static constexpr v2 = 0;
+template<typename T> using t = T;
 
 auto main() -> int;
     
@@ -66,6 +68,7 @@ requires (std::same_as<T,cpp2::i32>)
 #line 18 "pure2-requires-clauses.cpp2"
 T const v {0}; 
 
+#line 22 "pure2-requires-clauses.cpp2"
 auto main() -> int{
     X<int,int> x {}; 
     std::cout << f<int,int>(2, 5);

--- a/regression-tests/test-results/pure2-requires-clauses.cpp
+++ b/regression-tests/test-results/pure2-requires-clauses.cpp
@@ -41,8 +41,14 @@ template<typename T>
 CPP2_REQUIRES_ (std::same_as<T,cpp2::i32>)
 #line 18 "pure2-requires-clauses.cpp2"
 extern T const v;
-template<typename T> T static constexpr v2 = 0;
-template<typename T> using t = T;
+template<typename T> 
+CPP2_REQUIRES (std::same_as<T,cpp2::i32>)
+#line 19 "pure2-requires-clauses.cpp2"
+T static constexpr v2 = 0;
+template<typename T> 
+CPP2_REQUIRES (std::same_as<T,cpp2::i32>)
+#line 20 "pure2-requires-clauses.cpp2"
+using t = T;
 
 auto main() -> int;
     

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -5143,9 +5143,9 @@ public:
                 && parent->is_type()
                 )
             {
-                if (parent->requires_clause_expression) {
+                if (parent->requires_clause.expression) {
                     parent_template_parameters =
-                        "requires( " + print_to_string(*parent->requires_clause_expression) + " )\n"
+                        "requires( " + print_to_string(*parent->requires_clause.expression) + " )\n"
                         + parent_template_parameters;
                 }
                 if (parent->template_parameters) {
@@ -5193,10 +5193,10 @@ public:
 
             if (printer.get_phase() != printer.phase2_func_defs)
             {
-                if (n.requires_clause_expression) {
-                    printer.print_cpp2("requires( ", n.requires_pos);
-                    emit(*n.requires_clause_expression);
-                    printer.print_cpp2(" )\n", n.requires_pos);
+                if (n.requires_clause.expression) {
+                    printer.print_cpp2("requires( ", n.requires_clause.pos);
+                    emit(*n.requires_clause.expression);
+                    printer.print_cpp2(" )\n", n.requires_clause.pos);
                 }
 
                 printer.print_cpp2("class ", n.position());
@@ -5341,7 +5341,7 @@ public:
         //  Helper for declarations that can have requires-clauses
         auto const emit_requires_clause = [&]() {
             if (
-                n.requires_clause_expression
+                n.requires_clause.expression
                 || !function_requires_conditions.empty()
                 )
             {
@@ -5361,8 +5361,8 @@ public:
                     printer.print_extra("requires (");
                 }
 
-                if (n.requires_clause_expression) {
-                    emit(*n.requires_clause_expression);
+                if (n.requires_clause.expression) {
+                    emit(*n.requires_clause.expression);
                     if (!function_requires_conditions.empty()) {
                         printer.print_extra(" && ");
                     }

--- a/source/parse.h
+++ b/source/parse.h
@@ -6954,9 +6954,9 @@ private:
 
 
     //G alias
-    //G     ':' template-parameter-declaration-list? 'type' '==' type-id ';'
+    //G     ':' template-parameter-declaration-list? 'type' requires-clause? '==' type-id ';'
     //G     ':' 'namespace' '==' qualified-id ';'
-    //G     ':' template-parameter-declaration-list? type-id? '==' expression ';'
+    //G     ':' template-parameter-declaration-list? type-id? requires-clause? '==' expression ';'
     //G
     //GT     ':' function-type '==' expression ';'
     //GT        # See commit 63efa6ed21c4d4f4f136a7a73e9f6b2c110c81d7 comment
@@ -6991,6 +6991,9 @@ private:
         if (curr() == "type")
         {
             next();
+            if (auto r = requires_clause(*n, false)) {
+                n->requires_clause = std::move(r).value();
+            }
         }
         else if (curr() == "namespace")
         {
@@ -7002,6 +7005,13 @@ private:
                 );
                 return {};
             }
+            if (curr() == "requires") {
+                errors.emplace_back(
+                    curr().position(),
+                    "a namespace or namespace alias cannot have a requires clause"
+                );
+                return {};
+            }
         }
         else if (curr().type() != lexeme::EqualComparison)
         {
@@ -7009,6 +7019,9 @@ private:
             if (!a->type_id) {
                 pos = start_pos;    // backtrack
                 return {};
+            }
+            if (auto r = requires_clause(*n)) {
+                n->requires_clause = std::move(r).value();
             }
         }
 


### PR DESCRIPTION
Resolves #640.

<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 794

Total Test time (real) =  57.00 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
