### PR TITLE
Implement `Type is Type`

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -959,6 +959,15 @@ inline auto to_string(auto&& value, std::string_view) -> std::string
 //  TODO: Does this really warrant a new synonym? Perhaps "is void" is enough
 using empty = void;
 
+//  Type is Type
+//
+
+template <typename X, typename C>
+auto is() -> std::false_type { return {}; }
+
+template <typename X, typename C>
+    requires std::same_as<X, C> || std::derived_from<X,C>
+auto is() -> std::true_type { return {}; }
 
 //  Templates
 //

--- a/regression-tests/mixed-inspect-templates.cpp2
+++ b/regression-tests/mixed-inspect-templates.cpp2
@@ -16,10 +16,10 @@ fun: (v : _) -> std::string = {
 }
 
 fun2: (v : _) -> std::string = {
-    if v is std::vector  { return "std::vector";  }
-    if v is std::array   { return "std::array";   }
-    if v is std::variant { return "std::variant"; }
-    if v is my_type      { return "my_type";      }
+    if (v) is std::vector  { return "std::vector";  }
+    if (v) is std::array   { return "std::array";   }
+    if (v) is std::variant { return "std::variant"; }
+    if (v) is my_type      { return "my_type";      }
     return "unknown";
 }
 

--- a/regression-tests/mixed-inspect-values-2.cpp2
+++ b/regression-tests/mixed-inspect-values-2.cpp2
@@ -25,11 +25,11 @@ main: () -> int = {
         is _ = "i is out of our interest";
     } << std::endl;
 
