### PR TITLE
fix: lower (nested) _braced-init-list_ (argument)

### DIFF
--- a/regression-tests/pure2-bugfix-for-nested-lists.cpp2
+++ b/regression-tests/pure2-bugfix-for-nested-lists.cpp2
@@ -1,0 +1,27 @@
+point: @value type = {
+    public x: int = 0;
+    public y: int = 0;
+    operator=: (implicit out this, x_: int, y_: int) = {
+        x = x_;
+        y = y_;
+    }
+}
+
+check: (p: point) p;
+
+main: () = {
+    assert(check((17, 29)).x == 17);
+    assert(check((17, 29)).y == 29);
+
+    board: std::array<std::array<u8, 3>, 3> = ((
+                                            ('O', 'X', 'O'),
+                                            (' ', ('X'), 'X'),
+                                            ('X', 'O', 'O')
+    ));
+    assert(board[0] == :std::array<u8, 3> = ('O', 'X', 'O'));
+    assert(board[1] == :std::array<u8, 3> = (' ', 'X', 'X'));
+    assert(board[2] == :std::array<u8, 3> = ('X', 'O', 'O'));
+
+    // Still parentheses (for now?)
+    assert((:std::vector = (17, 29)).size() == 2);
+}

--- a/regression-tests/pure2-bugfix-for-nested-lists.cpp2
+++ b/regression-tests/pure2-bugfix-for-nested-lists.cpp2
@@ -27,7 +27,6 @@ main: () = {
 }
 
 issue_1283: () = {
-  arr: std::array<std::string, 10> = ();
-  f: MyFunctor = ("Some initial value");
-  std::ranges::generate(arr, :() (f&$*)());
+  f := :() = { };
+  _ = :() = (f&$*)();
 }

--- a/regression-tests/pure2-bugfix-for-nested-lists.cpp2
+++ b/regression-tests/pure2-bugfix-for-nested-lists.cpp2
@@ -25,3 +25,9 @@ main: () = {
     // Still parentheses (for now?)
     assert((:std::vector = (17, 29)).size() == 2);
 }
+
+issue_1283: () = {
+  arr: std::array<std::string, 10> = ();
+  f: MyFunctor = ("Some initial value");
+  std::ranges::generate(arr, :() (f&$*)());
+}

