### PR TITLE
fix(to_cpp1): emit non-local using statements

### DIFF
--- a/regression-tests/pure2-print.cpp2
+++ b/regression-tests/pure2-print.cpp2
@@ -97,6 +97,8 @@ outer: @print type = {
     all: <Args...: type> (args...: Args) -> bool =
         (... && args);
 
+    using std::endian::native;
+
 }
 
 main: () = {

--- a/regression-tests/test-results/pure2-print.cpp
+++ b/regression-tests/test-results/pure2-print.cpp
@@ -76,12 +76,14 @@ CPP2_REQUIRES_ (cpp2::cmp_greater_eq(sizeof(Args)...,0))
 #line 97 "pure2-print.cpp2"
     public: template<typename ...Args> [[nodiscard]] static auto all(Args const& ...args) -> bool;
         
+
+    using std::endian::native;
     public: outer() = default;
     public: outer(outer const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(outer const&) -> void = delete;
 
 
-#line 100 "pure2-print.cpp2"
+#line 102 "pure2-print.cpp2"
 };
 
 auto main() -> int;
@@ -199,7 +201,7 @@ requires (cpp2::cmp_greater_eq(sizeof(Args)...,0))
     template<typename ...Args> [[nodiscard]] auto outer::all(Args const& ...args) -> bool { 
         return (... && args);  }
 
-#line 102 "pure2-print.cpp2"
+#line 104 "pure2-print.cpp2"
 auto main() -> int{
     outer::test();
 }

--- a/regression-tests/test-results/pure2-print.cpp2.output
+++ b/regression-tests/test-results/pure2-print.cpp2.output
@@ -145,6 +145,7 @@ outer: type =
     }
 
     all: <Args...: type>(in args...: Args) -> move bool = (... && args);
+    using std::endian::native;
 }
  ok (all Cpp2, passes safety checks)
 

--- a/source/parse.h
+++ b/source/parse.h
@@ -3960,6 +3960,12 @@ auto statement_node::position() const
         return s->position();
     }
 
+    break;case using_: {
+        auto const& s = std::get<using_>(statement);
+        assert (s);
+        return s->position();
+    }
+
     break;default:
         assert (!"illegal statement_node state");
         return { 0, 0 };

--- a/source/sema.h
+++ b/source/sema.h
@@ -33,7 +33,7 @@ auto parser::apply_type_metafunctions( declaration_node& n )
     auto rtype = meta::type_declaration{ &n, cs };
 
     return apply_metafunctions(
-        n, 
+        n,
         rtype,
         [&](std::string const& msg) { error( msg, false ); }
     );
@@ -1459,10 +1459,14 @@ public:
             auto compound_stmt = n.initializer->get_if<compound_statement_node>();
             assert (compound_stmt);
             for (auto& stmt : compound_stmt->statements) {
-                if (!stmt->is_declaration()) {
+                if (
+                    !stmt->is_declaration()
+                    && !stmt->is_using()
+                    )
+                {
                     errors.emplace_back(
                         stmt->position(),
-                        "a user-defined type body must contain only declarations, not other code"
+                        "a user-defined type body must contain only declarations or using statements, not other code"
                     );
                     return false;
                 }
@@ -1636,7 +1640,7 @@ public:
             //  Skip type scope (member) variables
             && !(n.parent_is_type() && n.is_object())
             //  Skip unnamed variables
-            && n.identifier 
+            && n.identifier
             //  Skip non-out parameters
             && (
                 !inside_parameter_list


### PR DESCRIPTION
Resolves #803.

<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 818

Total Test time (real) =  42.30 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
