### PR TITLE
feat(reflect): add `@cpp1_rule_of_zero`

### DIFF
--- a/source/reflect.h
+++ b/source/reflect.h
@@ -36,10 +36,10 @@ class type_declaration;
 #line 589 "reflect.h2"
 class alias_declaration;
 
-#line 928 "reflect.h2"
+#line 962 "reflect.h2"
 class value_member_info;
 
-#line 1445 "reflect.h2"
+#line 1482 "reflect.h2"
 }
 
 }
@@ -621,6 +621,31 @@ auto partially_ordered_value(meta::type_declaration& t) -> void;
 #line 868 "reflect.h2"
 //-----------------------------------------------------------------------
 //
+//     C.20: If you can avoid defining default operations, do
+//
+//     ##### Reason
+//
+//     It's the simplest and gives the cleanest semantics.
+//
+//     ...
+//
+//     This is known as "the rule of zero".
+//
+//          -- C++ Core Guidelines
+//             C.20: If you can avoid defining any default operations, do
+//             <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-zero>
+//
+//-----------------------------------------------------------------------
+//
+//  rule_of_zero
+//
+//  a type without declared copy/move/destructor functions
+//
+auto rule_of_zero(meta::type_declaration& t) -> void;
+
+#line 902 "reflect.h2"
+//-----------------------------------------------------------------------
+//
 //     "By definition, a `struct` is a `class` in which members
 //      are by default `public`; that is,
 //
@@ -646,7 +671,7 @@ auto partially_ordered_value(meta::type_declaration& t) -> void;
 //
 auto cpp2_struct(meta::type_declaration& t) -> void;
 
-#line 911 "reflect.h2"
+#line 945 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //     "C enumerations constitute a curiously half-baked concept. ...
@@ -676,7 +701,7 @@ auto basic_enum(
     cpp2::in<bool> bitwise
     ) -> void;
 
-#line 1117 "reflect.h2"
+#line 1151 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //    "An enum[...] is a totally ordered value type that stores a
@@ -688,7 +713,7 @@ auto basic_enum(
 //
 auto cpp2_enum(meta::type_declaration& t) -> void;
 
-#line 1143 "reflect.h2"
+#line 1177 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //     "flag_enum expresses an enumeration that stores values
@@ -701,7 +726,7 @@ auto cpp2_enum(meta::type_declaration& t) -> void;
 //
 auto flag_enum(meta::type_declaration& t) -> void;
 
-#line 1175 "reflect.h2"
+#line 1209 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //     "As with void*, programmers should know that unions [...] are
@@ -728,14 +753,14 @@ auto flag_enum(meta::type_declaration& t) -> void;
 
 auto cpp2_union(meta::type_declaration& t) -> void;
 
-#line 1331 "reflect.h2"
+#line 1365 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  print - output a pretty-printed visualization of t
 //
 auto print(cpp2::in<meta::type_declaration> t) -> void;
 
-#line 1341 "reflect.h2"
+#line 1375 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  apply_metafunctions
@@ -746,7 +771,7 @@ auto print(cpp2::in<meta::type_declaration> t) -> void;
     auto const& error
     ) -> bool;
 
-#line 1445 "reflect.h2"
+#line 1482 "reflect.h2"
 }
 
 }
@@ -1081,7 +1106,7 @@ declaration::declaration(declaration const& that)
     {
         if ((*this).has_handler() && !(!(has_initializer())) ) { (*this).report_violation(CPP2_CONTRACT_MSG("cannot add an initializer to a function that already has one")); }
         if ((*this).has_handler() && !(parent_is_type()) ) { (*this).report_violation(CPP2_CONTRACT_MSG("cannot add an initializer to a function that isn't in a type scope")); }
-        //require( !has_initializer(), 
+        //require( !has_initializer(),
         //         "cannot add an initializer to a function that already has one");
         //require( parent_is_type(),
         //         "cannot add an initializer to a function that isn't in a type scope");
@@ -1442,7 +1467,20 @@ auto partially_ordered_value(meta::type_declaration& t) -> void
     CPP2_UFCS(basic_value)(t);
 }
 
