### PR TITLE
Rework of `is` that adds new functionalities or simplify implementation

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -379,6 +379,11 @@ concept specialization_of_template_type_and_nttp = requires (X x) {
 template <template <typename...> class C>
 concept type_trait = std::derived_from<C<int>, std::true_type> || std::derived_from<C<int>, std::false_type>;
 
+template<typename X>
+concept boolean_testable = std::convertible_to<X, bool> && requires(X&& x) {
+  { !std::forward<X>(x) } -> std::convertible_to<bool>;
+};
+
 template <typename X>
 concept polymorphic = std::is_polymorphic_v<std::remove_cvref_t<X>>;
 
@@ -484,6 +489,66 @@ struct aligned_storage {
     alignas(Align) unsigned char data[Len];
 };
 
+//-----------------------------------------------------------------------
+//
+//  A type_find_if for iterating over types in parameter packs
+//
+//  Note: the current implementation is a workaround for clang-12 internal error.
+//  Original implementation does not need type_it and is implemented
+//  using lambda with explicit parameter type list in the following way:
+//
+//    template <typename... Ts, typename F>
+//    constexpr auto type_find_if(F&& fun)
+//    {
+//        std::size_t found = std::variant_npos;
+//        [&]<std::size_t... Is>(std::index_sequence<Is...>){
+//            if constexpr ((requires { {CPP2_FORWARD(fun).template operator()<Is, Ts>()} -> std::convertible_to<bool>;} && ...)) {
+//                (((CPP2_FORWARD(fun).template operator()<Is, Ts>()) && (found = Is, true)) || ...);
+//            }
+//        }(std::index_sequence_for<Ts...>());
+//        return found;
+//    }
+//
+//  The workaround is not needed in gcc-12.1+, clang-13+, msvc 19.29+
+//
+//  Note2: the internal if constexpr could have else with static_assert.
+//  Unfortunatelly I cannot make it work on MSVC.
+//
+//-----------------------------------------------------------------------
+//
+template <std::size_t Index, typename T>
+struct type_it {
+    using type = T;
+    inline static const std::size_t index = Index;
+};
+
+template <typename... Ts, typename F>
+constexpr auto type_find_if(F&& fun)
+{
+    std::size_t found = std::variant_npos;
+    [&]<std::size_t... Is>(std::index_sequence<Is...>){
+        if constexpr ((requires { {CPP2_FORWARD(fun)(type_it<Is, Ts>{})} -> boolean_testable;} && ...)) {
+            ((CPP2_FORWARD(fun)(type_it<Is, Ts>{}) && (found = Is, true)) || ...);
+        } 
+    }(std::index_sequence_for<Ts...>());
+    return found;
+}
+
+template <typename F, template<typename...> class C, typename... Ts>
+constexpr auto type_find_if(C<Ts...>, F&& fun)
+{
+    return type_find_if<Ts...>(CPP2_FORWARD(fun));
+}
+
+template <typename T, typename... Ts>
+constexpr auto variant_contains_type(std::variant<Ts...>)
+{
+    if constexpr (is_any<T, Ts...>) {
+        return std::true_type{};
+    } else {
+        return std::false_type{};
+    }
+}
 
 //-----------------------------------------------------------------------
 //
@@ -848,6 +913,26 @@ using in =
         T const&
     >;
 
+
+template<class T, class U>
+[[nodiscard]] constexpr auto&& forward_like(U&& x) noexcept
+{
+    constexpr bool is_adding_const = std::is_const_v<std::remove_reference_t<T>>;
+    if constexpr (std::is_lvalue_reference_v<T&&>)
+    {
+        if constexpr (is_adding_const)
+            return std::as_const(x);
+        else
+            return static_cast<U&>(x);
+    }
+    else
+    {
+        if constexpr (is_adding_const)
+            return std::move(std::as_const(x));
+        else
+            return std::move(x);
+    }
+}
 
 //-----------------------------------------------------------------------
 //
@@ -1615,104 +1700,79 @@ constexpr auto operator_as( std::variant<Ts...> const& x ) -> decltype(auto) {
     }
 }
 
-
-//  is Type
+//-------------------------------------------------------------------------------------------------------------
+//  forward declarations needed for recursive calls
 //
-template<typename... Ts>
-constexpr auto operator_is( std::variant<Ts...> const& x ) {
-    return x.index();
-}
 
-template<typename T, typename... Ts>
-auto is( std::variant<Ts...> const& x );
+template<specialization_of_template<std::variant> T, typename C>
+constexpr auto is( T&& x, C&& value );
 
-
-//  is Value
+//  std::variant variable is Template
 //
-template<typename... Ts>
-constexpr auto is( std::variant<Ts...> const& x, auto&& value ) -> bool
-{
-    //  Predicate case
-    if constexpr      (requires{ bool{ value(operator_as< 0>(x)) }; }) { if (x.index() ==  0) return value(operator_as< 0>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as< 1>(x)) }; }) { if (x.index() ==  1) return value(operator_as< 1>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as< 2>(x)) }; }) { if (x.index() ==  2) return value(operator_as< 2>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as< 3>(x)) }; }) { if (x.index() ==  3) return value(operator_as< 3>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as< 4>(x)) }; }) { if (x.index() ==  4) return value(operator_as< 4>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as< 5>(x)) }; }) { if (x.index() ==  5) return value(operator_as< 5>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as< 6>(x)) }; }) { if (x.index() ==  6) return value(operator_as< 6>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as< 7>(x)) }; }) { if (x.index() ==  7) return value(operator_as< 7>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as< 8>(x)) }; }) { if (x.index() ==  8) return value(operator_as< 8>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as< 9>(x)) }; }) { if (x.index() ==  9) return value(operator_as< 9>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<10>(x)) }; }) { if (x.index() == 10) return value(operator_as<10>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<11>(x)) }; }) { if (x.index() == 11) return value(operator_as<11>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<12>(x)) }; }) { if (x.index() == 12) return value(operator_as<12>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<13>(x)) }; }) { if (x.index() == 13) return value(operator_as<13>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<14>(x)) }; }) { if (x.index() == 14) return value(operator_as<14>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<15>(x)) }; }) { if (x.index() == 15) return value(operator_as<15>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<16>(x)) }; }) { if (x.index() == 16) return value(operator_as<16>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<17>(x)) }; }) { if (x.index() == 17) return value(operator_as<17>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<18>(x)) }; }) { if (x.index() == 18) return value(operator_as<18>(x)); }
-    else if constexpr (requires{ bool{ value(operator_as<19>(x)) }; }) { if (x.index() == 19) return value(operator_as<19>(x)); }
-    else if constexpr (std::is_function_v<decltype(value)> || requires{ &value.operator(); }) {
+
+template<template <typename...> class C, specialization_of_template<std::variant> T>
+    requires (!specialization_of_template<T, C>)
+constexpr auto is( T&& x ) {
+    return type_find_if(x, [&]<typename It>(It const&) -> bool {
+        if (x.index() == It::index) { return is<C>(forward_like<T>(std::get<It::index>(x)));}
         return false;
-    }
-
-    //  Value case
-    else {
-        if constexpr (requires{ bool{ operator_as< 0>(x) == value }; }) { if (x.index() ==  0) return operator_as< 0>(x) == value; }
-        if constexpr (requires{ bool{ operator_as< 1>(x) == value }; }) { if (x.index() ==  1) return operator_as< 1>(x) == value; }
-        if constexpr (requires{ bool{ operator_as< 2>(x) == value }; }) { if (x.index() ==  2) return operator_as< 2>(x) == value; }
-        if constexpr (requires{ bool{ operator_as< 3>(x) == value }; }) { if (x.index() ==  3) return operator_as< 3>(x) == value; }
-        if constexpr (requires{ bool{ operator_as< 4>(x) == value }; }) { if (x.index() ==  4) return operator_as< 4>(x) == value; }
-        if constexpr (requires{ bool{ operator_as< 5>(x) == value }; }) { if (x.index() ==  5) return operator_as< 5>(x) == value; }
-        if constexpr (requires{ bool{ operator_as< 6>(x) == value }; }) { if (x.index() ==  6) return operator_as< 6>(x) == value; }
-        if constexpr (requires{ bool{ operator_as< 7>(x) == value }; }) { if (x.index() ==  7) return operator_as< 7>(x) == value; }
-        if constexpr (requires{ bool{ operator_as< 8>(x) == value }; }) { if (x.index() ==  8) return operator_as< 8>(x) == value; }
-        if constexpr (requires{ bool{ operator_as< 9>(x) == value }; }) { if (x.index() ==  9) return operator_as< 9>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<10>(x) == value }; }) { if (x.index() == 10) return operator_as<10>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<11>(x) == value }; }) { if (x.index() == 11) return operator_as<11>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<12>(x) == value }; }) { if (x.index() == 12) return operator_as<12>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<13>(x) == value }; }) { if (x.index() == 13) return operator_as<13>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<14>(x) == value }; }) { if (x.index() == 14) return operator_as<14>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<15>(x) == value }; }) { if (x.index() == 15) return operator_as<15>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<16>(x) == value }; }) { if (x.index() == 16) return operator_as<16>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<17>(x) == value }; }) { if (x.index() == 17) return operator_as<17>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<18>(x) == value }; }) { if (x.index() == 18) return operator_as<18>(x) == value; }
-        if constexpr (requires{ bool{ operator_as<19>(x) == value }; }) { if (x.index() == 19) return operator_as<19>(x) == value; }
-    }
-    return false;
+    }) != std::variant_npos;
 }
 
