### PR TITLE
Implement `if` alternatives for `inspect`

### DIFF
--- a/regression-tests/mixed-inspect-values.cpp2
+++ b/regression-tests/mixed-inspect-values.cpp2
@@ -26,6 +26,7 @@ main: ()->int = {
     test(-42);
     test("xyzzy" as std::string);
     test(3.14);
+    test("");
 }
 
 test: (x:_) = {
@@ -37,6 +38,7 @@ test: (x:_) = {
         is (forty_two) = "the answer";
         is int         = "integer " + cpp2::to_string(x);
         is std::string = x as std::string;
+        if x is std::optional = "an optional";
         is _           = "(no match)";
     } << "\n";
 }

--- a/regression-tests/test-results/mixed-inspect-values.cpp
+++ b/regression-tests/test-results/mixed-inspect-values.cpp
@@ -19,7 +19,7 @@ auto in(int min, int max) {
 [[nodiscard]] auto main() -> int;
     
 
-#line 31 "mixed-inspect-values.cpp2"
+#line 32 "mixed-inspect-values.cpp2"
 auto test(auto const& x) -> void;
     
 
@@ -51,6 +51,7 @@ auto test(auto const& x) -> void;
     test(-42);
     test(cpp2::as_<std::string>("xyzzy"));
     test(3.14);
+    test("");
 }
 
 auto test(auto const& x) -> void{
@@ -62,6 +63,7 @@ auto test(auto const& x) -> void{
         else if (cpp2::is(_expr, std::move(forty_two))) { if constexpr( requires{"the answer";} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("the answer")),std::string> ) return "the answer"; else return std::string{}; else return std::string{}; }
         else if (cpp2::is<int>(_expr)) { if constexpr( requires{"integer " + cpp2::to_string(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF(("integer " + cpp2::to_string(x))),std::string> ) return "integer " + cpp2::to_string(x); else return std::string{}; else return std::string{}; }
         else if (cpp2::is<std::string>(_expr)) { if constexpr( requires{cpp2::as<std::string>(x);} ) if constexpr( std::is_convertible_v<CPP2_TYPEOF((cpp2::as<std::string>(x))),std::string> ) return cpp2::as<std::string>(x); else return std::string{}; else return std::string{}; }
+        else if (cpp2::is<std::optional>(x)) return "an optional";
         else return "(no match)"; }
     () << "\n";
 }


### PR DESCRIPTION
Implement another kind of *alternative*:
`if` *logical-or-expression* `=` *statement*

See section 3.1 of https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2392r0.pdf.

Note: Part of the `cppfront.cpp` diff is just an unindent, so it helps to ignore whitespace changes.