### PR TITLE
Allow `inspect` statements

### DIFF
--- a/regression-tests/pure2-inspect-statement.cpp2
+++ b/regression-tests/pure2-inspect-statement.cpp2
@@ -3,7 +3,7 @@ v : std::any = ();
 f: () -> int =
     inspect v {
         is 1 = return 1;
-        is int = return 2;
+        is int = { return 2; }
         is _ = return 3;
     }
 

--- a/regression-tests/pure2-inspect-statement.cpp2
+++ b/regression-tests/pure2-inspect-statement.cpp2
@@ -1,0 +1,18 @@
+v : std::any = ();
+
+f: () -> int =
+    inspect v {
+        is 1 = return 1;
+        is int = return 2;
+        is _ = return 3;
+    }
+
+main: () =
+{
+    v = 1;
+    [[assert: f() == 1]]
+    v = 10;
+    [[assert: f() == 2]]
+    v = true;
+    [[assert: f() == 3]]
+}

--- a/regression-tests/test-results/pure2-inspect-statement.cpp
+++ b/regression-tests/test-results/pure2-inspect-statement.cpp
@@ -25,7 +25,7 @@ std::any v {};
 [[nodiscard]] auto f() -> int
     { auto&& _expr = v;
         if (cpp2::is(_expr, 1)) return 1;
-        else if (cpp2::is<int>(_expr)) return 2;
+        else if (cpp2::is<int>(_expr)) {return 2; }
         else return 3;
     }
 

--- a/regression-tests/test-results/pure2-inspect-statement.cpp
+++ b/regression-tests/test-results/pure2-inspect-statement.cpp
@@ -1,0 +1,41 @@
+
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+extern std::any v;
+
+[[nodiscard]] auto f() -> int;
+    
+
+#line 10 "pure2-inspect-statement.cpp2"
+auto main() -> int;
+
+
+//=== Cpp2 function definitions =================================================
+
+std::any v {}; 
+
+[[nodiscard]] auto f() -> int
+    { auto&& _expr = v;
+        if (cpp2::is(_expr, 1)) return 1;
+        else if (cpp2::is<int>(_expr)) return 2;
+        else return 3;
+    }
+
+auto main() -> int
+{
+    v = 1;
+    cpp2::Default.expects(f() == 1, "");
+    v = 10;
+    cpp2::Default.expects(f() == 2, "");
+    v = true;
+    cpp2::Default.expects(f() == 3, "");
+}
+

--- a/regression-tests/test-results/pure2-inspect-statement.cpp2.output
+++ b/regression-tests/test-results/pure2-inspect-statement.cpp2.output
@@ -1,0 +1,1 @@
+pure2-inspect-statement.cpp2... ok (all Cpp2, passes safety checks)

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1944,6 +1944,7 @@ public:
                 emit(*alt->statement);
                 printer.emit_to_string();
                 //  ... and jettison the final ; for an expression-statement
+                auto return_suffix = std::string{};
                 while (
                     !statement.empty()
                     && (
@@ -1953,6 +1954,7 @@ public:
                     )
                 {
                     statement.pop_back();
+                    return_suffix = ";";   // use this to tack the ; back on in the alternative body
                 }
 
                 replace_all( statement, "cpp2::as_<", "cpp2::as<" );
@@ -1961,7 +1963,6 @@ public:
                 //  in an 'if constexpr' so that its type is ignored for mismatches with
                 //  the inspect-expression's type
                 auto return_prefix = std::string{};
-                auto return_suffix = std::string{";"};   // use this to tack the ; back on in the alternative body
                 if (is_expression) {
                     return_prefix = "{ if constexpr( requires{" + statement + ";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((" + statement + "))," + result_type + "> ) return ";
                     return_suffix += " }";

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -1943,18 +1943,16 @@ public:
                 printer.emit_to_string(&statement);
                 emit(*alt->statement);
                 printer.emit_to_string();
-                //  ... and jettison the final ; for an expression-statement
+                //  ... and jettison any final ; for an expression-statement
                 auto return_suffix = std::string{};
-                while (
-                    !statement.empty()
-                    && (
-                        statement.back() == ';'
-                        || isspace(statement.back())
-                        )
-                    )
+                while (!statement.empty())
                 {
+                    if (statement.back() == ';') {
+                        return_suffix = ';'; // tack the ; back on in the alternative body
+                    } else if (!isspace(statement.back())) {
+                        break;
+                    }
                     statement.pop_back();
-                    return_suffix = ";";   // use this to tack the ; back on in the alternative body
                 }
 
                 replace_all( statement, "cpp2::as_<", "cpp2::as<" );

--- a/source/parse.h
+++ b/source/parse.h
@@ -6770,14 +6770,6 @@ private:
             return {};
         }
 
-        if (!is_expression) {
-            errors.emplace_back(
-                curr().position(),
-                "(temporary alpha limitation) cppfront is still learning 'inspect' - only inspect expressions are currently supported"
-            );
-            return {};
-        }
-
         auto n = std::make_unique<inspect_expression_node>();
         n->identifier = &curr();
         next();


### PR DESCRIPTION
I'm not sure why they were disabled, the test below works.

Update: A small fix was needed to avoid emitting `}; else` Cpp1 when *statement* is a compound statement.