+template <template <typename...> class C, typename... Ts>
+    requires std::same_as<C<Ts...>, std::variant<Ts...>>
+constexpr auto is( std::variant<Ts...> const& ) -> std::true_type {
+    return {};
+}
 
-//  as
+template<template <typename, auto...> class C, specialization_of_template<std::variant> T>
+constexpr auto is( T&& x ) {
+    return type_find_if(x, [&]<typename It>(It const&) -> bool {
+        if (x.index() == It::index) { return is<C>(forward_like<T>(std::get<It::index>(x)));}
+        return false;
+    }) != std::variant_npos || specialization_of_template_type_and_nttp<T, C>;
+}
+
+//  std::variant variable is Value
 //
-template<typename T, typename... Ts>
-auto is( std::variant<Ts...> const& x ) {
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 0>(x)), T >) { if (x.index() ==  0) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 1>(x)), T >) { if (x.index() ==  1) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 2>(x)), T >) { if (x.index() ==  2) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 3>(x)), T >) { if (x.index() ==  3) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 4>(x)), T >) { if (x.index() ==  4) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 5>(x)), T >) { if (x.index() ==  5) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 6>(x)), T >) { if (x.index() ==  6) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 7>(x)), T >) { if (x.index() ==  7) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 8>(x)), T >) { if (x.index() ==  8) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 9>(x)), T >) { if (x.index() ==  9) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<11>(x)), T >) { if (x.index() == 11) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<12>(x)), T >) { if (x.index() == 12) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<14>(x)), T >) { if (x.index() == 14) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<16>(x)), T >) { if (x.index() == 16) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<17>(x)), T >) { if (x.index() == 17) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<18>(x)), T >) { if (x.index() == 18) return true; }
-    if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<19>(x)), T >) { if (x.index() == 19) return true; }
-    if constexpr (std::is_same_v< T, empty > ) {
-        if (x.valueless_by_exception()) return true;
-        //  Need to guard this with is_any otherwise the get_if is illegal
-        if constexpr (is_any<std::monostate, Ts...>) return std::get_if<std::monostate>(&x) != nullptr;
+
+template<specialization_of_template<std::variant> T, typename C>
+constexpr auto is( T&& x, C&& value ) {
+    if constexpr (std::same_as<T,C>) {
+        return x == value;
+    } else {
+        return type_find_if(x, [&]<typename It>(It const&) -> bool {
+            if (x.index() == It::index) { return is(forward_like<T>(std::get<It::index>(x)), std::forward<C>(value));}
+            return false;
+        }) != std::variant_npos;
     }
+}
+
+//  std::variant variable is Type
+//
+template<specialization_of_template<std::variant> T, specialization_of_template<std::variant> C>
+constexpr auto is( C&& ) {
+    if constexpr (std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<C>>) {
+        return std::true_type{};
+    } else {
+        return std::false_type{};
+    }
+}
+
+template<typename C, specialization_of_template<std::variant> T>
+auto is( T&& x ) {
+    return type_find_if(x, [&]<typename It>(It const&) -> bool {
+        if (x.index() == It::index) { return is<C>(std::get<It::index>(x));}
+        return false;
+    }) != std::variant_npos;
+}
+
+template<std::same_as<empty> C, specialization_of_template<std::variant> T>
+auto is( T&& x ) {
+    if (x.valueless_by_exception())
+        return true;
+    if constexpr (requires { {variant_contains_type<std::monostate>(std::declval<T>())} -> std::same_as<std::true_type>; }) 
+        return std::get_if<std::monostate>(&x) != nullptr;
     return false;
 }
 

--- a/regression-tests/mixed-overview-of-is-inspections.cpp2
+++ b/regression-tests/mixed-overview-of-is-inspections.cpp2
@@ -1,0 +1,327 @@
+int* raw_null = nullptr;
+
+auto expect_throws(auto l) -> bool {
+    try {
+        l();
+    } catch (...) {
+        return true;
+    }
+    return false;
+}
+
+struct ThrowingConstruction {
+    constexpr ThrowingConstruction() = default;
+    ThrowingConstruction(int) { throw 1; }
+};
+
+
+main: () = {
+
+    print_header("type is type");
+    {
+        print("<A> is A", cpp2::is<A,A>(), true);
+        print("<A> is B", cpp2::is<A,B>(), false);
+        print("<A> is C", cpp2::is<A,C>(), false);
+        print("<B> is A", cpp2::is<B,A>(), false);
+        print("<B> is B", cpp2::is<B,B>(), true);
+        print("<B> is C", cpp2::is<B,C>(), false);
+        print("<C> is A", cpp2::is<C,A>(), true);
+        print("<C> is B", cpp2::is<C,B>(), false);
+        print("<C> is C", cpp2::is<C,C>(), true);
+    }
+
+    print_header("type is template");
+    {
+        print("<std::vector<int>> is std::vector", cpp2::is<std::vector<int>,std::vector>(), true);
+        print("<std::vector<int>> is std::array", cpp2::is<std::vector<int>,std::array>(), false);
+        print("<std::vector<int>> is std::optional", cpp2::is<std::vector<int>,std::optional>(), false);
+        print("<std::array<int, 3>> is ", cpp2::is<std::array<int, 3>,std::vector>(), false);
+        print("<std::array<int, 3>> is ", cpp2::is<std::array<int, 3>,std::array>(), true);
+        print("<std::array<int, 3>> is ", cpp2::is<std::array<int, 3>,std::optional>(), false);
+        print("<std::optional<int>> is ", cpp2::is<std::optional<int>,std::vector>(), false);
+        print("<std::optional<int>> is ", cpp2::is<std::optional<int>,std::array>(), false);
+        print("<std::optional<int>> is ", cpp2::is<std::optional<int>,std::optional>(), true);
+    }
+
+    print_header("type is type_trait");
+    {
+        v : std::vector<int> = ();
+        print("<const std::vector<int>> is std::is_const", cpp2::is<const std::vector<int>,std::is_const>(), true);
+        print("<std::vector<int>> is std::is_const", cpp2::is<std::vector<int>,std::is_const>(), false);
+        print("<std::vector<int>&> is std::is_reference", cpp2::is<decltype(v),std::is_reference>(), true);
+    }
+
+    print_header("type is concept");
+    {
+        // requires: clang-13+, gcc-12.1+, msvc-v19.34+
+        print("<int> is std::integral", cpp2::is<int,:<T:std::integral>()={}>(), true);
+        print("<double> is std::integral", cpp2::is<double,:<T:std::integral>()={}>(), false);
+    }
+
+    print_header("variable is template");
+    {
+        v : std::vector = (1, 2, 3);
+        print("v is vector",   v is std::vector, true);
+        print("v is array",    v is std::array,  false);
+        print("v is optional", v is std::optional,  false);
+        a : std::array<int,4> = (4,3,2,1);
+        print("a is array",    a is std::array,  true);
+        print("a is vector",   a is std::vector, false);
+        print("a is optional", a is std::optional,  false);
+        o : std::optional = 42;
+        print("o is array",    o is std::array,  false);
+        print("o is vector",   o is std::vector, false);
+        print("o is optional", o is std::optional,  true);
+
+    }
+
+    print_header("variable is type");
+    {
+        a: A = ();
+        b: B = ();
+        c: C = ();
+        print("a is A", a is A, true);
+        print("b is A", b is A, false);
+        print("c is A", c is A, true);
+    }
+    {
+        vc: VC = ();
+        ptr_va0: *VA<0> = vc&;
+        ptr_va1: *VA<1> = vc&;
+        cptr_va0: * const VA<0> = vc&;
+
+        print("vc is VA<0>", vc is VA<0>, true);
+        print("vc is VA<1>", vc is VA<1>, true);
+        print("vc& is *VA<0>", vc& is *VA<0>, true);
+        print("vc& is *VA<1>", vc& is *VA<1>, true);
+
+        print("ptr_va0 is *VC", ptr_va0 is *VC, true);
+        print("ptr_va1 is *VC", ptr_va1 is *VC, true);
+        print("ptr_va0 is *VA<1>", ptr_va0 is *VA<1>, true);
+        print("ptr_va1 is *VA<0>", ptr_va1 is *VA<0>, true);
+        print("cptr_va0 is *VC", cptr_va0 is *VC, false);
+        print("cptr_va0 is * const VC", cptr_va0 is * const VC, true);
+
+        print("ptr_va0* is VC", ptr_va0* is VC, true);
+        print("ptr_va1* is VC", ptr_va1* is VC, true);
+        print("ptr_va0* is VA<1>", ptr_va0* is VA<1>, true);
+        print("ptr_va1* is VA<0>", ptr_va1* is VA<0>, true);
+        print("cptr_va0* is VC", cptr_va0* is VC, false);
+        print("cptr_va0* is const VC", cptr_va0* is const VC, true);
+    }
+
+    print_header("pointer-like variable is empty");
+    {
+        print("raw_null is empty", raw_null is cpp2::empty, true);
+        print("nullptr is empty", nullptr is cpp2::empty, true);
+        print("shared_ptr() is empty", std::shared_ptr<int>() is cpp2::empty, true);
+        print("unique_ptr() is empty", std::unique_ptr<int>() is cpp2::empty, true);
+
+        i := 42;
+        print("i& is empty", i& is cpp2::empty, false);
+        print("std::make_shared<int>(42) is empty", std::make_shared<int>(42) is cpp2::empty, false);
+        print("std::make_unique<int>(44) is empty", std::make_unique<int>(44) is cpp2::empty, false);
+    }
+
+    print_header("variable is value");
+    {
+        i := 42;
+        print("i{42} is empty", i is cpp2::empty, false);
+        print("i{42} is 24",    i is 24, false);
+        print("i{42} is 42",    i is 42, true);
+        print("i{42} is 42u",   i is 42u, true);
+        print("i{42} is 42L",   i is 42L, true);
+        print("i{42} is 42.0",  i is 42.0, true);
+        print("i{42} is 42.0f", i is 42.0f, true);
+        print("3.14f is 3.14",  3.14f is 3.14, false);
+        close_to := :(v) -> _ = :(x) -> bool = {
+            return std::abs(v$ - x) < std::max<std::common_type_t<std::decay_t<decltype(x)>,std::decay_t<decltype(v$)>>>(std::numeric_limits<std::decay_t<decltype(x)>>::epsilon(), std::numeric_limits<std::decay_t<decltype(v$)>>::epsilon());
+        };
+        print("3.14f is (close_to(3.14 ))",  3.14f is (close_to(3.14 )), true);
+        print("3.14  is (close_to(3.14f))",  3.14  is (close_to(3.14f)), true);
+    }
+
+    print_header("variable is type_trait");
+    {
+        i  : int       = 42;
+        ci : const int = 24;
+
+        print("i{int} is std::is_const",                  i is std::is_const, false);
+        print("ci{const int} is std::is_const",          ci is std::is_const, true);
+        print("ci{const int} is std::is_integral",       ci is std::is_integral, true);
+        print("ci{const int} is std::is_floating_point", ci is std::is_floating_point, false);
+    }
+
+    print_header("variable is predicate");
+    {
+        d := 3.14;
+
+        print("d{3.14} is (:(x) -> bool = x>0;)", d is (:(x) -> bool = x>0;), true);
+        print("d{3.14} is (:(x:int) -> bool = x>0;)", d is (:(x:int) -> bool = x>0;), false);
+        print("d{3.14} is (:(x:std::string) -> bool = x.ssize()>5;)", d is (:(x:std::string) -> bool = x.ssize()>5;), false);
+        print("std::string(\"abcdefg\") is (:(x:std::string) -> bool = x.ssize()>5;)", std::string("abcdefg") is (:(x:std::string) -> bool = x.ssize()>5;), true);
+
+        print("d{3.14} is (pred_i)", d is (pred_i), false);
+        print("d{3.14} is (pred_d)", d is (pred_d), true);
+        print("d{3.14} is (pred_)", true, true);
+
+        print("d{3.14} is (:<T:std::floating_point> () -> _ = true;)", d is (:<T:std::floating_point> () -> _ = true;), true);
+        print("d{3.14} is (:<T:std::floating_point> () = {})", d is (:<T:std::floating_point> () = {}), true);
+        print("d{3.14} is (:<T:std::integral> () = {})", d is (:<T:std::integral> () = {}), false);
+    }
+
+    print_header("variant variable is value");
+    {
+        v : std::variant<int, long, float, double, std::string, std::vector<int>> = (42);
+
+        print("v{42} is 42",   v is 42, true);
+        print("v{42} is int",   v is int, true);
+        print("v{42} is int",   v is double, false);
+        print("v{42} is 42.0", v is 42.0, true);
+        print("v{42} is 24",   v is 24, false);
+        print("v{42} is (std::string(\"hello\"))",   v is (std::string("hello")), false);
+        print("v{42} is std::integral",   v is (:<T:std::integral> () = {}), true);
+        print("v{42} is std::floating_point",   v is (:<T:std::floating_point> () = {}), false);
+
+        v = std::string("hello");
+        print("v{hello} is (std::string(\"hello\"))",   v is (std::string("hello")), true);
+        print("v{hello} is 42",    v is 42, false);
+        print("v{hello} is empty", v is cpp2::empty, false);
+        print("v{hello} is int",   v is int, false);
+        print("v{hello} is std::string",   v is std::string, true);
+
+        v = :std::vector = (1,2,3,4);
+        print("v{std::vector{1,2,3,4}} is std::vector<int>", v is std::vector<int>, true );
+        print("v{std::vector{1,2,3,4}} is std::vector",      v is std::vector,      true );
+        print("v{std::vector{1,2,3,4}} is std::map",         v is std::map,         false);
+        print("v{std::vector{1,2,3,4}} is std::variant",     v is std::variant,     true );
+    }
+
+    print_header("variant variable is empty");
+    {
+        v : std::variant<int, ThrowingConstruction, std::monostate> = ();
+        print("v{int} is empty", v is cpp2::empty, false, "v contains default value of first type");
+
+        v = std::monostate();
+        print("v{monostate} is empty", v is cpp2::empty, true);
+
+        expect_throws(:() = v&$*.emplace<1>(42););
+        print("v{valueless_by_exception} is empty", v is cpp2::empty, true, "is valueless: " + cpp2::to_string(v.valueless_by_exception()));
+
+    }
+
+    print_header("any variable is type");
+    {
+        a : std::any = 42;
+
+        print("a{42} is int", a is int, true);
+        print("a{42} is double", a is double, false);
+        print("a{42} is empty", a is cpp2::empty, false);
+
+        print("std::any() is empty", std::any() is cpp2::empty, true);
+    }
+
+    print_header("any variable is value");
+    {
+        a : std::any = 42;
+
+        print("a{42} is 42",  a is 42,  true);
+        print("a{42} is 24",  a is 24,  false);
+        print("a{42} is 42L", a is 42L, false);
+        print("std::any(3.14) is 3", std::any(3.14) is 3, false);
+
+        print("a{42} is :(v)->bool = v.has_value();", a is :(v)->bool = v.has_value();, true);
+        print("a{42} is :(v:std::any)->bool = v.has_value();", a is :(v:std::any)->bool = v.has_value();, true);
+        print("a{42} is :(v:int)->bool = v>0;", a is :(v:int)->bool = v>0;, true);
+    }
+
+    print_header("optional variable is type");
+    {
+        o : std::optional = 42;
+
+        print("o{42} is int",  o is int,  true);
+        print("o{42} is empty",  o is cpp2::empty,  false);
+        print("std::optional<int>() is empty",  std::optional<int>() is cpp2::empty,  true);
+    }
+
+    print_header("optional variable is value");
+    {
+        o : std::optional = 42;
+
+        print("o{42} is 42",   o is 42,  true);
+        print("o{42} is 24",   o is 24,  false);
+        print("o{42} is 42.0", o is 42.0,  true);
+
+        print("o{42} is :(v) -> bool = v > 0;",   o is :(v) -> bool = v > 0;,  true);
+        print("o{42} is :(v:std::optional<int>) -> bool = v > 0;",   o is :(v:std::optional<int>) -> bool = v > 0;,  true);
+        print("o{42} is :(v:std::optional<long>) -> bool = v > 0;",   o is :(v:std::optional<long>) -> bool = v > 0;,  true);
+        print("std::optional(3.14) is :(v:std::optional<int>) -> bool = v == 3;", std::optional(3.14) is :(v:std::optional<int>) -> bool = v* == 3;,  false);
+    }
+
+}
+
+A: type = {}
+B: type = {}
+C: type = {
+    this: A = ();
+}
+
+VA: @polymorphic_base <I:int> type = {}
+
+VC: type = {
+    this: VA<0>;
+    this: VA<1>;
+}
+
+
+pred_i: (x : int ) -> bool = {
+    return x > 0;
+}
+
+pred_d: (x : double ) -> bool = {
+    return x > 0;
+}
+
+pred_: (x) -> bool = {
+    return x > 0;
+}
+
+col : std::array<int, 5> = (70, 8, 8, 8, 40);
+
+print: (what, value, expected, comment) = {
+    l := :(value) -> std::string = { 
+        if value {
+            return "true";
+        } else {
+            return "false";
+        }
+    };
+    print(what, l(value), l(expected), inspect (value == expected) -> std::string { is (true) = "OK"; is _ = "FAILED!";}, comment );
+}
+
+print: (what, value, expected) = {
+    print(what, value, expected, std::string());
+}
+
+print: (what, value, expected, result, comment) = {
+    std::cout << "|" << std::setw(col[0]) << std::right << what;
+    std::cout << "|" << std::setw(col[1]) << std::internal << value;
+    std::cout << "|" << std::setw(col[2]) << std::internal << expected;
+    std::cout << "|" << std::setw(col[3]) << std::internal <<  result;
+    std::cout << "|" << std::setw(col[4]) << std::left << std::setprecision(20) << comment;
+    std::cout << "|" << std::endl;
+}
+
+print_header: (title) = {
+    std::cout << "\n# (title)$\n\n";
+    print("Test", "Actual", "Expected", "Result", "Comment");
+    print(     std::string(col[0]-1,'-')+":"
+         , ":"+std::string(col[1]-2,'-')+":"
+         , ":"+std::string(col[2]-2,'-')+":"
+         , ":"+std::string(col[3]-2,'-')+":"
+         , ":"+std::string(col[4]-1,'-')
+    );
+}
+
+#include <iomanip>
+#include <map>

--- a/regression-tests/test-results/apple-clang-14/mixed-overview-of-is-inspections.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-overview-of-is-inspections.cpp.execution
@@ -1,0 +1,203 @@
+
+# type is type
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                              <A> is A|    true|    true|      OK|                                        |
+|                                                              <A> is B|   false|   false|      OK|                                        |
+|                                                              <A> is C|   false|   false|      OK|                                        |
+|                                                              <B> is A|   false|   false|      OK|                                        |
+|                                                              <B> is B|    true|    true|      OK|                                        |
+|                                                              <B> is C|   false|   false|      OK|                                        |
+|                                                              <C> is A|    true|    true|      OK|                                        |
+|                                                              <C> is B|   false|   false|      OK|                                        |
+|                                                              <C> is C|    true|    true|      OK|                                        |
+
+# type is template
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                     <std::vector<int>> is std::vector|    true|    true|      OK|                                        |
+|                                      <std::vector<int>> is std::array|   false|   false|      OK|                                        |
+|                                   <std::vector<int>> is std::optional|   false|   false|      OK|                                        |
+|                                              <std::array<int, 3>> is |   false|   false|      OK|                                        |
+|                                              <std::array<int, 3>> is |    true|    true|      OK|                                        |
+|                                              <std::array<int, 3>> is |   false|   false|      OK|                                        |
+|                                              <std::optional<int>> is |   false|   false|      OK|                                        |
+|                                              <std::optional<int>> is |   false|   false|      OK|                                        |
+|                                              <std::optional<int>> is |    true|    true|      OK|                                        |
+
+# type is type_trait
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                             <const std::vector<int>> is std::is_const|    true|    true|      OK|                                        |
+|                                   <std::vector<int>> is std::is_const|   false|   false|      OK|                                        |
+|                              <std::vector<int>&> is std::is_reference|    true|    true|      OK|                                        |
+
+# type is concept
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                <int> is std::integral|    true|    true|      OK|                                        |
+|                                             <double> is std::integral|   false|   false|      OK|                                        |
+
+# variable is template
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                           v is vector|    true|    true|      OK|                                        |
+|                                                            v is array|   false|   false|      OK|                                        |
+|                                                         v is optional|   false|   false|      OK|                                        |
+|                                                            a is array|    true|    true|      OK|                                        |
+|                                                           a is vector|   false|   false|      OK|                                        |
+|                                                         a is optional|   false|   false|      OK|                                        |
+|                                                            o is array|   false|   false|      OK|                                        |
+|                                                           o is vector|   false|   false|      OK|                                        |
+|                                                         o is optional|    true|    true|      OK|                                        |
+
+# variable is type
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                                a is A|    true|    true|      OK|                                        |
+|                                                                b is A|   false|   false|      OK|                                        |
+|                                                                c is A|    true|    true|      OK|                                        |
+|                                                           vc is VA<0>|    true|    true|      OK|                                        |
+|                                                           vc is VA<1>|    true|    true|      OK|                                        |
+|                                                         vc& is *VA<0>|    true|    true|      OK|                                        |
+|                                                         vc& is *VA<1>|    true|    true|      OK|                                        |
+|                                                        ptr_va0 is *VC|    true|    true|      OK|                                        |
+|                                                        ptr_va1 is *VC|    true|    true|      OK|                                        |
+|                                                     ptr_va0 is *VA<1>|    true|    true|      OK|                                        |
+|                                                     ptr_va1 is *VA<0>|    true|    true|      OK|                                        |
+|                                                       cptr_va0 is *VC|   false|   false|      OK|                                        |
+|                                                cptr_va0 is * const VC|    true|    true|      OK|                                        |
+|                                                        ptr_va0* is VC|    true|    true|      OK|                                        |
+|                                                        ptr_va1* is VC|    true|    true|      OK|                                        |
+|                                                     ptr_va0* is VA<1>|    true|    true|      OK|                                        |
+|                                                     ptr_va1* is VA<0>|    true|    true|      OK|                                        |
+|                                                       cptr_va0* is VC|   false|   false|      OK|                                        |
+|                                                 cptr_va0* is const VC|    true|    true|      OK|                                        |
+
+# pointer-like variable is empty
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                     raw_null is empty|    true|    true|      OK|                                        |
+|                                                      nullptr is empty|    true|    true|      OK|                                        |
+|                                                 shared_ptr() is empty|    true|    true|      OK|                                        |
+|                                                 unique_ptr() is empty|    true|    true|      OK|                                        |
+|                                                           i& is empty|   false|   false|      OK|                                        |
+|                                    std::make_shared<int>(42) is empty|   false|   false|      OK|                                        |
+|                                    std::make_unique<int>(44) is empty|   false|   false|      OK|                                        |
+
+# variable is value
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                        i{42} is empty|   false|   false|      OK|                                        |
+|                                                           i{42} is 24|   false|   false|      OK|                                        |
+|                                                           i{42} is 42|    true|    true|      OK|                                        |
+|                                                          i{42} is 42u|    true|    true|      OK|                                        |
+|                                                          i{42} is 42L|    true|    true|      OK|                                        |
+|                                                         i{42} is 42.0|    true|    true|      OK|                                        |
+|                                                        i{42} is 42.0f|    true|    true|      OK|                                        |
+|                                                         3.14f is 3.14|   false|   false|      OK|                                        |
+|                                            3.14f is (close_to(3.14 ))|    true|    true|      OK|                                        |
+|                                            3.14  is (close_to(3.14f))|    true|    true|      OK|                                        |
+
+# variable is type_trait
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                               i{int} is std::is_const|   false|   false|      OK|                                        |
+|                                        ci{const int} is std::is_const|    true|    true|      OK|                                        |
+|                                     ci{const int} is std::is_integral|    true|    true|      OK|                                        |
+|                               ci{const int} is std::is_floating_point|   false|   false|      OK|                                        |
+
+# variable is predicate
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                      d{3.14} is (:(x) -> bool = x>0;)|    true|    true|      OK|                                        |
+|                                  d{3.14} is (:(x:int) -> bool = x>0;)|   false|   false|      OK|                                        |
+|                  d{3.14} is (:(x:std::string) -> bool = x.ssize()>5;)|   false|   false|      OK|                                        |
+|   std::string("abcdefg") is (:(x:std::string) -> bool = x.ssize()>5;)|    true|    true|      OK|                                        |
+|                                                   d{3.14} is (pred_i)|   false|   false|      OK|                                        |
+|                                                   d{3.14} is (pred_d)|    true|    true|      OK|                                        |
+|                                                    d{3.14} is (pred_)|    true|    true|      OK|                                        |
+|                 d{3.14} is (:<T:std::floating_point> () -> _ = true;)|    true|    true|      OK|                                        |
+|                         d{3.14} is (:<T:std::floating_point> () = {})|    true|    true|      OK|                                        |
+|                               d{3.14} is (:<T:std::integral> () = {})|   false|   false|      OK|                                        |
+
+# variant variable is value
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                           v{42} is 42|    true|    true|      OK|                                        |
+|                                                          v{42} is int|    true|    true|      OK|                                        |
+|                                                          v{42} is int|   false|   false|      OK|                                        |
+|                                                         v{42} is 42.0|    true|    true|      OK|                                        |
+|                                                           v{42} is 24|   false|   false|      OK|                                        |
+|                                       v{42} is (std::string("hello"))|   false|   false|      OK|                                        |
+|                                                v{42} is std::integral|    true|    true|      OK|                                        |
+|                                          v{42} is std::floating_point|   false|   false|      OK|                                        |
+|                                    v{hello} is (std::string("hello"))|    true|    true|      OK|                                        |
+|                                                        v{hello} is 42|   false|   false|      OK|                                        |
+|                                                     v{hello} is empty|   false|   false|      OK|                                        |
+|                                                       v{hello} is int|   false|   false|      OK|                                        |
+|                                               v{hello} is std::string|    true|    true|      OK|                                        |
+|                           v{std::vector{1,2,3,4}} is std::vector<int>|    true|    true|      OK|                                        |
+|                                v{std::vector{1,2,3,4}} is std::vector|    true|    true|      OK|                                        |
+|                                   v{std::vector{1,2,3,4}} is std::map|   false|   false|      OK|                                        |
+|                               v{std::vector{1,2,3,4}} is std::variant|    true|    true|      OK|                                        |
+
+# variant variable is empty
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                       v{int} is empty|   false|   false|      OK|v contains default value of first type  |
+|                                                 v{monostate} is empty|    true|    true|      OK|                                        |
+|                                    v{valueless_by_exception} is empty|    true|    true|      OK|is valueless: true                      |
+
+# any variable is type
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                          a{42} is int|    true|    true|      OK|                                        |
+|                                                       a{42} is double|   false|   false|      OK|                                        |
+|                                                        a{42} is empty|   false|   false|      OK|                                        |
+|                                                   std::any() is empty|    true|    true|      OK|                                        |
+
+# any variable is value
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                           a{42} is 42|    true|    true|      OK|                                        |
+|                                                           a{42} is 24|   false|   false|      OK|                                        |
+|                                                          a{42} is 42L|   false|   false|      OK|                                        |
+|                                                   std::any(3.14) is 3|   false|   false|      OK|                                        |
+|                                  a{42} is :(v)->bool = v.has_value();|    true|    true|      OK|                                        |
+|                         a{42} is :(v:std::any)->bool = v.has_value();|    true|    true|      OK|                                        |
+|                                        a{42} is :(v:int)->bool = v>0;|    true|    true|      OK|                                        |
+
+# optional variable is type
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                          o{42} is int|    true|    true|      OK|                                        |
+|                                                        o{42} is empty|   false|   false|      OK|                                        |
+|                                         std::optional<int>() is empty|    true|    true|      OK|                                        |
+
+# optional variable is value
+
+|                                                                  Test|  Actual|Expected|  Result|Comment                                 |
+|---------------------------------------------------------------------:|:------:|:------:|:------:|:---------------------------------------|
+|                                                           o{42} is 42|    true|    true|      OK|                                        |
+|                                                           o{42} is 24|   false|   false|      OK|                                        |
+|                                                         o{42} is 42.0|    true|    true|      OK|                                        |
+|                                        o{42} is :(v) -> bool = v > 0;|    true|    true|      OK|                                        |
+|                     o{42} is :(v:std::optional<int>) -> bool = v > 0;|    true|    true|      OK|                                        |
+|                    o{42} is :(v:std::optional<long>) -> bool = v > 0;|    true|    true|      OK|                                        |
+|      std::optional(3.14) is :(v:std::optional<int>) -> bool = v == 3;|   false|   false|      OK|                                        |

--- a/regression-tests/test-results/mixed-overview-of-is-inspections.cpp
+++ b/regression-tests/test-results/mixed-overview-of-is-inspections.cpp
@@ -1,0 +1,419 @@
+
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "mixed-overview-of-is-inspections.cpp2"
+
+#line 263 "mixed-overview-of-is-inspections.cpp2"
+class A;
+class B;
+class C;
+    
+
+#line 269 "mixed-overview-of-is-inspections.cpp2"
+template<int I> class VA;
+
+class VC;
+    
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "mixed-overview-of-is-inspections.cpp2"
+int* raw_null = nullptr;
+
+auto expect_throws(auto l) -> bool {
+    try {
+        l();
+    } catch (...) {
+        return true;
+    }
+    return false;
+}
+
+struct ThrowingConstruction {
+    constexpr ThrowingConstruction() = default;
+    ThrowingConstruction(int) { throw 1; }
+};
+
+#line 18 "mixed-overview-of-is-inspections.cpp2"
+auto main() -> int;
+
+#line 263 "mixed-overview-of-is-inspections.cpp2"
+class A {
+      public: A() = default;
+      public: A(A const&) = delete; /* No 'that' constructor, suppress copy */
+      public: auto operator=(A const&) -> void = delete;
+};
+#line 264 "mixed-overview-of-is-inspections.cpp2"
+class B {
+      public: B() = default;
+      public: B(B const&) = delete; /* No 'that' constructor, suppress copy */
+      public: auto operator=(B const&) -> void = delete;
+};
+#line 265 "mixed-overview-of-is-inspections.cpp2"
+class C: public A {
+    public: C() = default;
+    public: C(C const&) = delete; /* No 'that' constructor, suppress copy */
+    public: auto operator=(C const&) -> void = delete;
+
+
+#line 267 "mixed-overview-of-is-inspections.cpp2"
+};
+
+template<int I> class VA {
+public: virtual ~VA() noexcept;
+
+      public: VA() = default;
+      public: VA(VA const&) = delete; /* No 'that' constructor, suppress copy */
+      public: auto operator=(VA const&) -> void = delete;
+};
+#line 270 "mixed-overview-of-is-inspections.cpp2"
+
+class VC: public VA<0>, public VA<1> {
+    public: VC() = default;
+    public: VC(VC const&) = delete; /* No 'that' constructor, suppress copy */
+    public: auto operator=(VC const&) -> void = delete;
+
+
+#line 274 "mixed-overview-of-is-inspections.cpp2"
+};
+
+#line 277 "mixed-overview-of-is-inspections.cpp2"
+[[nodiscard]] auto pred_i(cpp2::in<int> x) -> bool;
+
+#line 281 "mixed-overview-of-is-inspections.cpp2"
+[[nodiscard]] auto pred_d(cpp2::in<double> x) -> bool;
+
+#line 285 "mixed-overview-of-is-inspections.cpp2"
+[[nodiscard]] auto pred_(auto const& x) -> bool;
+
+#line 289 "mixed-overview-of-is-inspections.cpp2"
+extern std::array<int,5> col;
+
+auto print(auto const& what, auto const& value, auto const& expected, auto const& comment) -> void;
+
+#line 302 "mixed-overview-of-is-inspections.cpp2"
+auto print(auto const& what, auto const& value, auto const& expected) -> void;
+
+#line 306 "mixed-overview-of-is-inspections.cpp2"
+auto print(auto const& what, auto const& value, auto const& expected, auto const& result, auto const& comment) -> void;
+
+#line 315 "mixed-overview-of-is-inspections.cpp2"
+auto print_header(auto const& title) -> void;
+#line 325 "mixed-overview-of-is-inspections.cpp2"
+
+#include <iomanip>
+#include <map>
+
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "mixed-overview-of-is-inspections.cpp2"
+
+#line 18 "mixed-overview-of-is-inspections.cpp2"
+auto main() -> int{
+
+    print_header("type is type");
+    {
+        print("<A> is A", cpp2::is<A,A>(), true);
+        print("<A> is B", cpp2::is<A,B>(), false);
+        print("<A> is C", cpp2::is<A,C>(), false);
+        print("<B> is A", cpp2::is<B,A>(), false);
+        print("<B> is B", cpp2::is<B,B>(), true);
+        print("<B> is C", cpp2::is<B,C>(), false);
+        print("<C> is A", cpp2::is<C,A>(), true);
+        print("<C> is B", cpp2::is<C,B>(), false);
+        print("<C> is C", cpp2::is<C,C>(), true);
+    }
+
+    print_header("type is template");
+    {
+        print("<std::vector<int>> is std::vector", cpp2::is<std::vector<int>,std::vector>(), true);
+        print("<std::vector<int>> is std::array", cpp2::is<std::vector<int>,std::array>(), false);
+        print("<std::vector<int>> is std::optional", cpp2::is<std::vector<int>,std::optional>(), false);
+        print("<std::array<int, 3>> is ", cpp2::is<std::array<int,3>,std::vector>(), false);
+        print("<std::array<int, 3>> is ", cpp2::is<std::array<int,3>,std::array>(), true);
+        print("<std::array<int, 3>> is ", cpp2::is<std::array<int,3>,std::optional>(), false);
+        print("<std::optional<int>> is ", cpp2::is<std::optional<int>,std::vector>(), false);
+        print("<std::optional<int>> is ", cpp2::is<std::optional<int>,std::array>(), false);
+        print("<std::optional<int>> is ", cpp2::is<std::optional<int>,std::optional>(), true);
+    }
+
+    print_header("type is type_trait");
+    {
+        std::vector<int> v {}; 
+        print("<const std::vector<int>> is std::is_const", cpp2::is<std::vector<int> const,std::is_const>(), true);
+        print("<std::vector<int>> is std::is_const", cpp2::is<std::vector<int>,std::is_const>(), false);
+        print("<std::vector<int>&> is std::is_reference", cpp2::is<decltype(std::move(v)),std::is_reference>(), true);
+    }
+
+    print_header("type is concept");
+    {
+        // requires: clang-13+, gcc-12.1+, msvc-v19.34+
+        print("<int> is std::integral", cpp2::is<int,[]<std::integral T>() mutable -> void{}>(), true);
+        print("<double> is std::integral", cpp2::is<double,[]<std::integral T>() mutable -> void{}>(), false);
+    }
+
+    print_header("variable is template");
+    {
+        std::vector v {1, 2, 3}; 
+        print("v is vector",   cpp2::is<std::vector>(v), true);
+        print("v is array",    cpp2::is<std::array>(v), false);
+        print("v is optional", cpp2::is<std::optional>(std::move(v)), false);
+        std::array<int,4> a {4, 3, 2, 1}; 
+        print("a is array",    cpp2::is<std::array>(a), true);
+        print("a is vector",   cpp2::is<std::vector>(a), false);
+        print("a is optional", cpp2::is<std::optional>(std::move(a)), false);
+        std::optional o {42}; 
+        print("o is array",    cpp2::is<std::array>(o), false);
+        print("o is vector",   cpp2::is<std::vector>(o), false);
+        print("o is optional", cpp2::is<std::optional>(std::move(o)), true);
+
+    }
+
+    print_header("variable is type");
+    {
+        A a {}; 
+        B b {}; 
+        C c {}; 
+        print("a is A", cpp2::is<A>(std::move(a)), true);
+        print("b is A", cpp2::is<A>(std::move(b)), false);
+        print("c is A", cpp2::is<A>(std::move(c)), true);
+    }
+    {
+        VC vc {}; 
+        VA<0>* ptr_va0 {&vc}; 
+        VA<1>* ptr_va1 {&vc}; 
+        VA<0> const* cptr_va0 {&vc}; 
+
+        print("vc is VA<0>", cpp2::is<VA<0>>(vc), true);
+        print("vc is VA<1>", cpp2::is<VA<1>>(vc), true);
+        print("vc& is *VA<0>", cpp2::is<VA<0>*>(&vc), true);
+        print("vc& is *VA<1>", cpp2::is<VA<1>*>(&vc), true);
+
+        print("ptr_va0 is *VC", cpp2::is<VC*>(ptr_va0), true);
+        print("ptr_va1 is *VC", cpp2::is<VC*>(ptr_va1), true);
+        print("ptr_va0 is *VA<1>", cpp2::is<VA<1>*>(ptr_va0), true);
+        print("ptr_va1 is *VA<0>", cpp2::is<VA<0>*>(ptr_va1), true);
+        print("cptr_va0 is *VC", cpp2::is<VC*>(cptr_va0), false);
+        print("cptr_va0 is * const VC", cpp2::is<VC const*>(cptr_va0), true);
+
+        print("ptr_va0* is VC", cpp2::is<VC>(*cpp2::assert_not_null(ptr_va0)), true);
+        print("ptr_va1* is VC", cpp2::is<VC>(*cpp2::assert_not_null(ptr_va1)), true);
+        print("ptr_va0* is VA<1>", cpp2::is<VA<1>>(*cpp2::assert_not_null(std::move(ptr_va0))), true);
+        print("ptr_va1* is VA<0>", cpp2::is<VA<0>>(*cpp2::assert_not_null(std::move(ptr_va1))), true);
+        print("cptr_va0* is VC", cpp2::is<VC>(*cpp2::assert_not_null(cptr_va0)), false);
+        print("cptr_va0* is const VC", cpp2::is<VC const>(*cpp2::assert_not_null(std::move(cptr_va0))), true);
+    }
+
+    print_header("pointer-like variable is empty");
+    {
+        print("raw_null is empty", cpp2::is<cpp2::empty>(raw_null), true);
+        print("nullptr is empty", cpp2::is<cpp2::empty>(nullptr), true);
+        print("shared_ptr() is empty", cpp2::is<cpp2::empty>(std::shared_ptr<int>()), true);
+        print("unique_ptr() is empty", cpp2::is<cpp2::empty>(std::unique_ptr<int>()), true);
+
+        auto i {42}; 
+        print("i& is empty", cpp2::is<cpp2::empty>(&i), false);
+        print("std::make_shared<int>(42) is empty", cpp2::is<cpp2::empty>(std::make_shared<int>(42)), false);
+        print("std::make_unique<int>(44) is empty", cpp2::is<cpp2::empty>(std::make_unique<int>(44)), false);
+    }
+
+    print_header("variable is value");
+    {
+        auto i {42}; 
+        print("i{42} is empty", cpp2::is<cpp2::empty>(i), false);
+        print("i{42} is 24",    cpp2::is(i, 24), false);
+        print("i{42} is 42",    cpp2::is(i, 42), true);
+        print("i{42} is 42u",   cpp2::is(i, 42u), true);
+        print("i{42} is 42L",   cpp2::is(i, 42L), true);
+        print("i{42} is 42.0",  cpp2::is(i, 42.0), true);
+        print("i{42} is 42.0f", cpp2::is(std::move(i), 42.0f), true);
+        print("3.14f is 3.14",  cpp2::is(3.14f, 3.14), false);
+        auto close_to {[](auto const& v) mutable -> auto { return [_0 = v](auto const& x) mutable -> bool{
+            return cpp2::cmp_less(std::abs(_0 - x),std::max<std::common_type_t<std::decay_t<decltype(x)>,std::decay_t<decltype(_0)>>>(std::numeric_limits<std::decay_t<decltype(x)>>::epsilon(), std::numeric_limits<std::decay_t<decltype(_0)>>::epsilon())); 
+        }; }}; 
+        print("3.14f is (close_to(3.14 ))",  cpp2::is(3.14f, (close_to(3.14))), true);
+        print("3.14  is (close_to(3.14f))",  cpp2::is(3.14, (std::move(close_to)(3.14f))), true);
+    }
+
+    print_header("variable is type_trait");
+    {
+        int i {42}; 
+        int const ci {24}; 
+
+        print("i{int} is std::is_const",                  cpp2::is<std::is_const>(std::move(i)), false);
+        print("ci{const int} is std::is_const",          cpp2::is<std::is_const>(ci), true);
+        print("ci{const int} is std::is_integral",       cpp2::is<std::is_integral>(ci), true);
+        print("ci{const int} is std::is_floating_point", cpp2::is<std::is_floating_point>(std::move(ci)), false);
+    }
+
+    print_header("variable is predicate");
+    {
+        auto d {3.14}; 
+
+        print("d{3.14} is (:(x) -> bool = x>0;)", cpp2::is(d, ([](auto const& x) mutable -> bool { return cpp2::cmp_greater(x,0); })), true);
+        print("d{3.14} is (:(x:int) -> bool = x>0;)", cpp2::is(d, ([](cpp2::in<int> x) mutable -> bool { return cpp2::cmp_greater(x,0); })), false);
+        print("d{3.14} is (:(x:std::string) -> bool = x.ssize()>5;)", cpp2::is(d, ([](cpp2::in<std::string> x) mutable -> bool { return cpp2::cmp_greater(CPP2_UFCS(ssize)(x),5); })), false);
+        print("std::string(\"abcdefg\") is (:(x:std::string) -> bool = x.ssize()>5;)", cpp2::is(std::string("abcdefg"), ([](cpp2::in<std::string> x) mutable -> bool { return cpp2::cmp_greater(CPP2_UFCS(ssize)(x),5); })), true);
+
+        print("d{3.14} is (pred_i)", cpp2::is(d, (pred_i)), false);
+        print("d{3.14} is (pred_d)", cpp2::is(d, (pred_d)), true);
+        print("d{3.14} is (pred_)", true, true);
+
+        print("d{3.14} is (:<T:std::floating_point> () -> _ = true;)", cpp2::is(d, ([]<std::floating_point T>() mutable -> auto { return true; })), true);
+        print("d{3.14} is (:<T:std::floating_point> () = {})", cpp2::is(d, ([]<std::floating_point T>() mutable -> void{})), true);
+        print("d{3.14} is (:<T:std::integral> () = {})", cpp2::is(std::move(d), ([]<std::integral T>() mutable -> void{})), false);
+    }
+
+    print_header("variant variable is value");
+    {
+        std::variant<int,long,float,double,std::string,std::vector<int>> v {42}; 
+
+        print("v{42} is 42",   cpp2::is(v, 42), true);
+        print("v{42} is int",   cpp2::is<int>(v), true);
+        print("v{42} is int",   cpp2::is<double>(v), false);
+        print("v{42} is 42.0", cpp2::is(v, 42.0), true);
+        print("v{42} is 24",   cpp2::is(v, 24), false);
+        print("v{42} is (std::string(\"hello\"))",   cpp2::is(v, (std::string("hello"))), false);
+        print("v{42} is std::integral",   cpp2::is(v, ([]<std::integral T>() mutable -> void{})), true);
+        print("v{42} is std::floating_point",   cpp2::is(v, ([]<std::floating_point T>() mutable -> void{})), false);
+
+        v = std::string("hello");
+        print("v{hello} is (std::string(\"hello\"))",   cpp2::is(v, (std::string("hello"))), true);
+        print("v{hello} is 42",    cpp2::is(v, 42), false);
+        print("v{hello} is empty", cpp2::is<cpp2::empty>(v), false);
+        print("v{hello} is int",   cpp2::is<int>(v), false);
+        print("v{hello} is std::string",   cpp2::is<std::string>(v), true);
+
+        v = std::vector{1, 2, 3, 4};
+        print("v{std::vector{1,2,3,4}} is std::vector<int>", cpp2::is<std::vector<int>>(v), true);
+        print("v{std::vector{1,2,3,4}} is std::vector",      cpp2::is<std::vector>(v), true);
+        print("v{std::vector{1,2,3,4}} is std::map",         cpp2::is<std::map>(v), false);
+        print("v{std::vector{1,2,3,4}} is std::variant",     cpp2::is<std::variant>(std::move(v)), true);
+    }
+
+    print_header("variant variable is empty");
+    {
+        std::variant<int,ThrowingConstruction,std::monostate> v {}; 
+        print("v{int} is empty", cpp2::is<cpp2::empty>(v), false, "v contains default value of first type");
+
+        v = std::monostate();
+        print("v{monostate} is empty", cpp2::is<cpp2::empty>(v), true);
+
+        expect_throws([_0 = (&v)]() mutable -> void { CPP2_UFCS_TEMPLATE(emplace<1>)((*cpp2::assert_not_null(_0)), 42);  });
+        print("v{valueless_by_exception} is empty", cpp2::is<cpp2::empty>(v), true, "is valueless: " + cpp2::to_string(CPP2_UFCS(valueless_by_exception)(std::move(v))));
+
+    }
+
+    print_header("any variable is type");
+    {
+        std::any a {42}; 
+
+        print("a{42} is int", cpp2::is<int>(a), true);
+        print("a{42} is double", cpp2::is<double>(a), false);
+        print("a{42} is empty", cpp2::is<cpp2::empty>(std::move(a)), false);
+
+        print("std::any() is empty", cpp2::is<cpp2::empty>(std::any()), true);
+    }
+
+    print_header("any variable is value");
+    {
+        std::any a {42}; 
+
+        print("a{42} is 42",  cpp2::is(a, 42), true);
+        print("a{42} is 24",  cpp2::is(a, 24), false);
+        print("a{42} is 42L", cpp2::is(a, 42L), false);
+        print("std::any(3.14) is 3", cpp2::is(std::any(3.14), 3), false);
+
+        print("a{42} is :(v)->bool = v.has_value();", cpp2::is(a, [](auto const& v) mutable -> bool { return CPP2_UFCS(has_value)(v); }), true);
+        print("a{42} is :(v:std::any)->bool = v.has_value();", cpp2::is(a, [](cpp2::in<std::any> v) mutable -> bool { return CPP2_UFCS(has_value)(v); }), true);
+        print("a{42} is :(v:int)->bool = v>0;", cpp2::is(std::move(a), [](cpp2::in<int> v) mutable -> bool { return cpp2::cmp_greater(v,0); }), true);
+    }
+
+    print_header("optional variable is type");
+    {
+        std::optional o {42}; 
+
+        print("o{42} is int",  cpp2::is<int>(o), true);
+        print("o{42} is empty",  cpp2::is<cpp2::empty>(std::move(o)), false);
+        print("std::optional<int>() is empty",  cpp2::is<cpp2::empty>(std::optional<int>()), true);
+    }
+
+    print_header("optional variable is value");
+    {
+        std::optional o {42}; 
+
+        print("o{42} is 42",   cpp2::is(o, 42), true);
+        print("o{42} is 24",   cpp2::is(o, 24), false);
+        print("o{42} is 42.0", cpp2::is(o, 42.0), true);
+
+        print("o{42} is :(v) -> bool = v > 0;",   cpp2::is(o, [](auto const& v) mutable -> bool { return cpp2::cmp_greater(v,0); }), true);
+        print("o{42} is :(v:std::optional<int>) -> bool = v > 0;",   cpp2::is(o, [](cpp2::in<std::optional<int>> v) mutable -> bool { return cpp2::cmp_greater(v,0); }), true);
+        print("o{42} is :(v:std::optional<long>) -> bool = v > 0;",   cpp2::is(std::move(o), [](cpp2::in<std::optional<long>> v) mutable -> bool { return cpp2::cmp_greater(v,0); }), true);
+        print("std::optional(3.14) is :(v:std::optional<int>) -> bool = v == 3;", cpp2::is(std::optional(3.14), [](cpp2::in<std::optional<int>> v) mutable -> bool { return *cpp2::assert_not_null(v) == 3; }), false);
+    }
+
+}
+
+template <int I> VA<I>::~VA() noexcept{}
+
+#line 277 "mixed-overview-of-is-inspections.cpp2"
+[[nodiscard]] auto pred_i(cpp2::in<int> x) -> bool{
+    return cpp2::cmp_greater(x,0); 
+}
+
+#line 281 "mixed-overview-of-is-inspections.cpp2"
+[[nodiscard]] auto pred_d(cpp2::in<double> x) -> bool{
+    return cpp2::cmp_greater(x,0); 
+}
+
+#line 285 "mixed-overview-of-is-inspections.cpp2"
+[[nodiscard]] auto pred_(auto const& x) -> bool{
+    return cpp2::cmp_greater(x,0); 
+}
+
+std::array<int,5> col {70, 8, 8, 8, 40}; 
+
+#line 291 "mixed-overview-of-is-inspections.cpp2"
+auto print(auto const& what, auto const& value, auto const& expected, auto const& comment) -> void{
+    auto l {[](auto const& value) mutable -> std::string{
+        if (value) {
+            return "true"; 
+        }else {
+            return "false"; 
+        }
+    }}; 
+    print(what, l(value), std::move(l)(expected), [&] () -> std::string { auto&& _expr = (value == expected); if (cpp2::is(_expr, (true))) { if constexpr( requires{"OK";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("OK")),std::string> ) return "OK"; else return std::string{}; else return std::string{}; }else return "FAILED!"; }(), comment);
+}
+
+#line 302 "mixed-overview-of-is-inspections.cpp2"
+auto print(auto const& what, auto const& value, auto const& expected) -> void{
+    print(what, value, expected, std::string());
+}
+
+#line 306 "mixed-overview-of-is-inspections.cpp2"
+auto print(auto const& what, auto const& value, auto const& expected, auto const& result, auto const& comment) -> void{
+    std::cout << "|" << std::setw(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 0)) << std::right << what;
+    std::cout << "|" << std::setw(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 1)) << std::internal << value;
+    std::cout << "|" << std::setw(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 2)) << std::internal << expected;
+    std::cout << "|" << std::setw(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 3)) << std::internal << result;
+    std::cout << "|" << std::setw(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 4)) << std::left << std::setprecision(20) << comment;
+    std::cout << "|" << std::endl;
+}
+
+#line 315 "mixed-overview-of-is-inspections.cpp2"
+auto print_header(auto const& title) -> void{
+    std::cout << ("\n# " + cpp2::to_string(title) + "\n\n");
+    print("Test", "Actual", "Expected", "Result", "Comment");
+    print(     std::string(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 0) - 1, '-') + ":", 
+         ":" + std::string(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 1) - 2, '-') + ":", 
+         ":" + std::string(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 2) - 2, '-') + ":", 
+         ":" + std::string(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 3) - 2, '-') + ":", 
+         ":" + std::string(CPP2_ASSERT_IN_BOUNDS_LITERAL(col, 4) - 1, '-')
+    );
+}
+