-#line 893 "reflect.h2"
+#line 890 "reflect.h2"
+auto rule_of_zero(meta::type_declaration& t) -> void
+{
+    for ( auto& mf : CPP2_UFCS(get_member_functions)(t) ) 
+    {
+        CPP2_UFCS(require)(t, !(CPP2_UFCS(is_constructor_with_that)(mf)) 
+                   && !(CPP2_UFCS(is_assignment_with_that)(mf)) 
+                   && !(CPP2_UFCS(is_destructor)(mf)), 
+                   "the rule of zero requires no copy/move/destructor functions");
+    }
+    CPP2_UFCS(disable_member_function_generation)(t);
+}
+
+#line 927 "reflect.h2"
 auto cpp2_struct(meta::type_declaration& t) -> void
 {
     for ( auto& m : CPP2_UFCS(get_members)(t) ) 
@@ -1457,10 +1495,10 @@ auto cpp2_struct(meta::type_declaration& t) -> void
                        "a struct may not have a user-defined operator=");
         }
     }
-    CPP2_UFCS(disable_member_function_generation)(t);
+    CPP2_UFCS(rule_of_zero)(t);
 }
 
-#line 934 "reflect.h2"
+#line 968 "reflect.h2"
 auto basic_enum(
     meta::type_declaration& t, 
     auto const& nextval, 
@@ -1485,7 +1523,7 @@ auto basic_enum(
 {
 std::string value{"-1"};
 
-#line 957 "reflect.h2"
+#line 991 "reflect.h2"
     for ( 
           auto const& m : CPP2_UFCS(get_members)(t) ) 
     if (  CPP2_UFCS(is_member_object)(m)) 
@@ -1523,7 +1561,7 @@ std::string value{"-1"};
     }
 }
 
-#line 993 "reflect.h2"
+#line 1027 "reflect.h2"
     if ((CPP2_UFCS(empty)(enumerators))) {
         CPP2_UFCS(error)(t, "an enumeration must contain at least one enumerator value");
         return ; 
@@ -1569,7 +1607,7 @@ std::string value{"-1"};
         }
     }
 
-#line 1039 "reflect.h2"
+#line 1073 "reflect.h2"
     //  2. Replace: Erase the contents and replace with modified contents
     //
     //  Note that most values and functions are declared as '==' compile-time values, i.e. Cpp1 'constexpr'
@@ -1617,7 +1655,7 @@ std::string to_string{"    to_string: (this) -> std::string = { \n"};
 
     //  Provide a 'to_string' function to print enumerator name(s)
 
-#line 1084 "reflect.h2"
+#line 1118 "reflect.h2"
     {
         if (bitwise) {
             to_string += "    _ret   : std::string = \"(\";\n";
@@ -1649,10 +1687,10 @@ std::string to_string{"    to_string: (this) -> std::string = { \n"};
         CPP2_UFCS(add_member)(t, std::move(to_string));
     }
 }
-#line 1114 "reflect.h2"
+#line 1148 "reflect.h2"
 }
 
-#line 1126 "reflect.h2"
+#line 1160 "reflect.h2"
 auto cpp2_enum(meta::type_declaration& t) -> void
 {
     //  Let basic_enum do its thing, with an incrementing value generator
@@ -1669,7 +1707,7 @@ auto cpp2_enum(meta::type_declaration& t) -> void
     );
 }
 
-#line 1153 "reflect.h2"
+#line 1187 "reflect.h2"
 auto flag_enum(meta::type_declaration& t) -> void
 {
     //  Let basic_enum do its thing, with a power-of-two value generator
@@ -1691,7 +1729,7 @@ auto flag_enum(meta::type_declaration& t) -> void
     );
 }
 
-#line 1199 "reflect.h2"
+#line 1233 "reflect.h2"
 auto cpp2_union(meta::type_declaration& t) -> void
 {
     std::vector<value_member_info> alternatives {}; 
@@ -1700,7 +1738,7 @@ auto value{0};
 
     //  1. Gather: All the user-written members, and find/compute the max size
 
-#line 1206 "reflect.h2"
+#line 1240 "reflect.h2"
     for ( 
 
            auto const& m : CPP2_UFCS(get_members)(t) )  { do 
@@ -1725,7 +1763,7 @@ auto value{0};
     } while (false); ++value; }
 }
 
