### PR TITLE
Fix possible division by zero when using -verbose

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -78,7 +78,10 @@ auto main(
                 auto total = count.cpp1_lines + count.cpp2_lines;
                 if (total > 0) {
                     out << " (";
-                    if (count.cpp2_lines / count.cpp1_lines > 25) {
+                    if (count.cpp1_lines == 0) {
+                        out << 100;
+                    }
+                    else if (count.cpp2_lines / count.cpp1_lines > 25) {
                         out << std::setprecision(3)
                             << 100.0 * count.cpp2_lines / total;
                     }


### PR DESCRIPTION
I encountered an issue where using `-verbose` on a pure cpp2 file causes a floating point exception, as there are zero cpp1 lines, this PR fixes it.

To reproduce you may compile this simple file (or any other pure cpp2 file) with `-verbose`, other flags don't matter:
```cc
main: () -> int = {
  return 0;
}
```