-    if i is (less_than(20)) {
+    if (i) is (less_than(20)) {
         std::cout << "less than 20" << std::endl;
     }
 
-    if i is (in(10,30)) {
+    if (i) is (in(10,30)) {
         std::cout << "i is between 10 and 30" << std::endl;
     }
 
@@ -39,7 +39,7 @@ main: () -> int = {
         std::cout << "v is empty" << std::endl;
     }
 
-    if v is (empty) {
+    if (v) is (empty) {
         std::cout << "v is empty" << std::endl;
     }
 }

--- a/regression-tests/pure2-enum.cpp2
+++ b/regression-tests/pure2-enum.cpp2
@@ -49,7 +49,7 @@ main: () = {
     else if skat_game::hearts == x {    // ok, in either order
         std::cout << "hearts";
     }
-    else if x is (skat_game::spades) {  // ok, using is
+    else if (x) is (skat_game::spades) {  // ok, using is
         std::cout << "spades";
     }
     else if skat_game::clubs is (x) {   // ok, using is
@@ -95,8 +95,8 @@ main: () = {
     std::cout << "f. get_raw_value() is (f. get_raw_value())$\n";
     std::cout << "f2.get_raw_value() is (f2.get_raw_value())$\n";
 
-    std::cout << "f  is (f2) is (f  is (f2))$\n";
-    std::cout << "f2 is (f ) is (f2 is (f ))$\n\n";
+    std::cout << "(f ) is (f2) is ((f ) is (f2))$\n";
+    std::cout << "(f2) is (f ) is ((f2) is (f ))$\n\n";
 
     f.clear( f2 );
     f.set( file_attributes::current | f2 );
@@ -108,8 +108,8 @@ main: () = {
     std::cout << "f. get_raw_value() is (f. get_raw_value())$\n";
     std::cout << "f2.get_raw_value() is (f2.get_raw_value())$\n";
     std::cout << "f  == f2   is (f  == f2  )$\n";
-    std::cout << "f  is (f2) is (f  is (f2))$\n";
-    std::cout << "f2 is (f ) is (f2 is (f ))$\n";
+    std::cout << "(f ) is (f2) is ((f ) is (f2))$\n";
+    std::cout << "(f2) is (f ) is ((f2) is (f ))$\n";
     std::cout << "(f & f2) == f2 is ((f & f2) == f2)$\n";
 
     std::cout << "inspecting f: " << inspect f -> std::string {

--- a/regression-tests/pure2-enum.cpp2
+++ b/regression-tests/pure2-enum.cpp2
@@ -52,7 +52,7 @@ main: () = {
     else if (x) is (skat_game::spades) {  // ok, using is
         std::cout << "spades";
     }
-    else if skat_game::clubs is (x) {   // ok, using is
+    else if (skat_game::clubs) is (x) {   // ok, using is
         std::cout << "clubs";
     }
     else {

--- a/regression-tests/pure2-more-wildcards.cpp2
+++ b/regression-tests/pure2-more-wildcards.cpp2
@@ -7,11 +7,11 @@ main: () -> int
     p: *       _ = x&;
     q: * const _ = p&;
 
-    if x is (less_than(20)) {
+    if (x) is (less_than(20)) {
         std::cout << "yes, less\n";
     }
 
-    if x is _ {
+    if (x) is _ {
         std::cout << "yes, always\n";
     }
 }

--- a/regression-tests/pure2-type-is-type.cpp2
+++ b/regression-tests/pure2-type-is-type.cpp2
@@ -1,0 +1,18 @@
+main: () =
+{
+    T: type == int;
+    b := *T is *int;
+    [[assert: b]]
+
+    b = bool is T;
+    [[assert: !b]]
+
+    b = T is long;
+    [[assert: !b]]
+
+    b = std::runtime_error is std::exception;
+    [[assert: b]]
+
+    b = std::exception is std::runtime_error;
+    [[assert: !b]]
+}

--- a/regression-tests/pure2-type-safety-1.cpp2
+++ b/regression-tests/pure2-type-safety-1.cpp2
@@ -23,7 +23,7 @@ main: () -> int =
 
 test_generic: ( x, msg ) = {
     msgx: std::string = msg;
-    print( msgx + " is int? ", x is int );
+    print( msgx + " is int? ", (x) is int );
 }
 
 print: ( msg: std::string, b: bool ) = {

--- a/regression-tests/test-results/mixed-inspect-templates.cpp
+++ b/regression-tests/test-results/mixed-inspect-templates.cpp
@@ -42,10 +42,10 @@ struct my_type {};
 }
 
 [[nodiscard]] auto fun2(auto const& v) -> std::string{
-    if (cpp2::is<std::vector>(v)) {return "std::vector"; }
-    if (cpp2::is<std::array>(v)) {return "std::array"; }
-    if (cpp2::is<std::variant>(v)) {return "std::variant"; }
-    if (cpp2::is<my_type>(v)) {return "my_type";    }
+    if (cpp2::is<std::vector>((v))) {return "std::vector"; }
+    if (cpp2::is<std::array>((v))) {return "std::array"; }
+    if (cpp2::is<std::variant>((v))) {return "std::variant"; }
+    if (cpp2::is<my_type>((v))) {return "my_type";    }
     return "unknown"; 
 }
 

--- a/regression-tests/test-results/mixed-inspect-values-2.cpp
+++ b/regression-tests/test-results/mixed-inspect-values-2.cpp
@@ -44,11 +44,11 @@ constexpr auto empty = [](auto&& x){
         else return "i is out of our interest"; }
     () << std::endl;
 
-    if (cpp2::is(i, (less_than(20)))) {
+    if (cpp2::is((i), (less_than(20)))) {
         std::cout << "less than 20" << std::endl;
     }
 
-    if (cpp2::is(std::move(i), (in(10, 30)))) {
+    if (cpp2::is((std::move(i)), (in(10, 30)))) {
         std::cout << "i is between 10 and 30" << std::endl;
     }
 
@@ -58,7 +58,7 @@ constexpr auto empty = [](auto&& x){
         std::cout << "v is empty" << std::endl;
     }
 
-    if (cpp2::is(std::move(v), (empty))) {
+    if (cpp2::is((std::move(v)), (empty))) {
         std::cout << "v is empty" << std::endl;
     }
 }

--- a/regression-tests/test-results/pure2-enum.cpp
+++ b/regression-tests/test-results/pure2-enum.cpp
@@ -254,10 +254,10 @@ auto main() -> int{
     else {if (skat_game::hearts == x) { // ok, in either order
         std::cout << "hearts";
     }
-    else {if (cpp2::is(x, (skat_game::spades))) {// ok, using is
+    else {if (cpp2::is((x), (skat_game::spades))) {// ok, using is
         std::cout << "spades";
     }
-    else {if (cpp2::is(skat_game::clubs, (x))) {// ok, using is
+    else {if (cpp2::is((skat_game::clubs), (x))) {// ok, using is
         std::cout << "clubs";
     }
     else {
@@ -300,8 +300,8 @@ auto main() -> int{
     std::cout << "f. get_raw_value() is " + cpp2::to_string(CPP2_UFCS_0(get_raw_value, f)) + "\n";
     std::cout << "f2.get_raw_value() is " + cpp2::to_string(CPP2_UFCS_0(get_raw_value, f2)) + "\n";
 
-    std::cout << "f  is (f2) is " + cpp2::to_string(cpp2::is(f, (f2))) + "\n";
-    std::cout << "f2 is (f ) is " + cpp2::to_string(cpp2::is(f2, (f))) + "\n\n";
+    std::cout << "(f ) is (f2) is " + cpp2::to_string(cpp2::is((f), (f2))) + "\n";
+    std::cout << "(f2) is (f ) is " + cpp2::to_string(cpp2::is((f2), (f))) + "\n\n";
 
     CPP2_UFCS(clear, f, f2);
     CPP2_UFCS(set, f, file_attributes::current | f2);
@@ -313,8 +313,8 @@ auto main() -> int{
     std::cout << "f. get_raw_value() is " + cpp2::to_string(CPP2_UFCS_0(get_raw_value, f)) + "\n";
     std::cout << "f2.get_raw_value() is " + cpp2::to_string(CPP2_UFCS_0(get_raw_value, f2)) + "\n";
     std::cout << "f  == f2   is " + cpp2::to_string(f  == f2  ) + "\n";
-    std::cout << "f  is (f2) is " + cpp2::to_string(cpp2::is(f, (f2))) + "\n";
-    std::cout << "f2 is (f ) is " + cpp2::to_string(cpp2::is(f2, (f))) + "\n";
+    std::cout << "(f ) is (f2) is " + cpp2::to_string(cpp2::is((f), (f2))) + "\n";
+    std::cout << "(f2) is (f ) is " + cpp2::to_string(cpp2::is((f2), (f))) + "\n";
     std::cout << "(f & f2) == f2 is " + cpp2::to_string((f & f2) == f2) + "\n";
 
     std::cout << "inspecting f: " << [&] () -> std::string { auto&& _expr = std::move(f);

--- a/regression-tests/test-results/pure2-more-wildcards.cpp
+++ b/regression-tests/test-results/pure2-more-wildcards.cpp
@@ -29,7 +29,7 @@
     auto* p {&x}; 
     auto const* q {&p}; 
 
-    if (cpp2::is(x, (less_than(20)))) {
+    if (cpp2::is((x), (less_than(20)))) {
         std::cout << "yes, less\n";
     }
 

--- a/regression-tests/test-results/pure2-type-is-type.cpp
+++ b/regression-tests/test-results/pure2-type-is-type.cpp
@@ -1,0 +1,35 @@
+
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+auto main() -> int;
+
+
+//=== Cpp2 function definitions =================================================
+
+auto main() -> int
+{
+    using T = int;
+    auto b {bool(cpp2::is<T*, int*>())}; 
+    cpp2::Default.expects(b, "");
+
+    b = bool(cpp2::is<bool, T>());
+    cpp2::Default.expects(!(b), "");
+
+    b = bool(cpp2::is<T, long>());
+    cpp2::Default.expects(!(b), "");
+
+    b = bool(cpp2::is<std::runtime_error, std::exception>());
+    cpp2::Default.expects(b, "");
+
+    b = bool(cpp2::is<std::exception, std::runtime_error>());
+    cpp2::Default.expects(!(std::move(b)), "");
+}
+

--- a/regression-tests/test-results/pure2-type-is-type.cpp
+++ b/regression-tests/test-results/pure2-type-is-type.cpp
@@ -1,4 +1,5 @@
 
+#define CPP2_IMPORT_STD          Yes
 
 //=== Cpp2 type declarations ====================================================
 

--- a/regression-tests/test-results/pure2-type-safety-1.cpp
+++ b/regression-tests/test-results/pure2-type-safety-1.cpp
@@ -52,7 +52,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
 
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::string msgx {msg}; 
-    print(std::move(msgx) + " is int? ", cpp2::is<int>(x));
+    print(std::move(msgx) + " is int? ", cpp2::is<int>((x)));
 }
 
 auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void{

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -3195,12 +3195,25 @@ public:
         auto wildcard_found = false;
         bool as_on_literal  = false;
 
-        assert(
-            n.expr
-            && n.expr->get_postfix_expression_node()
-            && n.expr->get_postfix_expression_node()->expr
-        );
+        if (n.type) {
+            assert(
+                n.ops.size() == 1
+                && *n.ops[0].op == "is"
+                && n.ops[0].type
+            );
+            printer.print_cpp2("cpp2::is<", n.position());
+            emit(*n.type);
+            printer.print_cpp2(", ", n.position());
+            emit(*n.ops[0].type);
+            printer.print_cpp2(">()", n.position());
+            return;
+        }
+        else if (n.expr)
         {
+            assert(
+                n.expr->get_postfix_expression_node()
+                && n.expr->get_postfix_expression_node()->expr
+            );
             auto& p = n.expr->get_postfix_expression_node()->expr;
             if (auto t = p->get_token();
                 t

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -3201,11 +3201,11 @@ public:
                 && *n.ops[0].op == "is"
                 && n.ops[0].type
             );
-            printer.print_cpp2("cpp2::is<", n.position());
+            printer.print_cpp2("bool(cpp2::is<", n.position());
             emit(*n.type);
             printer.print_cpp2(", ", n.position());
             emit(*n.ops[0].type);
-            printer.print_cpp2(">()", n.position());
+            printer.print_cpp2(">())", n.position());
             return;
         }
         else if (n.expr)

--- a/source/parse.h
+++ b/source/parse.h
@@ -1438,10 +1438,9 @@ struct is_as_expression_node
     {
         if (type) {
             return type->position();
-        } else if (expr) {
-            return expr->position();
         } else {
-            assert(!"ICE: missing case");
+            assert (expr);
+            return expr->position();
         }
     }
 
@@ -1451,10 +1450,9 @@ struct is_as_expression_node
         v.start(*this, depth);
         if (type) {
             type->visit(v, depth+1);
-        } else if (expr) {
-            expr->visit(v, depth+1);
         } else {
-            assert(!"ICE: missing case");
+            assert (expr);
+            expr->visit(v, depth+1);
         }
         for (auto const& x : ops) {
             assert (x.op);

--- a/source/parse.h
+++ b/source/parse.h
@@ -6030,7 +6030,7 @@ private:
 
     //G is-as-expression:
     //G     prefix-expression
-    //GTODO     type-id is-type-constraint
+    //G     type-id is-type-constraint
     //G     is-as-expression is-type-constraint
     //G     is-as-expression is-value-constraint
     //G     is-as-expression as-type-cast

--- a/source/parse.h
+++ b/source/parse.h
@@ -6094,7 +6094,17 @@ private:
                 ;
             }
             else if ((term.expr = expression()) != nullptr) {
-                ;
+                if (n->type) {
+                    assert(is_found);
+                    error("expected type-id after type-id 'is', not an expression", false, term.expr->position());
+                    if (
+                        n->type->pc_qualifiers.empty()
+                        && n->type->id.index() == type_id_node::unqualified
+                    ) {
+                        error("did you mean to use '(identifier) is' to test an expression?", false, n->type->position());
+                    }
+                    return {};
+                }
             }
 
             if (

--- a/source/parse.h
+++ b/source/parse.h
@@ -6015,10 +6015,10 @@ private:
 
     //G is-as-expression:
     //G     prefix-expression
+    //GTODO     type-id is-type-constraint
     //G     is-as-expression is-type-constraint
     //G     is-as-expression is-value-constraint
     //G     is-as-expression as-type-cast
-    //GTODO     type-id is-type-constraint
     //G
     //G is-type-constraint
     //G     'is' type-id

--- a/source/parse.h
+++ b/source/parse.h
@@ -6033,6 +6033,17 @@ private:
         -> std::unique_ptr<is_as_expression_node>
     {
         auto n = std::make_unique<is_as_expression_node>();
+
+        if (
+            curr().type() == lexeme::Identifier
+            && peek(1)
+            && *peek(1) == "is"
+            )
+        {
+            error("(temporary alpha limitation) testing a type with 'is' is not supported yet (or perhaps use '(identifier) is' to test an expression)");
+            return {};
+        }
+
         n->expr = prefix_expression();
         if (!(n->expr)) {
             return {};

--- a/source/parse.h
+++ b/source/parse.h
@@ -1356,25 +1356,25 @@ struct is_as_expression_node
     {
         //  This is a fold-expression if any subexpression
         //  has an identifier named "..."
-        return expr->is_fold_expression();
+        return expr && expr->is_fold_expression();
     }
 
     auto is_identifier() const
         -> bool
     {
-        return ops.empty() && expr->is_identifier();
+        return expr && ops.empty() && expr->is_identifier();
     }
 
     auto is_id_expression() const
         -> bool
     {
-        return ops.empty() && expr->is_id_expression();
+        return expr && ops.empty() && expr->is_id_expression();
     }
 
     auto is_expression_list() const
         -> bool
     {
-        return ops.empty() && expr->is_expression_list();
+        return expr && ops.empty() && expr->is_expression_list();
     }
 
     auto get_expression_list() const
@@ -1389,7 +1389,7 @@ struct is_as_expression_node
     auto is_literal() const
         -> bool
     {
-        return ops.empty() && expr->is_literal();
+        return expr && ops.empty() && expr->is_literal();
     }
 
     auto get_postfix_expression_node() const
@@ -1404,15 +1404,20 @@ struct is_as_expression_node
             assert(expr);
             return expr->is_result_a_temporary_variable();
         } else {
-            return true;
+            return expr != nullptr;
         }
     }
 
     auto to_string() const
         -> std::string
     {
-        assert (expr);
-        auto ret = expr->to_string();
+        auto ret = std::string{};
+        if (type) {
+            ret = type->to_string();
+        } else {
+            assert (expr);
+            ret = expr->to_string();
+        }
         for (auto const& x : ops) {
             assert (x.op);
             ret += " " + x.op->to_string();


### PR DESCRIPTION
This supplants #759. The same rationale applies for requiring `(identifier) is` to test an expression, see that PR for details. I added a diagnostic for `identifier is expr` where `expr` is not a type-id, because `Type is expr` is not valid - instead it will suggest using `(identifier) is`.

`cpp2util.h` changes are taken from #701 by @filipsajdak. That makes `std::runtime_error is std::exception` true, which seems correct, although I think that is not mentioned in P2392.

I had to add a `speculative` parameter to `parser::type_id()` which is `true` when there might not be a type (but an expression instead). This avoids an error for `ptr*` which is parsed as a postfix-expression from prefix-expression from is-as-expression.