### PR TITLE
reserve `identifier is` for *type-id* `is`

### DIFF
--- a/regression-tests/mixed-inspect-templates.cpp2
+++ b/regression-tests/mixed-inspect-templates.cpp2
@@ -16,10 +16,10 @@ fun: (v : _) -> std::string = {
 }
 
 fun2: (v : _) -> std::string = {
-    if v is std::vector  { return "std::vector";  }
-    if v is std::array   { return "std::array";   }
-    if v is std::variant { return "std::variant"; }
-    if v is my_type      { return "my_type";      }
+    if (v) is std::vector  { return "std::vector";  }
+    if (v) is std::array   { return "std::array";   }
+    if (v) is std::variant { return "std::variant"; }
+    if (v) is my_type      { return "my_type";      }
     return "unknown";
 }
 

--- a/regression-tests/mixed-inspect-values-2.cpp2
+++ b/regression-tests/mixed-inspect-values-2.cpp2
@@ -25,11 +25,11 @@ main: () -> int = {
         is _ = "i is out of our interest";
     } << std::endl;
 
-    if i is (less_than(20)) {
+    if (i) is (less_than(20)) {
         std::cout << "less than 20" << std::endl;
     }
 
-    if i is (in(10,30)) {
+    if (i) is (in(10,30)) {
         std::cout << "i is between 10 and 30" << std::endl;
     }
 
@@ -39,7 +39,7 @@ main: () -> int = {
         std::cout << "v is empty" << std::endl;
     }
 
-    if v is (empty) {
+    if (v) is (empty) {
         std::cout << "v is empty" << std::endl;
     }
 }

--- a/regression-tests/pure2-enum.cpp2
+++ b/regression-tests/pure2-enum.cpp2
@@ -49,7 +49,7 @@ main: () = {
     else if skat_game::hearts == x {    // ok, in either order
         std::cout << "hearts";
     }
-    else if x is (skat_game::spades) {  // ok, using is
+    else if (x) is (skat_game::spades) {  // ok, using is
         std::cout << "spades";
     }
     else if skat_game::clubs is (x) {   // ok, using is
@@ -95,8 +95,8 @@ main: () = {
     std::cout << "f. get_raw_value() is (f. get_raw_value())$\n";
     std::cout << "f2.get_raw_value() is (f2.get_raw_value())$\n";
 
-    std::cout << "f  is (f2) is (f  is (f2))$\n";
-    std::cout << "f2 is (f ) is (f2 is (f ))$\n\n";
+    std::cout << "(f ) is (f2) is ((f ) is (f2))$\n";
+    std::cout << "(f2) is (f ) is ((f2) is (f ))$\n\n";
 
     f.clear( f2 );
     f.set( file_attributes::current | f2 );
@@ -108,8 +108,8 @@ main: () = {
     std::cout << "f. get_raw_value() is (f. get_raw_value())$\n";
     std::cout << "f2.get_raw_value() is (f2.get_raw_value())$\n";
     std::cout << "f  == f2   is (f  == f2  )$\n";
-    std::cout << "f  is (f2) is (f  is (f2))$\n";
-    std::cout << "f2 is (f ) is (f2 is (f ))$\n";
+    std::cout << "(f ) is (f2) is ((f ) is (f2))$\n";
+    std::cout << "(f2) is (f ) is ((f2) is (f ))$\n";
     std::cout << "(f & f2) == f2 is ((f & f2) == f2)$\n";
 
     std::cout << "inspecting f: " << inspect f -> std::string {

--- a/regression-tests/pure2-more-wildcards.cpp2
+++ b/regression-tests/pure2-more-wildcards.cpp2
@@ -7,11 +7,11 @@ main: () -> int
     p: *       _ = x&;
     q: * const _ = p&;
 
-    if x is (less_than(20)) {
+    if (x) is (less_than(20)) {
         std::cout << "yes, less\n";
     }
 
-    if x is _ {
+    if (x) is _ {
         std::cout << "yes, always\n";
     }
 }

--- a/regression-tests/pure2-type-safety-1.cpp2
+++ b/regression-tests/pure2-type-safety-1.cpp2
@@ -23,7 +23,7 @@ main: () -> int =
 
 test_generic: ( x, msg ) = {
     msgx: std::string = msg;
-    print( msgx + " is int? ", x is int );
+    print( msgx + " is int? ", (x) is int );
 }
 
 print: ( msg: std::string, b: bool ) = {

--- a/source/parse.h
+++ b/source/parse.h
@@ -6015,10 +6015,10 @@ private:
 
     //G is-as-expression:
     //G     prefix-expression
+    //GTODO     type-id is-type-constraint
     //G     is-as-expression is-type-constraint
     //G     is-as-expression is-value-constraint
     //G     is-as-expression as-type-cast
-    //GTODO     type-id is-type-constraint
     //G
     //G is-type-constraint
     //G     'is' type-id

--- a/source/parse.h
+++ b/source/parse.h
@@ -6033,6 +6033,17 @@ private:
         -> std::unique_ptr<is_as_expression_node>
     {
         auto n = std::make_unique<is_as_expression_node>();
+
+        if (
+            curr().type() == lexeme::Identifier
+            && peek(1)
+            && *peek(1) == "is"
+            )
+        {
+            error("(temporary alpha limitation) testing a type with 'is' is not supported yet (or perhaps use '(identifier) is' to test an expression)");
+            return {};
+        }
+
         n->expr = prefix_expression();
         if (!(n->expr)) {
             return {};


### PR DESCRIPTION
Relevant lines from the grammar:
```c
    //G is-as-expression:
    //G     prefix-expression
    //G     is-as-expression is-type-constraint
    //G     is-as-expression is-value-constraint
    //GTODO     type-id is-type-constraint
```
Both *prefix-expression* and *type-id* can be an *unqualified-id*. `T is` is not implemented yet, but when it is, it would ~~conflict with~~ be parsed as `identifier is` to test an expression.

I understand the usual way of disambiguating between a type or an expression is to require parens to force an expression, so I have done that here to fix 5 `regression_tests`. I have added a temporary error for `identifier is`, because that should be the unimplemented `T is` form.

_Update_: So I've moved the *type-id* form above *prefix-expression* in the grammar.