### PR TITLE
Enable debugging with LLDB (Xcode, Qt Creator, etc) v2

### DIFF
--- a/regression-tests/test-results/mixed-bounds-safety-with-assert-2.cpp
+++ b/regression-tests/test-results/mixed-bounds-safety-with-assert-2.cpp
@@ -35,6 +35,7 @@ auto add_42_to_subrange(auto& rng, cpp2::in<int> start, cpp2::in<int> end) -> vo
         std::cout << i << "\n";
 }
 
+#line 10 "mixed-bounds-safety-with-assert-2.cpp2"
 auto add_42_to_subrange(auto& rng, cpp2::in<int> start, cpp2::in<int> end) -> void
 {
     cpp2::Bounds.expects(cpp2::cmp_less_eq(0,start), "");

--- a/regression-tests/test-results/mixed-bounds-safety-with-assert.cpp
+++ b/regression-tests/test-results/mixed-bounds-safety-with-assert.cpp
@@ -35,6 +35,7 @@ auto print_subrange(auto const& rng, cpp2::in<int> start, cpp2::in<int> end) -> 
     print_subrange(std::move(v), 1, 13);
 }
 
+#line 9 "mixed-bounds-safety-with-assert.cpp2"
 auto print_subrange(auto const& rng, cpp2::in<int> start, cpp2::in<int> end) -> void{
     cpp2::Bounds.expects(cpp2::cmp_less_eq(0,start), "");
     cpp2::Bounds.expects(cpp2::cmp_less_eq(end,CPP2_UFCS_0(ssize, rng)), "");

--- a/regression-tests/test-results/mixed-captures-in-expressions-and-postconditions.cpp
+++ b/regression-tests/test-results/mixed-captures-in-expressions-and-postconditions.cpp
@@ -41,6 +41,7 @@ auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void;
 
 std::vector<int> vec {}; 
 
+#line 19 "mixed-captures-in-expressions-and-postconditions.cpp2"
 auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void
 
 #line 22 "mixed-captures-in-expressions-and-postconditions.cpp2"

--- a/regression-tests/test-results/mixed-fixed-type-aliases.cpp
+++ b/regression-tests/test-results/mixed-fixed-type-aliases.cpp
@@ -35,6 +35,7 @@ auto test(auto const& x) -> void{
         << "\n";
 }
 
+#line 15 "mixed-fixed-type-aliases.cpp2"
 [[nodiscard]] auto main(int const argc_, char** argv_) -> int{
     auto const args = cpp2::make_args(argc_, argv_); 
 #line 16 "mixed-fixed-type-aliases.cpp2"

--- a/regression-tests/test-results/mixed-float-literals.cpp
+++ b/regression-tests/test-results/mixed-float-literals.cpp
@@ -134,6 +134,7 @@ auto literals_cpp2() -> void{
   // 1.E-10F;
 }
 
+#line 114 "mixed-float-literals.cpp2"
 [[nodiscard]] auto main() -> int{
   literals_cpp1();
   literals_cpp2();

--- a/regression-tests/test-results/mixed-forwarding.cpp
+++ b/regression-tests/test-results/mixed-forwarding.cpp
@@ -48,6 +48,7 @@ CPP2_REQUIRES (std::is_same_v<CPP2_TYPEOF(t), std::pair<X,X>>)
 #line 11 "mixed-forwarding.cpp2"
 auto copy_from([[maybe_unused]] auto param1) -> void{}
 
+#line 13 "mixed-forwarding.cpp2"
 auto use([[maybe_unused]] auto const& param1) -> void{}
 
 #line 16 "mixed-forwarding.cpp2"
@@ -58,6 +59,7 @@ requires (std::is_same_v<CPP2_TYPEOF(t), std::pair<X,X>>)
     copy_from(t.first);             // copies
     copy_from(CPP2_FORWARD(t).second);// moves
 }
+#line 20 "mixed-forwarding.cpp2"
 auto apply_explicit_forward(auto&& t) -> void
 requires (std::is_same_v<CPP2_TYPEOF(t), std::pair<X,X>>)
 #line 20 "mixed-forwarding.cpp2"
@@ -66,6 +68,7 @@ requires (std::is_same_v<CPP2_TYPEOF(t), std::pair<X,X>>)
     copy_from(CPP2_FORWARD(t).second);// moves
 }
 
+#line 25 "mixed-forwarding.cpp2"
 [[nodiscard]] auto main() -> int{
     std::pair<X,X> t1 {1, 2}; 
     apply_implicit_forward(t1);

--- a/regression-tests/test-results/mixed-hello.cpp
+++ b/regression-tests/test-results/mixed-hello.cpp
@@ -38,6 +38,7 @@ auto main() -> int {
     return s; 
 }
 
+#line 11 "mixed-hello.cpp2"
 auto decorate(std::string& s) -> void{
     s = "[" + s + "]";
 }

--- a/regression-tests/test-results/mixed-initialization-safety-3-contract-violation.cpp
+++ b/regression-tests/test-results/mixed-initialization-safety-3-contract-violation.cpp
@@ -52,6 +52,7 @@ bool flip_a_coin() {
     print_decorated(std::move(x.value()));
 }
 
+#line 18 "mixed-initialization-safety-3-contract-violation.cpp2"
 auto fill(
     cpp2::out<std::string> x, 
     cpp2::in<std::string> value, 
@@ -64,5 +65,6 @@ auto fill(
     x.construct(CPP2_UFCS(substr, value, 0, count));
 }
 
+#line 28 "mixed-initialization-safety-3-contract-violation.cpp2"
 auto print_decorated(auto const& x) -> void { std::cout << ">> [" << x << "]\n";  }
 

--- a/regression-tests/test-results/mixed-initialization-safety-3.cpp
+++ b/regression-tests/test-results/mixed-initialization-safety-3.cpp
@@ -47,6 +47,7 @@ auto print_decorated(auto const& x) -> void;
     print_decorated(std::move(x.value()));
 }
 
+#line 16 "mixed-initialization-safety-3.cpp2"
 auto fill(
     cpp2::out<std::string> x, 
     cpp2::in<std::string> value, 
@@ -59,6 +60,7 @@ auto fill(
     x.construct(CPP2_UFCS(substr, value, 0, count));
 }
 
+#line 26 "mixed-initialization-safety-3.cpp2"
 auto print_decorated(auto const& x) -> void { std::cout << ">> [" << x << "]\n";  }
 
 #line 30 "mixed-initialization-safety-3.cpp2"

--- a/regression-tests/test-results/mixed-inspect-templates.cpp
+++ b/regression-tests/test-results/mixed-inspect-templates.cpp
@@ -41,6 +41,7 @@ struct my_type {};
     (); 
 }
 
+#line 18 "mixed-inspect-templates.cpp2"
 [[nodiscard]] auto fun2(auto const& v) -> std::string{
     if (cpp2::is<std::vector>(v)) {return "std::vector"; }
     if (cpp2::is<std::array>(v)) {return "std::array"; }
@@ -49,6 +50,7 @@ struct my_type {};
     return "unknown"; 
 }
 
+#line 26 "mixed-inspect-templates.cpp2"
 [[nodiscard]] auto main() -> int{
     std::vector<int> vec {1, 2, 3}; 
     std::array<int,4> arr {1, 2, 3, 4}; 

--- a/regression-tests/test-results/mixed-inspect-values.cpp
+++ b/regression-tests/test-results/mixed-inspect-values.cpp
@@ -29,6 +29,7 @@ auto test(auto const& x) -> void;
 #line 5 "mixed-inspect-values.cpp2"
 [[nodiscard]] auto in_2_3(cpp2::in<int> x) -> bool { return cpp2::cmp_less_eq(2,x) && cpp2::cmp_less_eq(x,3);  }
 
+#line 7 "mixed-inspect-values.cpp2"
 [[nodiscard]] auto main() -> int{
     std::variant<double,std::string,double> v {}; 
     v = "rev dodgson";
@@ -53,6 +54,7 @@ auto test(auto const& x) -> void;
     test(3.14);
 }
 
+#line 31 "mixed-inspect-values.cpp2"
 auto test(auto const& x) -> void{
     auto forty_two {42}; 
     std::cout << [&] () -> std::string { auto&& _expr = x;

--- a/regression-tests/test-results/mixed-inspect-with-typeof-of-template-arg-list.cpp
+++ b/regression-tests/test-results/mixed-inspect-with-typeof-of-template-arg-list.cpp
@@ -34,6 +34,7 @@ auto calc() {
     (); 
 }
 
+#line 14 "mixed-inspect-with-typeof-of-template-arg-list.cpp2"
 [[nodiscard]] auto main() -> int{
     return fun(42); 
 }

--- a/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
@@ -46,6 +46,7 @@ auto try_pointer_stuff() -> void{
                 // to show -n
 }
 
+#line 21 "mixed-lifetime-safety-and-null-contracts.cpp2"
 auto call_my_framework(char const* msg) -> void{
     std::cout 
         << "sending error to my framework... [" 

--- a/regression-tests/test-results/mixed-lifetime-safety-pointer-init-4.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-pointer-init-4.cpp
@@ -48,6 +48,7 @@ bool flip_a_coin() {
     print_and_decorate(*cpp2::assert_not_null(std::move(p.value())));
 }
 
+#line 21 "mixed-lifetime-safety-pointer-init-4.cpp2"
 auto print_and_decorate(auto const& thing) -> void { 
     std::cout << ">> " << thing << "\n";  }
 

--- a/regression-tests/test-results/mixed-multiple-return-values.cpp
+++ b/regression-tests/test-results/mixed-multiple-return-values.cpp
@@ -59,6 +59,7 @@ bool flip_a_coin() {
     return  { std::move(i.value()), std::move(s.value()) }; 
 }
 
+#line 22 "mixed-multiple-return-values.cpp2"
 auto do_print(cpp2::in<std::string> name, auto const& value) -> void { 
     std::cout << name << " is " << value << "\n";  }
 

--- a/regression-tests/test-results/mixed-out-destruction.cpp
+++ b/regression-tests/test-results/mixed-out-destruction.cpp
@@ -55,12 +55,17 @@ int main() {
 
 #line 22 "mixed-out-destruction.cpp2"
 auto f00() -> void     {   C c {"f00"}; cpp2::deferred_init<X> x; f01(cpp2::out(&x));}
+#line 23 "mixed-out-destruction.cpp2"
 auto f01(cpp2::out<X> x) -> void{C c {"f01"}; x.construct();throw_1();}
 
 #line 27 "mixed-out-destruction.cpp2"
 auto f10() -> void     {   C c {"f10"}; cpp2::deferred_init<X> x; f11(cpp2::out(&x));}
+#line 28 "mixed-out-destruction.cpp2"
 auto f11(cpp2::out<X> x) -> void{C c {"f11"}; f12(cpp2::out(&x));}
+#line 29 "mixed-out-destruction.cpp2"
 auto f12(cpp2::out<X> x) -> void{C c {"f12"}; f13(cpp2::out(&x));throw_1();}
+#line 30 "mixed-out-destruction.cpp2"
 auto f13(cpp2::out<X> x) -> void{C c {"f13"}; f14(cpp2::out(&x));}
+#line 31 "mixed-out-destruction.cpp2"
 auto f14(cpp2::out<X> x) -> void{C c {"f14"}; x.construct();}
 

--- a/regression-tests/test-results/mixed-parameter-passing-generic-out.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing-generic-out.cpp
@@ -37,6 +37,7 @@ auto f(auto x_) -> void{
     x.construct(42);
 }
 
+#line 15 "mixed-parameter-passing-generic-out.cpp2"
 [[nodiscard]] auto main() -> int{
     cpp2::deferred_init<int> a; 
     f(cpp2::out(&a));

--- a/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
@@ -38,6 +38,7 @@ CPP2_REQUIRES (std::is_same_v<CPP2_TYPEOF(e), std::string>)
 #line 6 "mixed-parameter-passing-with-forward.cpp2"
 auto copy_from([[maybe_unused]] auto param1) -> void{}
 
+#line 8 "mixed-parameter-passing-with-forward.cpp2"
 auto parameter_styles(
     [[maybe_unused]] cpp2::in<std::string> param1, 
     std::string b, 
@@ -74,5 +75,6 @@ requires (std::is_same_v<CPP2_TYPEOF(e), std::string>)
 
 }
 
+#line 42 "mixed-parameter-passing-with-forward.cpp2"
 [[nodiscard]] auto main() -> int{}
 

--- a/regression-tests/test-results/mixed-parameter-passing.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing.cpp
@@ -34,6 +34,7 @@ auto parameter_styles(
 #line 6 "mixed-parameter-passing.cpp2"
 auto copy_from([[maybe_unused]] auto param1) -> void{}
 
+#line 8 "mixed-parameter-passing.cpp2"
 auto parameter_styles(
     [[maybe_unused]] cpp2::in<std::string> param1, 
     std::string b, 
@@ -66,5 +67,6 @@ auto parameter_styles(
 
 }
 
+#line 40 "mixed-parameter-passing.cpp2"
 [[nodiscard]] auto main() -> int{}
 

--- a/regression-tests/test-results/mixed-postexpression-with-capture.cpp
+++ b/regression-tests/test-results/mixed-postexpression-with-capture.cpp
@@ -36,6 +36,7 @@ auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void;
 
 std::vector<int> vec {}; 
 
+#line 14 "mixed-postexpression-with-capture.cpp2"
 auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void
 
 #line 17 "mixed-postexpression-with-capture.cpp2"

--- a/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
+++ b/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
@@ -26,6 +26,7 @@ auto call([[maybe_unused]] auto const& param1, [[maybe_unused]] auto const& para
 #line 2 "mixed-postfix-expression-custom-formatting.cpp2"
 auto call([[maybe_unused]] auto const& param1, [[maybe_unused]] auto const& param2, [[maybe_unused]] auto const& param3, [[maybe_unused]] auto const& param4, [[maybe_unused]] auto const& param5) -> void{}
 
+#line 4 "mixed-postfix-expression-custom-formatting.cpp2"
 [[nodiscard]] auto test(auto const& a) -> std::string{
     return call(a, 
         ++*cpp2::assert_not_null(CPP2_UFCS(b, a, a.c)), "hello", /* polite
@@ -37,5 +38,6 @@ auto call([[maybe_unused]] auto const& param1, [[maybe_unused]] auto const& para
         ); 
 }
 
+#line 15 "mixed-postfix-expression-custom-formatting.cpp2"
 [[nodiscard]] auto main() -> int{}
 

--- a/regression-tests/test-results/mixed-type-safety-1.cpp
+++ b/regression-tests/test-results/mixed-type-safety-1.cpp
@@ -40,6 +40,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
 auto print(cpp2::in<std::string> msg, auto const& x) -> void { 
     std::cout << msg << x << "\n";  }
 
+#line 16 "mixed-type-safety-1.cpp2"
 auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void
 {
     cpp2::deferred_init<char const*> bmsg; 

--- a/regression-tests/test-results/pure2-bounds-safety-span.cpp
+++ b/regression-tests/test-results/pure2-bounds-safety-span.cpp
@@ -35,6 +35,7 @@ auto print_and_decorate(auto const& thing) -> void;
     }
 }
 
+#line 14 "pure2-bounds-safety-span.cpp2"
 auto print_and_decorate(auto const& thing) -> void { 
     std::cout << ">> " << thing << "\n";  }
 

--- a/regression-tests/test-results/pure2-break-continue.cpp
+++ b/regression-tests/test-results/pure2-break-continue.cpp
@@ -73,6 +73,7 @@ auto for_break_outer() -> void;
     std::cout <<   "\nfor_break_outer:\n  ";    for_break_outer();
 }
 
+#line 20 "pure2-break-continue.cpp2"
 auto while_continue_inner() -> void
 {
     auto i {0}; 
@@ -92,6 +93,7 @@ auto while_continue_inner() -> void
     }
 }
 
+#line 36 "pure2-break-continue.cpp2"
 auto while_continue_outer() -> void
 {
     auto i {0}; 
@@ -111,6 +113,7 @@ auto while_continue_outer() -> void
 #line 50 "pure2-break-continue.cpp2"
 }
 
+#line 52 "pure2-break-continue.cpp2"
 auto while_break_inner() -> void
 {
     auto i {0}; 
@@ -130,6 +133,7 @@ auto while_break_inner() -> void
     }
 }
 
+#line 68 "pure2-break-continue.cpp2"
 auto while_break_outer() -> void
 {
     auto i {0}; 
@@ -149,6 +153,7 @@ auto while_break_outer() -> void
 #line 82 "pure2-break-continue.cpp2"
 }
 
+#line 84 "pure2-break-continue.cpp2"
 auto do_continue_inner() -> void
 {
     auto i {0}; 
@@ -174,6 +179,7 @@ auto do_continue_inner() -> void
     cpp2::cmp_less(i,3) && [&]{ ++i ; return true; }() );
 }
 
+#line 103 "pure2-break-continue.cpp2"
 auto do_continue_outer() -> void
 {
     auto i {0}; 
@@ -199,6 +205,7 @@ auto do_continue_outer() -> void
     cpp2::cmp_less(i,3) && [&]{ ++i ; return true; }() );
 }
 
+#line 122 "pure2-break-continue.cpp2"
 auto do_break_inner() -> void
 {
     auto i {0}; 
@@ -224,6 +231,7 @@ auto do_break_inner() -> void
     cpp2::cmp_less(i,3) && [&]{ ++i ; return true; }() );
 }
 
+#line 141 "pure2-break-continue.cpp2"
 auto do_break_outer() -> void
 {
     auto i {0}; 
@@ -249,6 +257,7 @@ auto do_break_outer() -> void
     cpp2::cmp_less(i,3) && [&]{ ++i ; return true; }() );
 }
 
+#line 160 "pure2-break-continue.cpp2"
 auto for_continue_inner() -> void
 {
     std::vector vi {0, 1, 2}; 
@@ -270,6 +279,7 @@ auto for_continue_inner() -> void
     } while (false); ++counter; }
 }
 
+#line 178 "pure2-break-continue.cpp2"
 auto for_continue_outer() -> void
 {
     std::vector vi {0, 1, 2}; 
@@ -291,6 +301,7 @@ auto for_continue_outer() -> void
 #line 194 "pure2-break-continue.cpp2"
 }
 
+#line 196 "pure2-break-continue.cpp2"
 auto for_break_inner() -> void
 {
     std::vector vi {0, 1, 2}; 
@@ -312,6 +323,7 @@ auto for_break_inner() -> void
     } while (false); ++counter; }
 }
 
+#line 214 "pure2-break-continue.cpp2"
 auto for_break_outer() -> void
 {
     std::vector vi {0, 1, 2}; 

--- a/regression-tests/test-results/pure2-bugfix-for-discard-precedence.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-discard-precedence.cpp
@@ -41,6 +41,7 @@ auto main(int const argc_, char** argv_) -> int;
                                   return *this;
 #line 3 "pure2-bugfix-for-discard-precedence.cpp2"
                                  }
+#line 4 "pure2-bugfix-for-discard-precedence.cpp2"
   [[nodiscard]] auto quantity::operator+(quantity const& that) & -> quantity { return quantity(number + that.number);  }
 
 #line 7 "pure2-bugfix-for-discard-precedence.cpp2"

--- a/regression-tests/test-results/pure2-bugfix-for-memberwise-base-assignment.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-memberwise-base-assignment.cpp
@@ -47,35 +47,33 @@ auto main() -> int;
 
 #line 2 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Base::Base(){}
+#line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Base::Base ([[maybe_unused]] Base const& that) { std::cout << "(out this, that)\n"; }
 #line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   auto Base::operator=([[maybe_unused]] Base const& that) -> Base&  { std::cout << "(out this, that)\n";
-                                      return *this;
-#line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
-                                     }
+                                      return *this; }
 #line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Base::Base ([[maybe_unused]] Base&& that) noexcept { std::cout << "(out this, that)\n"; }
 #line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   auto Base::operator=([[maybe_unused]] Base&& that) noexcept -> Base&  { std::cout << "(out this, that)\n";
-                                      return *this;
-#line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
-                                     }
+                                      return *this; }
+#line 4 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Base::Base([[maybe_unused]] auto const& param2) { std::cout << "(implicit out this, _)\n";  }
 #line 4 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   auto Base::operator=([[maybe_unused]] auto const& param2) -> Base&  { std::cout << "(implicit out this, _)\n";
-                                      return *this;
-#line 4 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
-   }
+                                      return *this;  }
 
 #line 9 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Derived::Derived()
                             : Base{  }
 #line 9 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   {}
+#line 10 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Derived::Derived(Derived const& that)
                                     : Base{ static_cast<Base const&>(that) }
 #line 10 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
                                 {}
+#line 11 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   auto Derived::operator=(Derived&& that) noexcept -> Derived& {
                                          Base::operator= ( static_cast<Base&&>(that) );
                                          return *this;

--- a/regression-tests/test-results/pure2-bugfix-for-memberwise-base-assignment.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-memberwise-base-assignment.cpp
@@ -51,17 +51,23 @@ auto main() -> int;
   Base::Base ([[maybe_unused]] Base const& that) { std::cout << "(out this, that)\n"; }
 #line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   auto Base::operator=([[maybe_unused]] Base const& that) -> Base&  { std::cout << "(out this, that)\n";
-                                      return *this; }
+                                      return *this;
+#line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
+                                     }
 #line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Base::Base ([[maybe_unused]] Base&& that) noexcept { std::cout << "(out this, that)\n"; }
 #line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   auto Base::operator=([[maybe_unused]] Base&& that) noexcept -> Base&  { std::cout << "(out this, that)\n";
-                                      return *this; }
+                                      return *this;
+#line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
+                                     }
 #line 4 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Base::Base([[maybe_unused]] auto const& param2) { std::cout << "(implicit out this, _)\n";  }
 #line 4 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   auto Base::operator=([[maybe_unused]] auto const& param2) -> Base&  { std::cout << "(implicit out this, _)\n";
-                                      return *this;  }
+                                      return *this;
+#line 4 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
+   }
 
 #line 9 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Derived::Derived()

--- a/regression-tests/test-results/pure2-bugfix-for-name-lookup-and-value-decoration.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-name-lookup-and-value-decoration.cpp
@@ -28,6 +28,7 @@ struct vals_ret { int i; };
     return  { std::move(i.value()) }; 
 }
 
+#line 6 "pure2-bugfix-for-name-lookup-and-value-decoration.cpp2"
 [[nodiscard]] auto main() -> int{
     auto v {vals()}; 
     std::move(v).i;

--- a/regression-tests/test-results/pure2-bugfix-for-optional-template-argument-list.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-optional-template-argument-list.cpp
@@ -17,5 +17,6 @@ extern std::plus<> const plus;
 //=== Cpp2 function definitions =================================================
 
 std::plus<> const plus {}; 
+#line 2 "pure2-bugfix-for-optional-template-argument-list.cpp2"
 [[nodiscard]] auto main() -> int { return std::plus<>()(0, 0); }
 

--- a/regression-tests/test-results/pure2-bugfix-for-requires-clause-in-forward-declaration.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-requires-clause-in-forward-declaration.cpp
@@ -49,5 +49,6 @@ requires (std::is_same_v<CPP2_TYPEOF(n), std::string>)
 #line 3 "pure2-bugfix-for-requires-clause-in-forward-declaration.cpp2"
   }
 
+#line 5 "pure2-bugfix-for-requires-clause-in-forward-declaration.cpp2"
 auto main() -> int{}
 

--- a/regression-tests/test-results/pure2-bugfix-for-requires-clause-unbraced-function-initializer.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-requires-clause-unbraced-function-initializer.cpp
@@ -19,5 +19,6 @@ auto main() -> int;
 
 template<typename T> auto f() -> void
 requires (std::regular<T>) { g(T());  }
+#line 2 "pure2-bugfix-for-requires-clause-unbraced-function-initializer.cpp2"
 auto main() -> int                 {}
 

--- a/regression-tests/test-results/pure2-bugfix-for-variable-template.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-variable-template.cpp
@@ -17,5 +17,6 @@ template<auto V> extern int const v0;
 //=== Cpp2 function definitions =================================================
 
 template<auto V> int const v0 {0}; 
+#line 2 "pure2-bugfix-for-variable-template.cpp2"
 [[nodiscard]] auto main() -> int { return v0<0>; }
 

--- a/regression-tests/test-results/pure2-forward-return.cpp
+++ b/regression-tests/test-results/pure2-forward-return.cpp
@@ -33,8 +33,10 @@ extern int const global;
     return *cpp2::assert_not_null(std::begin(CPP2_FORWARD(rng)));  }
 
 int const global {42}; 
+#line 8 "pure2-forward-return.cpp2"
 [[nodiscard]] auto f() -> int const&{return global; }
 
+#line 10 "pure2-forward-return.cpp2"
 [[nodiscard]] auto main() -> int{
     std::vector v {1, 2, 3}; 
     first(v) = 4;

--- a/regression-tests/test-results/pure2-function-multiple-forward-arguments.cpp
+++ b/regression-tests/test-results/pure2-function-multiple-forward-arguments.cpp
@@ -25,6 +25,7 @@ requires (std::is_same_v<CPP2_TYPEOF(s1), std::string> && std::is_same_v<CPP2_TY
     std::cout << CPP2_FORWARD(s1) << CPP2_FORWARD(s2) << CPP2_FORWARD(s3) << std::endl;
 }
 
+#line 5 "pure2-function-multiple-forward-arguments.cpp2"
 auto main() -> int{
     std::string b {"b"}; 
     std::string c {"c"}; 

--- a/regression-tests/test-results/pure2-hello.cpp
+++ b/regression-tests/test-results/pure2-hello.cpp
@@ -31,12 +31,14 @@ auto decorate(std::string& s) -> void;
     std::cout << "Hello " << name() << "\n";
 }
 
+#line 6 "pure2-hello.cpp2"
 [[nodiscard]] auto name() -> std::string{
     std::string s {"world"}; 
     decorate(s);
     return s; 
 }
 
+#line 12 "pure2-hello.cpp2"
 auto decorate(std::string& s) -> void{
     s = "[" + s + "]";
 }

--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -38,6 +38,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(std::move(o), "optional<int>");
 }
 
+#line 20 "pure2-inspect-expression-in-generic-function-multiple-types.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << std::setw(30) << msg 

--- a/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
@@ -25,6 +25,7 @@ auto print_an_int(auto const& x) -> void;
     print_an_int(1.1);
 }
 
+#line 7 "pure2-inspect-expression-with-as-in-generic-function.cpp2"
 auto print_an_int(auto const& x) -> void{
     std::cout 
         << std::setw(30) << cpp2::to_string(x) 

--- a/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
@@ -35,6 +35,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(std::move(o), "optional<string>");
 }
 
+#line 14 "pure2-inspect-fallback-with-variant-any-optional.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << "\n" << msg << "\n    ..." 

--- a/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
@@ -39,6 +39,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(std::move(o), "optional<string>");
 }
 
+#line 18 "pure2-inspect-generic-void-empty-with-variant-any-optional.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << "\n" << msg << "\n    ..." 

--- a/regression-tests/test-results/pure2-interpolation.cpp
+++ b/regression-tests/test-results/pure2-interpolation.cpp
@@ -30,8 +30,11 @@ class item {
 
 #line 3 "pure2-interpolation.cpp2"
     [[nodiscard]] auto item::name() const& -> std::string { return "Dog kennel";  }
+#line 4 "pure2-interpolation.cpp2"
     [[nodiscard]] auto item::color() const& -> std::string { return "mauve";  }
+#line 5 "pure2-interpolation.cpp2"
     [[nodiscard]] auto item::price() const& -> double { return 3.14;  }
+#line 6 "pure2-interpolation.cpp2"
     [[nodiscard]] auto item::count() const& -> int { return 42;  }
 
 #line 9 "pure2-interpolation.cpp2"

--- a/regression-tests/test-results/pure2-intro-example-hello-2022.cpp
+++ b/regression-tests/test-results/pure2-intro-example-hello-2022.cpp
@@ -34,11 +34,13 @@ auto print_it(auto const& x, auto const& len) -> void;
     }
 }
 
+#line 12 "pure2-intro-example-hello-2022.cpp2"
 [[nodiscard]] auto decorate(auto& thing) -> int{
     thing = "[" + thing + "]";
     return CPP2_UFCS_0(ssize, thing); 
 }
 
+#line 17 "pure2-intro-example-hello-2022.cpp2"
 auto print_it(auto const& x, auto const& len) -> void { 
     std::cout 
         << ">> " << x 

--- a/regression-tests/test-results/pure2-intro-example-three-loops.cpp
+++ b/regression-tests/test-results/pure2-intro-example-three-loops.cpp
@@ -31,11 +31,13 @@ auto decorate_and_print(auto& thing) -> void;
 auto print(auto const& thing) -> void { 
     std::cout << ">> " << thing << "\n";  }
 
+#line 5 "pure2-intro-example-three-loops.cpp2"
 auto decorate_and_print(auto& thing) -> void{
     thing = "[" + thing + "]";
     print(thing);
 }
 
+#line 10 "pure2-intro-example-three-loops.cpp2"
 [[nodiscard]] auto main() -> int{
     std::vector<std::string> words {
         "hello", "big", "world"}; 

--- a/regression-tests/test-results/pure2-look-up-parameter-across-unnamed-function.cpp
+++ b/regression-tests/test-results/pure2-look-up-parameter-across-unnamed-function.cpp
@@ -38,6 +38,7 @@ struct f_ret { int ri; };
     return  { std::move(ri) }; // "return;" is implicit"
 }
 
+#line 8 "pure2-look-up-parameter-across-unnamed-function.cpp2"
 [[nodiscard]] auto g() -> g_ret{
         cpp2::deferred_init<int> ri;
 #line 9 "pure2-look-up-parameter-across-unnamed-function.cpp2"
@@ -47,6 +48,7 @@ struct f_ret { int ri; };
     return  { std::move(ri.value()) }; 
 }
 
+#line 15 "pure2-look-up-parameter-across-unnamed-function.cpp2"
 [[nodiscard]] auto main() -> int{
     std::cout << f().ri + g().ri << "\n";
 }

--- a/regression-tests/test-results/pure2-more-wildcards.cpp
+++ b/regression-tests/test-results/pure2-more-wildcards.cpp
@@ -23,6 +23,7 @@
 #line 2 "pure2-more-wildcards.cpp2"
 [[nodiscard]] auto less_than(auto const& value) -> auto { return [_0 = value](auto const& x) -> auto { return cpp2::cmp_less(x,_0); }; }
 
+#line 4 "pure2-more-wildcards.cpp2"
 [[nodiscard]] auto main() -> int
 {
     auto const x {2}; 

--- a/regression-tests/test-results/pure2-print.cpp
+++ b/regression-tests/test-results/pure2-print.cpp
@@ -99,6 +99,7 @@ requires (true)
 #line 10 "pure2-print.cpp2"
         [[nodiscard]] auto outer::mytype::f() -> int { return 42;  }
 
+#line 12 "pure2-print.cpp2"
         [[nodiscard]] auto outer::mytype::g(cpp2::in<int> i) const -> int{
             using namespace ::std;
 
@@ -118,6 +119,7 @@ requires (true)
             return ret; 
         }
 
+#line 31 "pure2-print.cpp2"
         [[nodiscard]] auto outer::mytype::h(cpp2::in<std::string> s, std::map<int const,std::string>& m) -> std::string
 
 #line 34 "pure2-print.cpp2"
@@ -147,6 +149,7 @@ requires (true)
             return [_0 = (s + cpp2::assert_in_bounds(m, 0))]() -> std::string { return _0;  }(); 
         }
 
+#line 54 "pure2-print.cpp2"
         template<typename T> [[nodiscard]] auto outer::mytype::values([[maybe_unused]] T const& param2) const& -> values_ret{
                 cpp2::deferred_init<int> offset;
                 cpp2::deferred_init<std::string> name;
@@ -155,12 +158,16 @@ requires (true)
             name.construct("plugh");
         return  { std::move(offset.value()), std::move(name.value()) }; }
 
+#line 59 "pure2-print.cpp2"
         outer::mytype::mytype(){}
 
+#line 61 "pure2-print.cpp2"
         outer::mytype::mytype([[maybe_unused]] mytype const& that){}
 
+#line 63 "pure2-print.cpp2"
         outer::mytype::mytype([[maybe_unused]] cpp2::in<int> param2){}
 
+#line 65 "pure2-print.cpp2"
         auto outer::mytype::variadic(auto const& ...x) -> void
 requires ((std::is_convertible_v<CPP2_TYPEOF(x), int> && ...))
 #line 65 "pure2-print.cpp2"
@@ -196,6 +203,7 @@ requires (cpp2::cmp_greater_eq(sizeof(Args)...,0))
         (out << ... << args);
     }
 
+#line 97 "pure2-print.cpp2"
     template<typename ...Args> [[nodiscard]] auto outer::all(Args const& ...args) -> bool { 
         return (... && args);  }
 

--- a/regression-tests/test-results/pure2-requires-clauses.cpp
+++ b/regression-tests/test-results/pure2-requires-clauses.cpp
@@ -52,6 +52,7 @@ auto main() -> int;
     template <typename T, typename U> requires( std::is_same_v<T,int> && std::is_same_v<U,int> )
 X<T,U>::X(){}
 
+#line 10 "pure2-requires-clauses.cpp2"
 template<typename T, typename U> [[nodiscard]] auto f
     (auto&& a, auto&& b) -> int
 requires (std::is_same_v<T,int> && std::is_same_v<U,int> && std::is_same_v<CPP2_TYPEOF(a), int> && std::is_same_v<CPP2_TYPEOF(b), int>)
@@ -66,6 +67,7 @@ requires (std::same_as<T,cpp2::i32>)
 #line 18 "pure2-requires-clauses.cpp2"
 T const v {0}; 
 
+#line 20 "pure2-requires-clauses.cpp2"
 auto main() -> int{
     X<int,int> x {}; 
     std::cout << f<int,int>(2, 5);

--- a/regression-tests/test-results/pure2-synthesize-rightshift-and-rightshifteq.cpp
+++ b/regression-tests/test-results/pure2-synthesize-rightshift-and-rightshifteq.cpp
@@ -25,6 +25,7 @@
     return std::move(x) >> 1; 
 }
 
+#line 7 "pure2-synthesize-rightshift-and-rightshifteq.cpp2"
 [[nodiscard]] auto main() -> int{
     std::cout << f(32, 1) << "\n";
 }

--- a/regression-tests/test-results/pure2-template-parameter-lists.cpp
+++ b/regression-tests/test-results/pure2-template-parameter-lists.cpp
@@ -25,10 +25,14 @@ auto main() -> int;
 
 #line 2 "pure2-template-parameter-lists.cpp2"
     template<typename T, typename U> [[nodiscard]] auto f1(T const& t, U const& u) -> auto { return t + u; }
+#line 3 "pure2-template-parameter-lists.cpp2"
 template<typename T, typename U> [[nodiscard]] auto f2(T const& t, U const& u) -> auto { return t + u; }
+#line 4 "pure2-template-parameter-lists.cpp2"
 template<auto T, auto U> [[nodiscard]] auto f3() -> auto { return T + U; }
+#line 5 "pure2-template-parameter-lists.cpp2"
 template<cpp2::i8 T, cpp2::i16 U> [[nodiscard]] auto f4() -> auto { return T + U; }
 
+#line 7 "pure2-template-parameter-lists.cpp2"
 auto main() -> int{
     std::cout << "f1: " + cpp2::to_string(f1(1, 1)) + "\n";
     std::cout << "f2: " + cpp2::to_string(f2(2, 2)) + "\n";

--- a/regression-tests/test-results/pure2-type-safety-1.cpp
+++ b/regression-tests/test-results/pure2-type-safety-1.cpp
@@ -50,11 +50,13 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
     test_generic(std::move(o), "optional<int>");
 }
 
+#line 24 "pure2-type-safety-1.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::string msgx {msg}; 
     print(std::move(msgx) + " is int? ", cpp2::is<int>(x));
 }
 
+#line 29 "pure2-type-safety-1.cpp2"
 auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void{
     cpp2::deferred_init<char const*> bmsg; 
     if (b) { bmsg.construct("true");}

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -38,6 +38,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(std::move(o), "optional<int>");
 }
 
+#line 20 "pure2-type-safety-2-with-inspect-expression.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << std::setw(30) << msg 

--- a/regression-tests/test-results/pure2-types-basics.cpp
+++ b/regression-tests/test-results/pure2-types-basics.cpp
@@ -118,6 +118,7 @@ namespace N {
 #line 11 "pure2-types-basics.cpp2"
     }
 
+#line 13 "pure2-types-basics.cpp2"
     myclass::myclass(cpp2::in<std::string> s)
         : data{ 99 }
         , more{ s }
@@ -140,6 +141,7 @@ namespace N {
 #line 18 "pure2-types-basics.cpp2"
     }
 
+#line 20 "pure2-types-basics.cpp2"
     myclass::myclass(cpp2::in<int> x, cpp2::in<std::string> s)
         : data{ 77 }
         , more{ s + std::to_string(x) + " plugh" }
@@ -151,6 +153,7 @@ namespace N {
         print();
     }
 
+#line 27 "pure2-types-basics.cpp2"
     myclass::myclass()
         : more{ std::to_string(3.14159) }
 #line 27 "pure2-types-basics.cpp2"
@@ -161,18 +164,22 @@ namespace N {
         print();
     }
 
+#line 34 "pure2-types-basics.cpp2"
     auto myclass::print() const& -> void{
         std::cout << "    data: " + cpp2::to_string(data) + ", more: " + cpp2::to_string(more) + "\n";
     }
 
+#line 38 "pure2-types-basics.cpp2"
     auto myclass::print() && -> void{
         std::cout << "    (move print) data: " + cpp2::to_string(data) + ", more: " + cpp2::to_string(more) + "\n";
     }
 
+#line 42 "pure2-types-basics.cpp2"
     myclass::~myclass() noexcept{
         std::cout << "myclass: destructor\n";
     }
 
+#line 46 "pure2-types-basics.cpp2"
     auto myclass::f(cpp2::in<int> x) const& -> void{
         std::cout << "N::myclass::f with " + cpp2::to_string(x) + "\n";
     }
@@ -182,13 +189,17 @@ namespace N {
 
 #line 57 "pure2-types-basics.cpp2"
     template<typename T, typename U> [[nodiscard]] auto myclass::f1(T const& t, U const& u) -> auto { return t + u; }
+#line 58 "pure2-types-basics.cpp2"
     template<typename T, typename U> [[nodiscard]] auto myclass::f2(T const& t, U const& u) -> auto { return t + u; }
+#line 59 "pure2-types-basics.cpp2"
     template<auto T, auto U> [[nodiscard]] auto myclass::f3() -> auto { return T + U; }
+#line 60 "pure2-types-basics.cpp2"
     template<cpp2::i8 T, cpp2::i16 U> [[nodiscard]] auto myclass::f4() -> auto { return T + U; }
 
 #line 64 "pure2-types-basics.cpp2"
 }
 
+#line 66 "pure2-types-basics.cpp2"
 auto main() -> int{
     N::myclass x {1}; 
     CPP2_UFCS(f, x, 53);

--- a/regression-tests/test-results/pure2-types-down-upcast.cpp
+++ b/regression-tests/test-results/pure2-types-down-upcast.cpp
@@ -66,14 +66,19 @@ auto test_down() -> void;
 
 #line 4 "pure2-types-down-upcast.cpp2"
  auto A::const_foo() const -> void{std::cout << "const foo \n"; }
+#line 5 "pure2-types-down-upcast.cpp2"
  auto A::mut_foo() & -> void{std::cout << "foo \n"; }
 
 #line 13 "pure2-types-down-upcast.cpp2"
 auto func_mut(A&  a) -> void    {std::cout << "Call A mut: " + cpp2::to_string(a.i) << std::endl;}
+#line 14 "pure2-types-down-upcast.cpp2"
 auto func_mut(B&  b) -> void    {std::cout << "Call B mut: " + cpp2::to_string(b.d) << std::endl;}
+#line 15 "pure2-types-down-upcast.cpp2"
 auto func_const(cpp2::in<A> a) -> void{std::cout << "Call A const: " + cpp2::to_string(a.i) << std::endl;}
+#line 16 "pure2-types-down-upcast.cpp2"
 auto func_const(cpp2::in<B> b) -> void{std::cout << "Call B const: " + cpp2::to_string(b.d) << std::endl;}
 
+#line 18 "pure2-types-down-upcast.cpp2"
 auto test_const_foo() -> void{
  A s {}; 
   A const* sC {&s}; 
@@ -85,6 +90,7 @@ auto test_const_foo() -> void{
   static_cast<void>(std::move(sC));
 }
 
+#line 29 "pure2-types-down-upcast.cpp2"
 auto test_mut_foo() -> void{
  A s {}; 
   CPP2_UFCS_0(mut_foo, s);
@@ -92,6 +98,7 @@ auto test_mut_foo() -> void{
   static_cast<void>(std::move(s));
 }
 
+#line 36 "pure2-types-down-upcast.cpp2"
 auto test_up() -> void{
   B b {}; 
   B const* bC {&b}; 
@@ -111,6 +118,7 @@ auto test_up() -> void{
   static_cast<void>(std::move(bC));
 }
 
+#line 55 "pure2-types-down-upcast.cpp2"
 auto test_down() -> void{
   B b {}; 
   B const* bC {&b}; 
@@ -133,6 +141,7 @@ auto test_down() -> void{
   static_cast<void>(std::move(aC));
 }
 
+#line 77 "pure2-types-down-upcast.cpp2"
 [[nodiscard]] auto main() -> int{
 
   test_const_foo();

--- a/regression-tests/test-results/pure2-types-inheritance.cpp
+++ b/regression-tests/test-results/pure2-types-inheritance.cpp
@@ -97,6 +97,7 @@ auto main() -> int;
 #line 6 "pure2-types-inheritance.cpp2"
 namespace N {
 
+#line 8 "pure2-types-inheritance.cpp2"
         template <int I> Machine<I>::Machine([[maybe_unused]] cpp2::in<std::string> param2){}
 
         template <int I> Machine<I>::~Machine() noexcept{}
@@ -117,15 +118,19 @@ namespace N {
         std::cout << cpp2::to_string(name) + " checks in for the day's shift\n";
     }
 
+#line 25 "pure2-types-inheritance.cpp2"
     auto Cyborg::speak() const -> void { 
         std::cout << cpp2::to_string(name) + " cracks a few jokes with a coworker\n";  }
 
+#line 28 "pure2-types-inheritance.cpp2"
     auto Cyborg::work() const -> void { 
         std::cout << cpp2::to_string(name) + " carries some half-tonne crates of Fe2O3 to cold storage\n";  }
 
+#line 31 "pure2-types-inheritance.cpp2"
     auto Cyborg::print() const& -> void { 
         std::cout << "printing: " + cpp2::to_string(name) + " lives at " + cpp2::to_string(address) + "\n";  }
 
+#line 34 "pure2-types-inheritance.cpp2"
     Cyborg::~Cyborg() noexcept { 
         std::cout << "Tired but satisfied after another successful day, " + cpp2::to_string(name) + " checks out and goes home to their family\n";  }
 
@@ -135,11 +140,13 @@ auto make_speak(cpp2::in<Human> h) -> void{
     CPP2_UFCS_0(speak, h);
 }
 
+#line 43 "pure2-types-inheritance.cpp2"
 auto do_work(cpp2::in<N::Machine<99>> m) -> void{
     std::cout << "-> [vcall: do_work] ";
     CPP2_UFCS_0(work, m);
 }
 
+#line 48 "pure2-types-inheritance.cpp2"
 auto main() -> int{
     Cyborg c {"Parsnip"}; 
     CPP2_UFCS_0(print, c);

--- a/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
+++ b/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
@@ -171,6 +171,7 @@ namespace N {
 #line 49 "pure2-types-order-independence-and-nesting.cpp2"
      }
 
+#line 51 "pure2-types-order-independence-and-nesting.cpp2"
     auto Y::why(cpp2::in<int> count) const& -> void { 
         CPP2_UFCS(exx, (*cpp2::assert_not_null(px)), count + 1);  }// use X object from Y
 

--- a/regression-tests/test-results/pure2-types-smf-and-that-1-provide-everything.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-1-provide-everything.cpp
@@ -67,6 +67,7 @@ auto main() -> int;
         std::cout << "ctor - copy (GENERAL)";
     }
 
+#line 8 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }
@@ -76,6 +77,7 @@ auto main() -> int;
         std::cout << "ctor - move          ";
     }
 
+#line 13 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     auto myclass::operator=(myclass const& that) -> myclass& {
         name = that.name;
         addr = that.addr + "(AC)";
@@ -86,6 +88,7 @@ auto main() -> int;
 #line 16 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     }
 
+#line 18 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
@@ -95,6 +98,7 @@ auto main() -> int;
 #line 20 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     }
 
+#line 22 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }
 #line 22 "pure2-types-smf-and-that-1-provide-everything.cpp2"

--- a/regression-tests/test-results/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp
@@ -70,6 +70,7 @@ auto main() -> int;
         std::cout << "ctor - copy (GENERAL)";
     }
 
+#line 8 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }
@@ -79,6 +80,7 @@ auto main() -> int;
         std::cout << "ctor - move          ";
     }
 
+#line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     auto myclass::operator=(myclass const& that) -> myclass& {
         name = that.name;
         addr = that.addr + "(AC)";

--- a/regression-tests/test-results/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp
@@ -80,6 +80,7 @@ auto main() -> int;
 #line 6 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     }
 
+#line 8 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }
@@ -99,6 +100,7 @@ auto main() -> int;
 #line 20 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     }
 
+#line 22 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }
 #line 22 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"

--- a/regression-tests/test-results/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp
@@ -90,6 +90,7 @@ auto main() -> int;
 #line 16 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     }
 
+#line 18 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
@@ -99,6 +100,7 @@ auto main() -> int;
 #line 20 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     }
 
+#line 22 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }
 #line 22 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"

--- a/regression-tests/test-results/pure2-types-that-parameters.cpp
+++ b/regression-tests/test-results/pure2-types-that-parameters.cpp
@@ -51,6 +51,7 @@ auto main() -> int;
 #line 4 "pure2-types-that-parameters.cpp2"
     myclass::myclass(){}
 
+#line 6 "pure2-types-that-parameters.cpp2"
     myclass::myclass(myclass const& that)
         : name{ that.name }
         , addr{ that.addr }
@@ -68,6 +69,7 @@ auto main() -> int;
 #line 9 "pure2-types-that-parameters.cpp2"
     }
 
+#line 11 "pure2-types-that-parameters.cpp2"
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name }
         , addr{ std::move(that).addr }
@@ -85,6 +87,7 @@ auto main() -> int;
 #line 14 "pure2-types-that-parameters.cpp2"
     }
 
+#line 16 "pure2-types-that-parameters.cpp2"
     auto myclass::print() const& -> void{
         std::cout << "name '" + cpp2::to_string(name) + "', addr '" + cpp2::to_string(addr) + "'\n";
     }

--- a/regression-tests/test-results/pure2-types-value-types-via-meta-functions.cpp
+++ b/regression-tests/test-results/pure2-types-value-types-via-meta-functions.cpp
@@ -163,6 +163,7 @@ auto main() -> int{
     test<p_widget>();
 }
 
+#line 23 "pure2-types-value-types-via-meta-functions.cpp2"
 template<typename T> auto test() -> void{
     //  should be default constructible
     T a {}; 

--- a/regression-tests/test-results/pure2-ufcs-member-access-and-chaining.cpp
+++ b/regression-tests/test-results/pure2-ufcs-member-access-and-chaining.cpp
@@ -59,12 +59,15 @@ extern int y;
     CPP2_UFCS_0(no_return, 42);
 }
 
+#line 24 "pure2-ufcs-member-access-and-chaining.cpp2"
 auto no_return([[maybe_unused]] auto const& param1) -> void{}
 
+#line 26 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto ufcs(cpp2::in<int> i) -> int{
     return i + 2; 
 }
 
+#line 30 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto fun() -> fun_ret{
         cpp2::deferred_init<int> i;
 #line 31 "pure2-ufcs-member-access-and-chaining.cpp2"
@@ -72,6 +75,7 @@ auto no_return([[maybe_unused]] auto const& param1) -> void{}
     return  { std::move(i.value()) }; 
 }
 
+#line 35 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto get_i(auto const& r) -> int{
     return r.i; 
 }

--- a/regression-tests/test-results/pure2-union.cpp
+++ b/regression-tests/test-results/pure2-union.cpp
@@ -212,6 +212,7 @@ auto print_name(cpp2::in<name_or_number> non) -> void{
     }
 }
 
+#line 28 "pure2-union.cpp2"
 auto main() -> int{
     name_or_number x {}; 
     std::cout << "sizeof(x) is " + cpp2::to_string(sizeof(x)) + "\n";

--- a/regression-tests/test-results/pure2-variadics.cpp
+++ b/regression-tests/test-results/pure2-variadics.cpp
@@ -49,14 +49,18 @@ template<typename ...Args> auto left_fold_print(std::ostream& out, Args const& .
     (out << ... << args);
 }
 
+#line 12 "pure2-variadics.cpp2"
 template<typename ...Args> [[nodiscard]] auto all(Args const& ...args) -> bool { 
     //  Unary left fold expression
     return (... && args);  }
 
+#line 16 "pure2-variadics.cpp2"
 template     <typename ...Args> [[nodiscard]] auto make_string(Args&& ...args) -> auto { return std::string{CPP2_FORWARD(args)...}; }
 
+#line 18 "pure2-variadics.cpp2"
 template  <typename T, typename ...Args> [[nodiscard]] auto make(Args&& ...args) -> auto { return T{CPP2_FORWARD(args)...}; }
 
+#line 20 "pure2-variadics.cpp2"
 auto main() -> int
 {
     x<int,long,std::string> a {}; 

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -5011,6 +5011,7 @@ public:
             current_functions.back().epilog.push_back( "return *this;");
             printer.print_cpp2( prefix, n.position() );
             printer.print_cpp2( "auto " + type_qualification_if_any_for(n) + print_to_string( *n.name() ), n.position());
+            printer.reset_line_directive_tracking();
             emit( *func, n.name() );
         }
     }


### PR DESCRIPTION
Debugging with LLDB (used by Xcode and Qt Creator) requires the following:

* Print line directives before each function definition
* Use absolute paths for filenames in line directives

### Changes in this PR

1. Print line directives before each function definition
2. Add a new command line option to use absolute paths in line directives (defaults to off). LLDB users will have to turn this on.
3. Update the `test-results` with the new line directives preceding function definitions

I manually verified the line numbers in the `test-results`. I also tested these changes with Visual Studio and the debugging experience continues to work as before, as well as with Xcode/Qt Creator after the changes.

### Changes to test-results

New line directives have been inserted before function definitions.

### EDIT: The following no longer applies (see comment history)

### ~~Bugfix?~~

There's one change that appears to be a bug fix.

See `pure2-bugfix-for-memberwise-base-assignment.cpp`:

**Before this PR:**
```
#line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
auto Base::operator=([[maybe_unused]] Base const& that) -> Base&  { std::cout << "(out this, that)\n";
                                      return *this;
#line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"    <---- bug?
                                     }
```

That second `#line 3` appears to be a bug.

**After this PR:**
```
#line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
auto Base::operator=([[maybe_unused]] Base const& that) -> Base&  { std::cout << "(out this, that)\n";
                                      return *this; }
```
