### PR TITLE
Bugfix: lowering of variadic templates of functions

### DIFF
--- a/regression-tests/pure2-variadics.cpp2
+++ b/regression-tests/pure2-variadics.cpp2
@@ -2,6 +2,8 @@
 //  Type pack expansion
 x: <Ts...: type> type = {
     tup: std::tuple<Ts...> = ();
+
+    func: () = {}
 }
 
 left_fold_print: <Args...: type> (inout out: std::ostream, args...: Args) = {

--- a/regression-tests/test-results/pure2-variadics.cpp
+++ b/regression-tests/test-results/pure2-variadics.cpp
@@ -20,19 +20,21 @@ template<typename ...Ts> class x;
 #line 3 "pure2-variadics.cpp2"
 template<typename ...Ts> class x {
     private: std::tuple<Ts...> tup {}; 
+
+    public: static auto func() -> void;
     public: x() = default;
     public: x(x const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(x const&) -> void = delete;
 
-#line 5 "pure2-variadics.cpp2"
+#line 7 "pure2-variadics.cpp2"
 };
 
 template<typename ...Args> auto left_fold_print(std::ostream& out, Args const& ...args) -> void;
 
-#line 12 "pure2-variadics.cpp2"
+#line 14 "pure2-variadics.cpp2"
 template<typename ...Args> [[nodiscard]] auto all(Args const& ...args) -> bool;
 
-#line 16 "pure2-variadics.cpp2"
+#line 18 "pure2-variadics.cpp2"
 template     <typename ...Args> [[nodiscard]] auto make_string(Args&& ...args) -> auto;
 
 template  <typename T, typename ...Args> [[nodiscard]] auto make(Args&& ...args) -> auto;
@@ -43,7 +45,10 @@ auto main() -> int;
 
 #line 1 "pure2-variadics.cpp2"
 
-#line 7 "pure2-variadics.cpp2"
+#line 6 "pure2-variadics.cpp2"
+    template <typename ...Ts> auto x<Ts...>::func() -> void{}
+
+#line 9 "pure2-variadics.cpp2"
 template<typename ...Args> auto left_fold_print(std::ostream& out, Args const& ...args) -> void{
     //  Binary left fold expression
     (out << ... << args);
@@ -59,7 +64,7 @@ template  <typename T, typename ...Args> [[nodiscard]] auto make(Args&& ...args)
 
 auto main() -> int
 {
-    x<int,long,std::string> auto_22_5 {}; 
+    x<int,long,std::string> auto_24_5 {}; 
 
     std::cout << std::string("xyzzy", 3) << "\n";
     std::cout << make_string("plugh", cpp2::u8{3}) << "\n";

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -4888,6 +4888,9 @@ public:
                     for (auto& tparam : parent->template_parameters->parameters) {
                         assert (tparam->has_name());
                         list += separator + tparam->name()->to_string();
+                        if(tparam->declaration->is_variadic) {
+                            list += "...";
+                        }
                         separator = ",";
                     }
                     list += ">";


### PR DESCRIPTION
Resolves #875

__Minimal example__: https://cpp2.godbolt.org/z/1bGGanfnr
```
x: <Ts...: type> type = { 
    func: () = {}
}
```
__Error__:
```
main.cpp2:2:36: error: qualifier contains unexpanded parameter pack 'Ts'
    2 |     template <typename ...Ts> auto x<Ts>::func() -> void{}
      |                                    ^
```
__Correct code__:
```
 template <typename ...Ts> auto x<Ts...>::func() -> void{}
```