-#line 1229 "reflect.h2"
+#line 1263 "reflect.h2"
     std::string discriminator_type {}; 
     if (cpp2::cmp_less(CPP2_UFCS(ssize)(alternatives),std::numeric_limits<cpp2::i8>::max())) {
         discriminator_type = "i8";
@@ -1740,7 +1778,7 @@ auto value{0};
         discriminator_type = "i64";
     }}}
 
-#line 1244 "reflect.h2"
+#line 1278 "reflect.h2"
     //  2. Replace: Erase the contents and replace with modified contents
 
     CPP2_UFCS(remove_marked_members)(t);
@@ -1749,12 +1787,12 @@ std::string storage{"    _storage: cpp2::aligned_storage<cpp2::max( "};
 
     //  Provide storage
 
-#line 1250 "reflect.h2"
+#line 1284 "reflect.h2"
     {
 {
 std::string comma{""};
 
-#line 1252 "reflect.h2"
+#line 1286 "reflect.h2"
         for ( 
 
               auto const& e : alternatives )  { do {
@@ -1762,12 +1800,12 @@ std::string comma{""};
         } while (false); comma = ", "; }
 }
 
-#line 1258 "reflect.h2"
+#line 1292 "reflect.h2"
         storage += "), cpp2::max( ";
 {
 std::string comma{""};
 
-#line 1261 "reflect.h2"
+#line 1295 "reflect.h2"
         for ( 
 
               auto const& e : alternatives )  { do {
@@ -1775,14 +1813,14 @@ std::string comma{""};
         } while (false); comma = ", "; }
 }
 
-#line 1267 "reflect.h2"
+#line 1301 "reflect.h2"
         storage += " )> = ();\n";
         CPP2_UFCS(add_member)(t, std::move(storage));
     }
 }
 
     //  Provide discriminator
-#line 1272 "reflect.h2"
+#line 1306 "reflect.h2"
     CPP2_UFCS(add_member)(t, ("    _discriminator: " + cpp2::to_string(std::move(discriminator_type)) + " = -1;\n"));
 
     //  Add the alternatives: is_alternative, get_alternative, and set_alternative
@@ -1804,7 +1842,7 @@ std::string destroy{"    private _destroy: (inout this) = {\n"};
 
     //  Add destroy
 
-#line 1291 "reflect.h2"
+#line 1325 "reflect.h2"
     {
         for ( 
               auto const& a : alternatives ) {
@@ -1818,7 +1856,7 @@ std::string destroy{"    private _destroy: (inout this) = {\n"};
 }
 
     //  Add the destructor
-#line 1303 "reflect.h2"
+#line 1337 "reflect.h2"
     CPP2_UFCS(add_member)(t, "    operator=: (move this) = { _destroy(); }");
 
     //  Add default constructor
@@ -1828,7 +1866,7 @@ std::string value_set{""};
 
     //  Add copy/move construction and assignment
 
-#line 1310 "reflect.h2"
+#line 1344 "reflect.h2"
     {
         for ( 
               auto const& a : alternatives ) {
@@ -1848,16 +1886,16 @@ std::string value_set{""};
                     );
     }
 }
-#line 1328 "reflect.h2"
+#line 1362 "reflect.h2"
 }
 
-#line 1335 "reflect.h2"
+#line 1369 "reflect.h2"
 auto print(cpp2::in<meta::type_declaration> t) -> void
 {
     std::cout << CPP2_UFCS(print)(t) << "\n";
 }
 
