### PR TITLE
fix(to_cpp1): don't emit `[[nodiscard]]` for pre-increment/decrement

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -2229,6 +2229,9 @@ struct function_type_node
     auto is_comparison() const
         -> bool;
 
+    auto is_prefix_increment_or_decrement() const
+        -> bool;
+
     auto is_compound_assignment() const
         -> bool;
 
@@ -3197,6 +3200,16 @@ public:
         return false;
     }
 
+    auto is_prefix_increment_or_decrement() const
+        -> bool
+    {
+        if (auto func = std::get_if<a_function>(&type)) {
+            return (*func)->is_prefix_increment_or_decrement();
+        }
+        //  else
+        return false;
+    }
+
     auto is_compound_assignment() const
         -> bool
     {
@@ -3701,6 +3714,25 @@ auto function_type_node::is_comparison() const
             || my_decl->has_name("operator>=")
             || my_decl->has_name("operator<=>")
         )
+        )
+    {
+        return true;
+    }
+    return false;
+}
+
+
+auto function_type_node::is_prefix_increment_or_decrement() const
+    -> bool
+{
+    if (
+        (
+            my_decl->has_name("operator++")
+            || my_decl->has_name("operator--")
+        )
+        && (*parameters).ssize() == 1
+        && (*parameters)[0]->has_name("this")
+        && (*parameters)[0]->direction() == passing_style::inout
         )
     {
         return true;

--- a/source/parse.h
+++ b/source/parse.h
@@ -2229,7 +2229,7 @@ struct function_type_node
     auto is_comparison() const
         -> bool;
 
-    auto is_prefix_increment_or_decrement() const
+    auto is_increment_or_decrement() const
         -> bool;
 
     auto is_compound_assignment() const
@@ -3200,11 +3200,11 @@ public:
         return false;
     }
 
-    auto is_prefix_increment_or_decrement() const
+    auto is_increment_or_decrement() const
         -> bool
     {
         if (auto func = std::get_if<a_function>(&type)) {
-            return (*func)->is_prefix_increment_or_decrement();
+            return (*func)->is_increment_or_decrement();
         }
         //  else
         return false;
@@ -3722,17 +3722,12 @@ auto function_type_node::is_comparison() const
 }
 
 
-auto function_type_node::is_prefix_increment_or_decrement() const
+auto function_type_node::is_increment_or_decrement() const
     -> bool
 {
     if (
-        (
-            my_decl->has_name("operator++")
-            || my_decl->has_name("operator--")
-        )
-        && (*parameters).ssize() == 1
-        && (*parameters)[0]->has_name("this")
-        && (*parameters)[0]->direction() == passing_style::inout
+        my_decl->has_name("operator++")
+        || my_decl->has_name("operator--")
         )
     {
         return true;

--- a/source/sema.h
+++ b/source/sema.h
@@ -1523,6 +1523,34 @@ public:
     }
 
 
+    auto check(function_type_node const& n)
+        -> bool
+    {
+        //  An increment/decrement function must have a single parameter that is 'inout this'
+        if (
+            (
+                n.my_decl->has_name("operator++")
+                || n.my_decl->has_name("operator--")
+            )
+            &&
+            (
+               (*n.parameters).ssize() != 1
+            || !(*n.parameters)[0]->has_name("this")
+            || (*n.parameters)[0]->direction() != passing_style::inout
+            )
+            )
+        {
+            errors.emplace_back(
+                n.position(),
+                "a user-defined " + n.my_decl->name()->to_string() + " must have a single 'inout this' parameter"
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+
     auto check(statement_node const& n)
         -> bool
     {

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -4594,6 +4594,10 @@ public:
     )
         -> void
     {
+        if (!sema.check(n)) {
+            return;
+        }
+
         assert(n.parameters);
 
         if (
@@ -6093,7 +6097,7 @@ public:
                     func->has_non_void_return_type()
                     && !func->is_assignment()
                     && !func->is_compound_assignment()
-                    && !func->is_prefix_increment_or_decrement()
+                    && !func->is_increment_or_decrement()
                     && (
                         printer.get_phase() == printer.phase1_type_defs_func_decls
                         || n.has_initializer()  // so we're printing it in phase 2

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -6093,6 +6093,7 @@ public:
                     func->has_non_void_return_type()
                     && !func->is_assignment()
                     && !func->is_compound_assignment()
+                    && !func->is_prefix_increment_or_decrement()
                     && (
                         printer.get_phase() == printer.phase1_type_defs_func_decls
                         || n.has_initializer()  // so we're printing it in phase 2

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -4594,11 +4594,11 @@ public:
     )
         -> void
     {
+        assert(n.parameters);
+
         if (!sema.check(n)) {
             return;
         }
-
-        assert(n.parameters);
 
         if (
             is_main


### PR DESCRIPTION
Resolves #882.

<a id="test"/>
<!-- <details><summary>
<a href="#test">T</a>esting summary:
</summary> -->

**[T](#test)esting summary**:

```ctest
100% tests passed, 0 tests failed out of 858

Total Test time (real) =  44.64 sec
```

<!-- </details> -->

<a id="ack"/>

**[A](#ack)cknowledgements**:

<!-- <details><summary>
<a href="#ack">A</a>cknowledgements:
</summary> -->

- Tested thanks to <https://github.com/modern-cmake/cppfront>.
- Commit messages follow [Conventional Commits][] 1.0.0.
- Comments and commit messages follow [Semantic Line Breaks][].

<!-- </details> -->

[Conventional Commits]: https://www.conventionalcommits.org/
[Semantic Line Breaks]: https://sembr.org/

[ABI]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#abi-api
[ADL]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#adl
[CNTTP]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#cnttp
[CPO]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#cpo
[CRTP]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#crtp
[CTAD]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#ctad
[WG]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#cwg-ewg-ewgi-lewg-lewgi-lwg
[SG]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#cwg-ewg-ewgi-lewg-lewgi-lwg
[EH]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#eh-tdeh
[HALO]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#halo
[ICE]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#ice
[IFNDR]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#ifndr
[II]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#iile
[NSDMI]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#nsdmi
[NTTP]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#nttp
[ODR]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#odr
[PIMPL]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#pimpl
[QoI]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#qoi
[RVO]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#rvo-nrvo-urvo
[SBO]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#sbo-soo-sso
[SCARY]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#scary-iterators
[SFINAE]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#sfinae
[SMF]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#smf
[STL]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#stl
[TMP]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#tmp
[TU]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#tu
[UB]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#ub
[UDL]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#udl
[UFCS]: https://quuxplusone.github.io/blog/2019/08/02/the-tough-guide-to-cpp-acronyms/#ufcs