--- a/regression-tests/pure2-hashable.cpp2
+++ b/regression-tests/pure2-hashable.cpp2
@@ -3,7 +3,7 @@ base: @struct @hashable type = {
 }
 
 mystruct: @struct @hashable type = {
-    this: base = (1);
+    this: base = 1;
     i: i32;
     j: std::string;
     k: u64;

--- a/regression-tests/test-results/mixed-default-arguments.cpp
+++ b/regression-tests/test-results/mixed-default-arguments.cpp
@@ -33,8 +33,8 @@ auto cxx2(cpp2::impl::in<int> x, cpp2::impl::in<std::string> y) -> void{
 #line 9 "mixed-default-arguments.cpp2"
 auto main() -> int{
  cxx(1, "test");
- cxx({}, {});
+ cxx({  }, {  });
  cxx2(1, "test");
- cxx2({}, {});
+ cxx2({  }, {  });
 }
 

--- a/regression-tests/test-results/pure2-bugfix-for-nested-lists.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-nested-lists.cpp
@@ -1,0 +1,86 @@
+
+#define CPP2_IMPORT_STD          Yes
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "pure2-bugfix-for-nested-lists.cpp2"
+class point;
+#line 2 "pure2-bugfix-for-nested-lists.cpp2"
+    
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-bugfix-for-nested-lists.cpp2"
+class point {
+#line 2 "pure2-bugfix-for-nested-lists.cpp2"
+    public: int x {0}; 
+    public: int y {0}; 
+    public: point(cpp2::impl::in<int> x_, cpp2::impl::in<int> y_);
+    public: [[nodiscard]] auto operator<=>(point const& that) const& -> std::strong_ordering = default;
+public: point(point const& that);
+
+public: auto operator=(point const& that) -> point& ;
+public: point(point&& that) noexcept;
+public: auto operator=(point&& that) noexcept -> point& ;
+public: explicit point();
+
+#line 8 "pure2-bugfix-for-nested-lists.cpp2"
+};
+
+[[nodiscard]] auto check(cpp2::impl::in<point> p) -> auto;
+
+auto main() -> int;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-bugfix-for-nested-lists.cpp2"
+
+#line 4 "pure2-bugfix-for-nested-lists.cpp2"
+    point::point(cpp2::impl::in<int> x_, cpp2::impl::in<int> y_)
+        : x{ x_ }
+        , y{ y_ }{
+
+#line 7 "pure2-bugfix-for-nested-lists.cpp2"
+    }
+
+
+    point::point(point const& that)
+                                : x{ that.x }
+                                , y{ that.y }{}
+
+auto point::operator=(point const& that) -> point& {
+                                x = that.x;
+                                y = that.y;
+                                return *this;}
+point::point(point&& that) noexcept
+                                : x{ std::move(that).x }
+                                , y{ std::move(that).y }{}
+auto point::operator=(point&& that) noexcept -> point& {
+                                x = std::move(that).x;
+                                y = std::move(that).y;
+                                return *this;}
+point::point(){}
+#line 10 "pure2-bugfix-for-nested-lists.cpp2"
+[[nodiscard]] auto check(cpp2::impl::in<point> p) -> auto { return p;  }
+
+#line 12 "pure2-bugfix-for-nested-lists.cpp2"
+auto main() -> int{
+    if (cpp2::cpp2_default.is_active() && !(check({ 17, 29 }).x == 17) ) { cpp2::cpp2_default.report_violation(""); }
+    if (cpp2::cpp2_default.is_active() && !(check({ 17, 29 }).y == 29) ) { cpp2::cpp2_default.report_violation(""); }
+
+    std::array<std::array<cpp2::u8,3>,3> board {{ { 
+                                            'O', 'X', 'O' }, { 
+                                            ' ', { 'X' }, 'X' }, { 
+                                            'X', 'O', 'O' } }}; 
+
+    if (cpp2::cpp2_default.is_active() && !(CPP2_ASSERT_IN_BOUNDS_LITERAL(board, 0) == std::array<cpp2::u8,3>{'O', 'X', 'O'}) ) { cpp2::cpp2_default.report_violation(""); }
+    if (cpp2::cpp2_default.is_active() && !(CPP2_ASSERT_IN_BOUNDS_LITERAL(board, 1) == std::array<cpp2::u8,3>{' ', 'X', 'X'}) ) { cpp2::cpp2_default.report_violation(""); }
+    if (cpp2::cpp2_default.is_active() && !(CPP2_ASSERT_IN_BOUNDS_LITERAL(cpp2::move(board), 2) == std::array<cpp2::u8,3>{'X', 'O', 'O'}) ) { cpp2::cpp2_default.report_violation(""); }
+
+    // Still parentheses (for now?)
+    if (cpp2::cpp2_default.is_active() && !(CPP2_UFCS(size)((std::vector{17, 29})) == 2) ) { cpp2::cpp2_default.report_violation(""); }
+}
+

--- a/regression-tests/test-results/pure2-bugfix-for-nested-lists.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-nested-lists.cpp
@@ -34,6 +34,9 @@ public: explicit point();
 
 auto main() -> int;
 
+#line 29 "pure2-bugfix-for-nested-lists.cpp2"
+auto issue_1283() -> void;
+
 //=== Cpp2 function definitions =================================================
 
 #line 1 "pure2-bugfix-for-nested-lists.cpp2"
@@ -82,5 +85,12 @@ auto main() -> int{
 
     // Still parentheses (for now?)
     if (cpp2::cpp2_default.is_active() && !(CPP2_UFCS(size)((std::vector{17, 29})) == 2) ) { cpp2::cpp2_default.report_violation(""); }
+}
+
+#line 29 "pure2-bugfix-for-nested-lists.cpp2"
+auto issue_1283() -> void{
+  std::array<std::string,10> arr {}; 
+  MyFunctor f {"Some initial value"}; 
+  std::ranges::generate(cpp2::move(arr), [_0 = (&f)]() mutable -> auto { return (*cpp2::impl::assert_not_null(_0))();  });
 }
 

--- a/regression-tests/test-results/pure2-bugfix-for-nested-lists.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-nested-lists.cpp
@@ -89,8 +89,7 @@ auto main() -> int{
 
 #line 29 "pure2-bugfix-for-nested-lists.cpp2"
 auto issue_1283() -> void{
-  std::array<std::string,10> arr {}; 
-  MyFunctor f {"Some initial value"}; 
-  std::ranges::generate(cpp2::move(arr), [_0 = (&f)]() mutable -> auto { return (*cpp2::impl::assert_not_null(_0))();  });
+  auto f {[]() -> void{}}; 
+  static_cast<void>([_0 = (&f)]() mutable -> void { (*cpp2::impl::assert_not_null(_0))();  });
 }
 

--- a/regression-tests/test-results/pure2-bugfix-for-nested-lists.cpp2.output
+++ b/regression-tests/test-results/pure2-bugfix-for-nested-lists.cpp2.output
@@ -1,0 +1,2 @@
+pure2-bugfix-for-nested-lists.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/regression-tests/test-results/pure2-hashable.cpp
+++ b/regression-tests/test-results/pure2-hashable.cpp
@@ -66,7 +66,7 @@ return ret;
 
 mystruct::mystruct(auto&& i_, auto&& j_, auto&& k_)
 requires (std::is_convertible_v<CPP2_TYPEOF(i_), std::add_const_t<cpp2::i32>&> && std::is_convertible_v<CPP2_TYPEOF(j_), std::add_const_t<std::string>&> && std::is_convertible_v<CPP2_TYPEOF(k_), std::add_const_t<cpp2::u64>&>) 
-                                                                                                       : base{ { 1 } }
+                                                                                                       : base{ 1 }
                                                                                                        , i{ CPP2_FORWARD(i_) }
                                                                                                        , j{ CPP2_FORWARD(j_) }
                                                                                                        , k{ CPP2_FORWARD(k_) }{}

--- a/regression-tests/test-results/pure2-hashable.cpp
+++ b/regression-tests/test-results/pure2-hashable.cpp
@@ -66,7 +66,7 @@ return ret;
 
 mystruct::mystruct(auto&& i_, auto&& j_, auto&& k_)
 requires (std::is_convertible_v<CPP2_TYPEOF(i_), std::add_const_t<cpp2::i32>&> && std::is_convertible_v<CPP2_TYPEOF(j_), std::add_const_t<std::string>&> && std::is_convertible_v<CPP2_TYPEOF(k_), std::add_const_t<cpp2::u64>&>) 
-                                                                                                       : base{ (1) }
+                                                                                                       : base{ { 1 } }
                                                                                                        , i{ CPP2_FORWARD(i_) }
                                                                                                        , j{ CPP2_FORWARD(j_) }
                                                                                                        , k{ CPP2_FORWARD(k_) }{}

--- a/source/parse.h
+++ b/source/parse.h
@@ -699,7 +699,6 @@ struct expression_list_node
     token const* open_paren  = {};
     token const* close_paren = {};
     bool inside_initializer  = false;
-    bool default_initializer = false;
 
     struct term {
         passing_style                    pass = {};
@@ -5772,7 +5771,6 @@ class parser
     };
     mutable std::vector<function_body_extent> function_body_extents;
     mutable bool                              is_function_body_extents_sorted = false;
-    bool                                      is_inside_call_expr = false;
 
 public:
     auto is_within_function_body(source_position p) const
@@ -6139,8 +6137,6 @@ private:
                 expr_list->inside_initializer = false;
             }
             n->expression_list_is_fold_expression = expr_list->is_fold_expression();
-            expr_list->default_initializer =
-                is_inside_call_expr && std::empty(expr_list->expressions);
 
             n->expr = std::move(expr_list);
             return n;
@@ -6296,9 +6292,7 @@ private:
                 //  Next should be an expression-list followed by a ')'
                 //  If not, then this wasn't a call expression so backtrack to
                 //  the '(' which will be part of the next grammar production
-                is_inside_call_expr = true;
                 term.expr_list = expression_list(term.op, lexeme::RightParen, true);
-                is_inside_call_expr = false;
 
                 if (
                     term.expr_list

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -4114,7 +4114,22 @@ public:
 
             assert(x.expr);
             current_args.push_back( {x.pass} );
-            emit(*x.expr);
+            //  In a nested expression-list in an initializer, we can
+            //  take over direct control of emitting it without needing to
+            //  go through the whole grammar, and surround it with braces
+            if (
+                n.inside_initializer
+                && x.expr->is_expression_list()
+                )
+            {
+                printer.print_cpp2( "{ ", n.position() );
+                emit(*x.expr->get_expression_list(), false);
+                printer.print_cpp2( " }", n.position() );
+            }
+            //  Otherwise, just emit the general expression as usual
+            else {
+                emit(*x.expr);
+            }
             current_args.pop_back();
 
             if (is_out) {

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -4074,13 +4074,6 @@ public:
             !(n.inside_initializer && current_declarations.back()->initializer->position() != n.open_paren->position())
             ;
 
-        if (n.default_initializer) {
-            if (add_parens) {
-                printer.print_cpp2("{}", n.position());
-            }
-            return;
-        }
-
         if (add_parens) {
             printer.print_cpp2( *n.open_paren, n.position());
         }


### PR DESCRIPTION
Resolves #1343.
Resolves #1283.
Resolves #1037.
Resolves #568.
Resolves #542.

The `main` branch already treats a return type contextually,
only lowering a _braced-init-list_ if it can work: <https://cpp2.godbolt.org/z/sonKE4zan>.

This PR recognizes two other places where an expression list can be an initializer to lower as a _braced-init-list_:
- As a function argument.
- As an expression in the expression list of an initializer (nested _braced-init-list_).