### PR TITLE
Add .gitattributes with auto line feed treatment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
The `* text=auto` option causes the line endings in text files to be normalized to LF on check-in, but reset to the platform-specific version on check-out.
This should ensure consistency of the repo throughout development on different platforms, while providing platform-specific line endings in the working directory. After some double-checking this seems to be the safest option to ensure global consistency for multi-platform development.
In its current version `.gitattributes` lets git decide what is/isn't a text file. This is not an issue in the for cppfront as all files in the repo are text. However, if it becomes necessary, further configuration can be added to the file to ensure certain files/files with certain extensions are treated as binary and so untouched on check-in/check-out.

In addition, to avoid the pain of diffs with only line ending differences in regression tests I have been using:
```
git diff --ignore-cr-at-eol -- <the file to check>
```