### PR TITLE
fix(to_cpp1): extend move supression to member access

### DIFF
--- a/regression-tests/mixed-parameter-passing-with-forward.cpp2
+++ b/regression-tests/mixed-parameter-passing-with-forward.cpp2
@@ -14,16 +14,20 @@ parameter_styles: (
     )
 = {
     z: int = 12;
+    y: std::pair = (17, 29);
 
     z++;
+    y.first--;
     b += "plugh";
 
     if std::rand()%2 {
         z++;
+        y.first--;
         copy_from(b);   // definite last use
     }
     else {
         copy_from(b&);  // NB: better not move from this (why not?)
+        copy_from(y.second&);  // Ditto
         copy_from(d);
         copy_from(z++);
         copy_from(e);

--- a/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
@@ -30,7 +30,7 @@ CPP2_REQUIRES (std::is_convertible_v<CPP2_TYPEOF(e), std::add_const_t<std::strin
 #line 8 "mixed-parameter-passing-with-forward.cpp2"
 ;
 
-#line 42 "mixed-parameter-passing-with-forward.cpp2"
+#line 46 "mixed-parameter-passing-with-forward.cpp2"
 [[nodiscard]] auto main() -> int;
 
 //=== Cpp2 function definitions =================================================
@@ -52,16 +52,20 @@ requires (std::is_convertible_v<CPP2_TYPEOF(e), std::add_const_t<std::string>&>)
 #line 15 "mixed-parameter-passing-with-forward.cpp2"
 {
     int z {12}; 
+    std::pair y {17, 29}; 
 
     ++z;
+    --y.first;
     b += "plugh";
 
     if (std::rand() % 2) {
         ++z;
+        --y.first;
         copy_from(cpp2::move(b));// definite last use
     }
     else {
         copy_from(&b);  // NB: better not move from this (why not?)
+        copy_from(&y.second);  // Ditto
         copy_from(cpp2::move(d));
         copy_from(++z);
         copy_from(CPP2_FORWARD(e));
@@ -77,6 +81,6 @@ requires (std::is_convertible_v<CPP2_TYPEOF(e), std::add_const_t<std::string>&>)
 
 }
 
-#line 42 "mixed-parameter-passing-with-forward.cpp2"
+#line 46 "mixed-parameter-passing-with-forward.cpp2"
 [[nodiscard]] auto main() -> int{}
 

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -3592,6 +3592,16 @@ public:
             n.ops.front().op->type() == lexeme::MinusMinus
             || n.ops.front().op->type() == lexeme::PlusPlus
             || n.ops.front().op->type() == lexeme::Ampersand
+            || (
+                std::ssize(n.ops) >= 2
+                && n.ops.front().op->type() == lexeme::Dot
+                &&
+                (
+                    n.ops[1].op->type() == lexeme::MinusMinus
+                    || n.ops[1].op->type() == lexeme::PlusPlus
+                    || n.ops[1].op->type() == lexeme::Ampersand
+                )
+              )
             )
         {
             suppress_move_from_last_use = true;


### PR DESCRIPTION
Resolves #558.

<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 818

Total Test time (real) =  50.70 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