-#line 1345 "reflect.h2"
+#line 1379 "reflect.h2"
 [[nodiscard]] auto apply_metafunctions(
     declaration_node& n, 
     type_declaration& rtype, 
@@ -1923,6 +1961,9 @@ auto print(cpp2::in<meta::type_declaration> t) -> void
         else {if (name == "partially_ordered_value") {
             partially_ordered_value(rtype);
         }
+        else {if (name == "rule_of_zero") {
+            rule_of_zero(rtype);
+        }
         else {if (name == "struct") {
             cpp2_struct(rtype);
         }
@@ -1940,9 +1981,9 @@ auto print(cpp2::in<meta::type_declaration> t) -> void
         }
         else {
             error("unrecognized metafunction name: " + name);
-            error("(temporary alpha limitation) currently the supported names are: interface, polymorphic_base, ordered, weakly_ordered, partially_ordered, copyable, basic_value, value, weakly_ordered_value, partially_ordered_value, struct, enum, flag_enum, union, print");
+            error("(temporary alpha limitation) currently the supported names are: interface, polymorphic_base, ordered, weakly_ordered, partially_ordered, copyable, basic_value, value, weakly_ordered_value, partially_ordered_value, rule_of_zero, struct, enum, flag_enum, union, print");
             return false; 
-        }}}}}}}}}}}}}}}
+        }}}}}}}}}}}}}}}}
 
         if ((
             !(CPP2_UFCS(empty)(args)) 
@@ -1957,7 +1998,7 @@ auto print(cpp2::in<meta::type_declaration> t) -> void
     return true; 
 }
 
-#line 1445 "reflect.h2"
+#line 1482 "reflect.h2"
 }
 
 }

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -637,11 +637,11 @@ auto partially_ordered_value(meta::type_declaration& t) -> void;
 //
 //-----------------------------------------------------------------------
 //
-//  rule_of_zero
+//  cpp1_rule_of_zero
 //
 //  a type without declared copy/move/destructor functions
 //
-auto rule_of_zero(meta::type_declaration& t) -> void;
+auto cpp1_rule_of_zero(meta::type_declaration& t) -> void;
 
 #line 902 "reflect.h2"
 //-----------------------------------------------------------------------
@@ -843,7 +843,7 @@ namespace meta {
             static_cast<void>(CPP2_UFCS(emplace_back)((*cpp2::assert_not_null(_1)), s, source_line::category::cpp2));
         }}; 
 {
-auto newline_pos{CPP2_UFCS(find)(source, '\n')};
+auto newline_pos = CPP2_UFCS(find)(source, '\n');
 
         //  First split this string into source_lines
         //
@@ -1468,7 +1468,7 @@ auto partially_ordered_value(meta::type_declaration& t) -> void
 }
 
 #line 890 "reflect.h2"
-auto rule_of_zero(meta::type_declaration& t) -> void
+auto cpp1_rule_of_zero(meta::type_declaration& t) -> void
 {
     for ( auto& mf : CPP2_UFCS(get_member_functions)(t) ) 
     {
@@ -1495,7 +1495,7 @@ auto cpp2_struct(meta::type_declaration& t) -> void
                        "a struct may not have a user-defined operator=");
         }
     }
-    CPP2_UFCS(rule_of_zero)(t);
+    CPP2_UFCS(cpp1_rule_of_zero)(t);
 }
 
 #line 968 "reflect.h2"
