### PR TITLE
CI: Enable pedantic warnings and treat all warnings as errors

### DIFF
--- a/.github/workflows/build-cppfront.yaml
+++ b/.github/workflows/build-cppfront.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Compiler name & version
         run: cl.exe
       - name: Build
-        run: cl.exe source/cppfront.cpp -std:c++latest -MD -EHsc -experimental:module -W4
+        run: cl.exe source/cppfront.cpp -std:c++latest -MD -EHsc -experimental:module -W4 -WX
   build-unix-like:
     strategy:
       fail-fast: false
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     env:
       CXX: ${{ matrix.compiler }}
-      CXXFLAGS: -std=${{ matrix.cxx-std }} -Wall -Wextra -Wold-style-cast -pthread
+      CXXFLAGS: -std=${{ matrix.cxx-std }} -Wall -Wextra -Wold-style-cast -Wpedantic -Werror -pthread
     steps:
     - uses: actions/checkout@v3
     - name: Install compiler

--- a/source/common.h
+++ b/source/common.h
@@ -65,8 +65,8 @@ struct source_line
         -> int
     {
         return
-            std::find_if_not( text.begin(), text.end(), &isspace )
-                - text.begin();
+            unsafe_narrow<int>(std::find_if_not( text.begin(), text.end(), &isspace )
+                               - text.begin());
     }
 
     auto prefix() const
@@ -759,7 +759,7 @@ public:
         auto length = std::ssize(name);
         if (opt_out) { length += 3; }   // space to print "[-]"
         if (max_flag_length < length) {
-            max_flag_length = length;
+            max_flag_length = unsafe_narrow<int>(length);
         }
     }
     struct register_flag {

--- a/source/common.h
+++ b/source/common.h
@@ -334,7 +334,7 @@ auto is_nondigit(char c)
         isalpha(c)
         || c == '_'
         ;
-};
+}
 
 //G identifier-start:
 //G     nondigit
@@ -379,7 +379,7 @@ auto starts_with_identifier(std::string_view s)
         return j;
     }
     return 0;
-};
+}
 
 
 //  Helper to allow one of the above or a digit separator

--- a/source/io.h
+++ b/source/io.h
@@ -457,7 +457,7 @@ public:
     }
 
     auto current_depth() const -> int {
-        return std::ssize(open_braces);
+        return unsafe_narrow<int>(std::ssize(open_braces));
     }
 
     //  --- Preprocessor matching functions - #if/#else/#endif
@@ -610,7 +610,7 @@ auto process_cpp_line(
                 return r;
             }
             in_raw_string_literal = false;
-            i = end_pos+raw_string_closing_seq.size()-1;
+            i = unsafe_narrow<int>(end_pos+raw_string_closing_seq.size()-1);
         }
         else {
             r.all_comment_line = false;
@@ -797,7 +797,7 @@ auto process_cpp2_line(
 
     if (in_char_literal) {
         errors.emplace_back(
-            source_position(lineno, ssize(line)),
+            source_position(lineno, unsafe_narrow<colno_t>(ssize(line))),
             std::string("line ended before character literal was terminated")
         );
     }
@@ -957,7 +957,7 @@ public:
                             lines.back().text,
                             in_comment,
                             braces,
-                            std::ssize(lines)-1,
+                            unsafe_narrow<lineno_t>(std::ssize(lines)-1),
                             errors
                         )
                         && in.getline(&buf[0], max_line_len)
@@ -982,7 +982,7 @@ public:
                             in_raw_string_literal,
                             raw_string_closing_seq,
                             braces,
-                            std::ssize(lines) - 1
+                            unsafe_narrow<lineno_t>(std::ssize(lines)-1)
                         );
                         if (stats.all_comment_line) {
                             lines.back().cat = source_line::category::comment;

--- a/source/lex.h
+++ b/source/lex.h
@@ -286,13 +286,13 @@ public:
         pos.colno += offset;
     }
 
-    auto position() const -> source_position { return pos;       }
+    auto position() const -> source_position { return pos;                           }
 
-    auto length  () const -> int             { return sv.size(); }
+    auto length  () const -> int             { return unsafe_narrow<int>(sv.size()); }
 
-    auto type    () const -> lexeme          { return lex_type;  }
+    auto type    () const -> lexeme          { return lex_type;                      }
 
