### PR TITLE
Update bounds check apple-clang-14 test

### DIFF
--- a/regression-tests/test-results/apple-clang-14/mixed-bounds-check.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/mixed-bounds-check.cpp.execution
@@ -1,1 +1,1 @@
-Bounds safety violation: out of bounds access attempt detected - attempted index 5, [min,max] range is [0,4]
+Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]


### PR DESCRIPTION
Update another MacOS test missed in a recent PR. The issue was spotted thanks to the tools from https://github.com/hsutter/cppfront/pull/897.