@@ -1521,7 +1521,7 @@ auto basic_enum(
 
     auto found_non_numeric {false}; 
 {
-std::string value{"-1"};
+std::string value = "-1";
 
 #line 991 "reflect.h2"
     for ( 
@@ -1651,7 +1651,7 @@ std::string value{"-1"};
     CPP2_UFCS(add_member)(t, "    operator=         : (out this, that) == { }");
     CPP2_UFCS(add_member)(t, "    operator<=>       : (this, that) -> std::strong_ordering;");
 {
-std::string to_string{"    to_string: (this) -> std::string = { \n"};
+std::string to_string = "    to_string: (this) -> std::string = { \n";
 
     //  Provide a 'to_string' function to print enumerator name(s)
 
@@ -1734,7 +1734,7 @@ auto cpp2_union(meta::type_declaration& t) -> void
 {
     std::vector<value_member_info> alternatives {}; 
 {
-auto value{0};
+auto value = 0;
 
     //  1. Gather: All the user-written members, and find/compute the max size
 
@@ -1783,14 +1783,14 @@ auto value{0};
 
     CPP2_UFCS(remove_marked_members)(t);
 {
-std::string storage{"    _storage: cpp2::aligned_storage<cpp2::max( "};
+std::string storage = "    _storage: cpp2::aligned_storage<cpp2::max( ";
 
     //  Provide storage
 
 #line 1284 "reflect.h2"
     {
 {
-std::string comma{""};
+std::string comma = "";
 
 #line 1286 "reflect.h2"
         for ( 
@@ -1803,7 +1803,7 @@ std::string comma{""};
 #line 1292 "reflect.h2"
         storage += "), cpp2::max( ";
 {
-std::string comma{""};
+std::string comma = "";
 
 #line 1295 "reflect.h2"
         for ( 
@@ -1838,7 +1838,7 @@ std::string comma{""};
         CPP2_UFCS(add_member)(t, ("    set_" + cpp2::to_string(a.name) + ": (inout this, forward _args...: _) = { if !is_" + cpp2::to_string(a.name) + "() { _destroy(); std::construct_at( reinterpret_cast<*" + cpp2::to_string(a.type) + ">(_storage&), _args...); } else { reinterpret_cast<*" + cpp2::to_string(a.type) + ">(_storage&)* = :" + cpp2::to_string(a.type) + " = (_args...); } _discriminator = " + cpp2::to_string(a.value) + "; }\n"));
     }
 {
-std::string destroy{"    private _destroy: (inout this) = {\n"};
+std::string destroy = "    private _destroy: (inout this) = {\n";
 
     //  Add destroy
 
@@ -1862,7 +1862,7 @@ std::string destroy{"    private _destroy: (inout this) = {\n"};
     //  Add default constructor
     CPP2_UFCS(add_member)(t, "    operator=: (out this) = { }");
 {
-std::string value_set{""};
+std::string value_set = "";
 
     //  Add copy/move construction and assignment
 
@@ -1961,8 +1961,8 @@ auto print(cpp2::in<meta::type_declaration> t) -> void
         else {if (name == "partially_ordered_value") {
             partially_ordered_value(rtype);
         }
-        else {if (name == "rule_of_zero") {
-            rule_of_zero(rtype);
+        else {if (name == "cpp1_rule_of_zero") {
+            cpp1_rule_of_zero(rtype);
         }
         else {if (name == "struct") {
             cpp2_struct(rtype);
@@ -1981,7 +1981,7 @@ auto print(cpp2::in<meta::type_declaration> t) -> void
         }
         else {
             error("unrecognized metafunction name: " + name);
-            error("(temporary alpha limitation) currently the supported names are: interface, polymorphic_base, ordered, weakly_ordered, partially_ordered, copyable, basic_value, value, weakly_ordered_value, partially_ordered_value, rule_of_zero, struct, enum, flag_enum, union, print");
+            error("(temporary alpha limitation) currently the supported names are: interface, polymorphic_base, ordered, weakly_ordered, partially_ordered, copyable, basic_value, value, weakly_ordered_value, partially_ordered_value, struct, enum, flag_enum, union, cpp1_rule_of_zero, print");
             return false; 
         }}}}}}}}}}}}}}}}
 

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -883,11 +883,11 @@ partially_ordered_value: (inout t: meta::type_declaration) =
 //
 //-----------------------------------------------------------------------
 //
-//  rule_of_zero
+//  cpp1_rule_of_zero
 //
 //  a type without declared copy/move/destructor functions
 //
-rule_of_zero: (inout t: meta::type_declaration) =
+cpp1_rule_of_zero: (inout t: meta::type_declaration) =
 {
     for t.get_member_functions() do (inout mf)
     {
@@ -938,7 +938,7 @@ struct: (inout t: meta::type_declaration) =
                        "a struct may not have a user-defined operator=");
         }
     }
-    t.rule_of_zero();
+    t.cpp1_rule_of_zero();
 }
 
 
@@ -1441,8 +1441,8 @@ apply_metafunctions: (
         else if name == "partially_ordered_value" {
             partially_ordered_value( rtype );
         }
-        else if name == "rule_of_zero" {
-            rule_of_zero( rtype );
+        else if name == "cpp1_rule_of_zero" {
+            cpp1_rule_of_zero( rtype );
         }
         else if name == "struct" {
             cpp2_struct( rtype );
@@ -1461,7 +1461,7 @@ apply_metafunctions: (
         }
         else {
             error( "unrecognized metafunction name: " + name );
-            error( "(temporary alpha limitation) currently the supported names are: interface, polymorphic_base, ordered, weakly_ordered, partially_ordered, copyable, basic_value, value, weakly_ordered_value, partially_ordered_value, rule_of_zero, struct, enum, flag_enum, union, print" );
+            error( "(temporary alpha limitation) currently the supported names are: interface, polymorphic_base, ordered, weakly_ordered, partially_ordered, copyable, basic_value, value, weakly_ordered_value, partially_ordered_value, struct, enum, flag_enum, union, cpp1_rule_of_zero, print" );
             return false;
         }
 

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -396,7 +396,7 @@ function_declaration: @copyable type =
         pre<this> (!has_initializer(), "cannot add an initializer to a function that already has one")
         pre<this> (parent_is_type(),   "cannot add an initializer to a function that isn't in a type scope")
     = {
-        //require( !has_initializer(), 
+        //require( !has_initializer(),
         //         "cannot add an initializer to a function that already has one");
         //require( parent_is_type(),
         //         "cannot add an initializer to a function that isn't in a type scope");
@@ -485,7 +485,7 @@ type_declaration: @copyable type =
         -> std::vector<function_declaration>
     = {
         ret: std::vector<function_declaration> = ();
-        for n*.get_type_scope_declarations(declaration_node::functions) 
+        for n*.get_type_scope_declarations(declaration_node::functions)
         do  (d) {
             _ = ret.emplace_back( d, this );
         }
@@ -867,6 +867,40 @@ partially_ordered_value: (inout t: meta::type_declaration) =
 
 //-----------------------------------------------------------------------
 //
+//     C.20: If you can avoid defining default operations, do
+//
+//     ##### Reason
+//
+//     It's the simplest and gives the cleanest semantics.
+//
+//     ...
+//
+//     This is known as "the rule of zero".
+//
+//          -- C++ Core Guidelines
+//             C.20: If you can avoid defining any default operations, do
+//             <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-zero>
+//
+//-----------------------------------------------------------------------
+//
+//  rule_of_zero
+//
+//  a type without declared copy/move/destructor functions
+//
+rule_of_zero: (inout t: meta::type_declaration) =
+{
+    for t.get_member_functions() do (inout mf)
+    {
+        t.require( !mf.is_constructor_with_that()
+                   && !mf.is_assignment_with_that()
+                   && !mf.is_destructor(),
+                   "the rule of zero requires no copy/move/destructor functions");
+    }
+    t.disable_member_function_generation();
+}
+
+//-----------------------------------------------------------------------
+//
 //     "By definition, a `struct` is a `class` in which members
 //      are by default `public`; that is,
 //
@@ -904,7 +938,7 @@ struct: (inout t: meta::type_declaration) =
                        "a struct may not have a user-defined operator=");
         }
     }
-    t.disable_member_function_generation();
+    t.rule_of_zero();
 }
 
 
@@ -1258,8 +1292,8 @@ union: (inout t : meta::type_declaration)
         storage += "), cpp2::max( ";
 
         (copy comma: std::string = "")
-        for  alternatives  
-        next comma = ", "  
+        for  alternatives
+        next comma = ", "
         do   (e) {
             storage += comma + "alignof((e.type)$)";
         }
@@ -1407,6 +1441,9 @@ apply_metafunctions: (
         else if name == "partially_ordered_value" {
             partially_ordered_value( rtype );
         }
+        else if name == "rule_of_zero" {
+            rule_of_zero( rtype );
+        }
         else if name == "struct" {
             cpp2_struct( rtype );
         }
@@ -1424,7 +1461,7 @@ apply_metafunctions: (
         }
         else {
             error( "unrecognized metafunction name: " + name );
-            error( "(temporary alpha limitation) currently the supported names are: interface, polymorphic_base, ordered, weakly_ordered, partially_ordered, copyable, basic_value, value, weakly_ordered_value, partially_ordered_value, struct, enum, flag_enum, union, print" );
+            error( "(temporary alpha limitation) currently the supported names are: interface, polymorphic_base, ordered, weakly_ordered, partially_ordered, copyable, basic_value, value, weakly_ordered_value, partially_ordered_value, rule_of_zero, struct, enum, flag_enum, union, print" );
             return false;
         }
 


### PR DESCRIPTION
Resolves #665.

<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#est)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 818

Total Test time (real) =  64.88 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/