-    auto set_type(lexeme l) -> void          { lex_type = l;     }
+    auto set_type(lexeme l) -> void          { lex_type = l;                         }
 
     auto visit(auto& v, int depth) const
         -> void
@@ -307,7 +307,7 @@ public:
             )
         {
             sv.remove_prefix(prefix.size());
-            pos.colno += prefix.size();
+            pos.colno += unsafe_narrow<colno_t>(prefix.size());
         }
     }
 
@@ -816,7 +816,7 @@ auto lex_line(
             source_position(lineno, i + 1),
             type
             });
-        i += num-1;
+        i += unsafe_narrow<int>(num-1);
 
         merge_cpp1_multi_token_fundamental_type_names();
         merge_operator_function_names();
@@ -1066,7 +1066,7 @@ auto lex_line(
         auto parts = expand_raw_string_literal(opening_seq, closing_seq, closing_strategy, part, errors, source_position(lineno, pos_to_replace + 1));
         auto new_part = parts.generate();
         mutable_line.replace( pos_to_replace, size_to_replace, new_part );
-        i += std::ssize(new_part)-1;
+        i += unsafe_narrow<colno_t>(std::ssize(new_part)-1);
 
         if (parts.is_expanded()) {
             // raw string was expanded and we need to repeat the processing of this line
@@ -1147,7 +1147,7 @@ auto lex_line(
                 auto closing_strategy = end_pos == line.npos ? string_parts::no_ends : string_parts::on_the_end;
                 auto size_to_replace  = end_pos == line.npos ? std::ssize(line) - i  : end_pos - i + std::ssize(rsm.closing_seq);
 
-                if (interpolate_raw_string(rsm.opening_seq, rsm.closing_seq, closing_strategy, part, i, size_to_replace ) ) {
+                if (interpolate_raw_string(rsm.opening_seq, rsm.closing_seq, closing_strategy, part, i, unsafe_narrow<int>(size_to_replace) ) ) {
                     continue;
                 }
             }
@@ -1164,7 +1164,7 @@ auto lex_line(
             raw_string_multiline.value().text += raw_string_multiline.value().closing_seq;
 
             // and position where multiline_raw_string ends (needed for reseting line parsing)
-            i = end_pos+std::ssize(raw_string_multiline.value().closing_seq)-1;
+            i = unsafe_narrow<colno_t>(end_pos+std::ssize(raw_string_multiline.value().closing_seq)-1);
 
             const auto& text = raw_string_multiline.value().should_interpolate ? raw_string_multiline.value().text.substr(1) : raw_string_multiline.value().text;
             multiline_raw_strings.emplace_back(multiline_raw_string{ text, {lineno, i} });
@@ -1379,7 +1379,9 @@ auto lex_line(
                                     opening_seq,
                                     closing_seq,
                                     string_parts::on_both_ends,
-                                    std::string_view(&line[paren_pos+1], closing_pos-paren_pos-1), i, closing_pos-i+std::ssize(closing_seq))
+                                    std::string_view(&line[paren_pos+1], closing_pos-paren_pos-1),
+                                    i,
+                                    unsafe_narrow<int>(closing_pos-i+std::ssize(closing_seq)))
                             ) {
                                 continue;
                             }
@@ -1397,12 +1399,14 @@ auto lex_line(
                                     opening_seq,
                                     closing_seq,
                                     string_parts::on_the_beginning,
-                                    std::string_view(&line[paren_pos+1], std::ssize(line)-(paren_pos+1)), i, std::ssize(line)-i)
+                                    std::string_view(&line[paren_pos+1], std::ssize(line)-(paren_pos+1)),
+                                    i,
+                                    unsafe_narrow<int>(std::ssize(line)-i))
                             ) {
                                 continue;
                             }
                             // skip entire raw string opening sequence R"
