### PR TITLE
fix(to_cpp1): support initializing assignment from expression list in `operator=`

### DIFF
--- a/regression-tests/pure2-bugfix-for-assign-expression-list.cpp2
+++ b/regression-tests/pure2-bugfix-for-assign-expression-list.cpp2
@@ -1,5 +1,13 @@
+vec: type == std::vector<int>;
+
+my_vec: type = {
+  v: vec = ();
+  operator=: (out this, _: std::integral_constant<int, 0>) = v = ();
+  operator=: (out this, _: std::integral_constant<int, 1>) = v = (1);
+  operator=: (out this, _: std::integral_constant<int, 2>) = v = (2, 3);
+}
+
 main: () = {
-  vec: type == std::vector<int>;
   v: vec              = (0);
   v                   = ();
   assert( v == :vec = () );

--- a/regression-tests/test-results/pure2-bugfix-for-assign-expression-list.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-assign-expression-list.cpp
@@ -8,18 +8,63 @@
 
 #line 1 "pure2-bugfix-for-assign-expression-list.cpp2"
 
+#line 3 "pure2-bugfix-for-assign-expression-list.cpp2"
+class my_vec;
+  
 
 //=== Cpp2 type definitions and function declarations ===========================
 
 #line 1 "pure2-bugfix-for-assign-expression-list.cpp2"
+using vec = std::vector<int>;
+#line 2 "pure2-bugfix-for-assign-expression-list.cpp2"
+
+class my_vec {
+  private: vec v {}; 
+  public: explicit my_vec([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,0>> unnamed_param_2);
+#line 5 "pure2-bugfix-for-assign-expression-list.cpp2"
+  public: auto operator=([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,0>> unnamed_param_2) -> my_vec& ;
+  public: explicit my_vec([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,1>> unnamed_param_2);
+#line 6 "pure2-bugfix-for-assign-expression-list.cpp2"
+  public: auto operator=([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,1>> unnamed_param_2) -> my_vec& ;
+  public: explicit my_vec([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,2>> unnamed_param_2);
+#line 7 "pure2-bugfix-for-assign-expression-list.cpp2"
+  public: auto operator=([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,2>> unnamed_param_2) -> my_vec& ;
+  public: my_vec(my_vec const&) = delete; /* No 'that' constructor, suppress copy */
+  public: auto operator=(my_vec const&) -> void = delete;
+
+#line 8 "pure2-bugfix-for-assign-expression-list.cpp2"
+};
+
 auto main() -> int;
 
 //=== Cpp2 function definitions =================================================
 
 #line 1 "pure2-bugfix-for-assign-expression-list.cpp2"
+
+#line 5 "pure2-bugfix-for-assign-expression-list.cpp2"
+  my_vec::my_vec([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,0>> unnamed_param_2)
+                                                             : v{  } {  }
+#line 5 "pure2-bugfix-for-assign-expression-list.cpp2"
+  auto my_vec::operator=([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,0>> unnamed_param_2) -> my_vec&  { 
+                                                             v = {  };
+                                                             return *this;  }
+#line 6 "pure2-bugfix-for-assign-expression-list.cpp2"
+  my_vec::my_vec([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,1>> unnamed_param_2)
+                                                             : v{ 1 } {  }
+#line 6 "pure2-bugfix-for-assign-expression-list.cpp2"
+  auto my_vec::operator=([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,1>> unnamed_param_2) -> my_vec&  { 
+                                                             v = { 1 };
+                                                             return *this;  }
+#line 7 "pure2-bugfix-for-assign-expression-list.cpp2"
+  my_vec::my_vec([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,2>> unnamed_param_2)
+                                                             : v{ 2, 3 } {  }
+#line 7 "pure2-bugfix-for-assign-expression-list.cpp2"
+  auto my_vec::operator=([[maybe_unused]] cpp2::impl::in<std::integral_constant<int,2>> unnamed_param_2) -> my_vec&  { 
+                                                             v = { 2, 3 };
+                                                             return *this;  }
+
+#line 10 "pure2-bugfix-for-assign-expression-list.cpp2"
 auto main() -> int{
-#line 2 "pure2-bugfix-for-assign-expression-list.cpp2"
-  using vec = std::vector<int>;
   vec v {0}; 
   v                   = {  };
   if (cpp2::cpp2_default.is_active() && !(v == vec{}) ) { cpp2::cpp2_default.report_violation(""); }

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -5451,6 +5451,14 @@ public:
                         if (found_explicit_init)
                         {
                             initializer = rhs;
+                            if (
+                                is_assignment
+                                && std::get<statement_node::expression>((*statement)->statement)
+                                       ->expr->expr->terms[0].expr->is_expression_list()
+                                )
+                            {
+                                initializer = "{ " + rhs + " }";
+                            }
 
                             //  We've used this statement, so note it
                             //  and move 'statement' forward


### PR DESCRIPTION
Resolves #679.

<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 818

Total Test time (real) =  48.87 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