--- a/regression-tests/test-results/mixed-overview-of-is-inspections.cpp2.output
+++ b/regression-tests/test-results/mixed-overview-of-is-inspections.cpp2.output
@@ -1,0 +1,2 @@
+mixed-overview-of-is-inspections.cpp2... ok (mixed Cpp1/Cpp2, Cpp2 code passes safety checks)
+


### PR DESCRIPTION
This change reworks a big part of the code for `is`.

* added concepts for simplify and utilize concept subsumption rules,
  * inspired by @JohelEGP - I have learned more here: https://andreasfertig.blog/2020/09/cpp20-concepts-subsumption-rules/
* Added `type_find_if` to iterate over `variant` types to simplify `is` for `variant`,
* rewrite `is` overloads to use `concepts` instead of `type_traits` (to utilize concepts subsumption rules),
* remove `operator_is`, implementation of `is`  for variants now use `type_find_if`,
* `is` that is not using argument `x` for inspection returns `std::true_type` or `std::false_type`
* add many atomic concepts that were used to build complex concepts - that are required for concept subsumption rules,

Closes #689
Closes #669 

Cases handled by the new `is()`:
* type is type,
* type is template,
* type is type_trait,
* type is concept, (no cpp2 syntax)
* variable is template,
* variable is type, (also works for variant, any, optional)
* variable is value, (also works for variant, any, optional)
* variable is empty, (also works for variant, any, optional)
* variable is type_trait,
* variable is predicate, (works also with free function and generic functions; forbids implicit cast of arguments)

# Tests

* All tests pass,
* Added tests that present all use cases handled by this change

# Issue

* does not compile on `macos-11, clang++, c++20` (one of the CI targets)

The original PR contained a rework of `as()` and `to_string()` - they will be provided in separate PRs. 
