### PR TITLE
CI: Add macos-11 Clang 13 runner, Add badge to Readme

### DIFF
--- a/.github/workflows/build-cppfront.yaml
+++ b/.github/workflows/build-cppfront.yaml
@@ -27,6 +27,9 @@ jobs:
           - compiler: clang++-14
             cxx-std: 'c++2b'
         include:
+          - runs-on: macos-11
+            compiler: clang++
+            cxx-std: 'c++20'
           - runs-on: macos-latest
             compiler: clang++
             cxx-std: 'c++20'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 See [License](LICENSE)
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Build (clang, gcc, vs)](https://github.com/hsutter/cppfront/actions/workflows/build-cppfront.yaml/badge.svg)](https://github.com/hsutter/cppfront/actions/workflows/build-cppfront.yaml)
 
 Cppfront is an experimental compiler from a potential C++ 'syntax 2' (Cpp2) to today's 'syntax 1' (Cpp1), to learn some things, prove out some concepts, and share some ideas. This compiler is a work in progress and currently hilariously incomplete... basic functions work, classes will be next, then metaclasses and lightweight exceptions.
 


### PR DESCRIPTION
Apple Clang 13 seems to be the lowest version we can go with the pre-installed compilers in the existing runners.

Tried adding Apple M1 (arm64) runner, but it seems like it requires Github Enterprise licensing at this time. Also tried adding Apple Clang 15 (via macos-13 runner), but I got a bunch of linking errors, I think it has to do with different compilers using different versions of libc++, but I am not completely sure. You can try yourself by adding:
```yaml
          - runs-on: macos-13
            compiler: /usr/local/opt/llvm@15/bin/clang
            cxx-std: 'c++20'
```

Finally, this commit also adds a bit of flavor to the Readme by showing that the main branch is currently passing CI.