-                            i = paren_pos;
+                            i = unsafe_narrow<int>(paren_pos);
 
                             // if we are on the end of the line we need to add new line char
                             if (i+1 == std::ssize(line)) {
@@ -1594,7 +1598,7 @@ auto lex_line(
                             } else {
                                 raw_string_multiline.emplace(raw_string{source_position{lineno, i}, opening_seq, opening_seq, closing_seq });
                                 // skip entire raw string opening sequence R"
-                                i = paren_pos;
+                                i = unsafe_narrow<int>(paren_pos);
 
                                 // if we are on the end of the line we need to add new line char
                                 if (i+1 == std::ssize(line)) {
@@ -1842,7 +1846,7 @@ public:
 
             //  Create new map entry for the section starting at this line,
             //  and populate its tokens with the tokens in this section
-            auto lineno = std::distance(std::begin(lines), line);
+            auto lineno = unsafe_narrow<lineno_t>(std::distance(std::begin(lines), line));
 
             //  If this is generated code, use negative line numbers to
             //  inform and assist the printer

--- a/source/lex.h
+++ b/source/lex.h
@@ -199,7 +199,7 @@ auto _as(lexeme l)
     break;case lexeme::None:                return "(NONE)";
     break;default:                          return "INTERNAL-ERROR";
     }
-};
+}
 
 
 auto is_operator(lexeme l)

--- a/source/parse.h
+++ b/source/parse.h
@@ -322,7 +322,7 @@ struct binary_expression_node
     auto terms_size() const
         -> int
     {
-        return std::ssize(terms);
+        return unsafe_narrow<int>(std::ssize(terms));
     }
 
     auto is_identifier() const
@@ -2313,7 +2313,7 @@ struct function_type_node
     auto parameter_count() const
         -> int
     {
-        return std::ssize(parameters->parameters);
+        return unsafe_narrow<int>(std::ssize(parameters->parameters));
     }
 
     auto index_of_parameter_named(std::string_view s) const
@@ -5780,7 +5780,7 @@ private:
         }
 
         for (auto& e : expression_node::current_expressions) {
-            e->num_subexpressions += std::ssize(n->ops);
+            e->num_subexpressions += unsafe_narrow<int>(std::ssize(n->ops));
         }
 
         return n;

--- a/source/sema.h
+++ b/source/sema.h
@@ -546,7 +546,7 @@ public:
         //-----------------------------------------------------------------------
         //  Function logic: For each entry in the table...
         //
-        for (auto sympos = std::ssize(symbols) - 1; sympos >= 0; --sympos)
+        for (auto sympos = unsafe_narrow<int>(std::ssize(symbols) - 1); sympos >= 0; --sympos)
         {
             //  If this is an uninitialized local variable,
             //  ensure it is definitely initialized and tag those initializations

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -376,11 +376,11 @@ private:
             //  Now also adjust the colno
             if (last_newline != std::string::npos) {
                 //  If we found a newline, it's the distance from the last newline to EOL
-                curr_pos.colno = s.length() - last_newline;
+                curr_pos.colno = unsafe_narrow<colno_t>(s.length() - last_newline);
             }
             else {
                 //  Else add the length of the string
-                curr_pos.colno += s.length();
+                curr_pos.colno += unsafe_narrow<colno_t>(s.length());
             }
         }
     }
@@ -2752,7 +2752,7 @@ public:
             return is_pointer_declaration(type_id_node->address_of, deref_cnt, addr_cnt + 1);
         }
 
-        int pointer_declarators_cnt = std::count_if(std::cbegin(type_id_node->pc_qualifiers), std::cend(type_id_node->pc_qualifiers), [](auto* q) {
+        auto pointer_declarators_cnt = std::count_if(std::cbegin(type_id_node->pc_qualifiers), std::cend(type_id_node->pc_qualifiers), [](auto* q) {
             return q->type() == lexeme::Multiply;
         });
 
@@ -2764,7 +2764,7 @@ public:
             return is_pointer_declaration(type_id_node->suspicious_initialization, deref_cnt, addr_cnt);
         }
 
-        return (pointer_declarators_cnt + addr_cnt - deref_cnt) > 0;
+        return (unsafe_narrow<int>(pointer_declarators_cnt) + addr_cnt - deref_cnt) > 0;
     }
 
     auto is_pointer_declaration(


### PR DESCRIPTION
This PRs makes the CI workflows fail if the compiler emits warnings for cppfront code (by using `-Werror` on clang/gcc and `-WX` on MSVC), it also adds `-pedantic` to clang/gcc to catch additional oversights.

Separately, I provide narrowing conversion "fixes", but I am not too fond of this commit, since it feels like the correct thing to do would be to promote `int` to _whatever `std::ssize` returns_ in most places, I didn't do that yet as I believe this requires more thought on the design of the compiler's code and want feedback first. The commit could be skipped and done by someone else, or the warning could be disabled (seen that in lots of projects 😛).