### PR TITLE
fix(to_cpp1): lower indexed call in the correct order

### DIFF
--- a/regression-tests/pure2-bugfix-for-indexed-call.cpp2
+++ b/regression-tests/pure2-bugfix-for-indexed-call.cpp2
@@ -1,0 +1,10 @@
+f: (_: i32) = { }
+main: () = {
+  array_of_functions: std::array = (f, f);
+  index := 0;
+  arguments: i32 = 0;
+  array_of_functions[index](arguments);
+  _ = array_of_functions;
+  _ = index;
+  _ = arguments;
+}

--- a/regression-tests/test-results/gcc-13/pure2-bugfix-for-indexed-call.cpp.output
+++ b/regression-tests/test-results/gcc-13/pure2-bugfix-for-indexed-call.cpp.output
@@ -1,8 +1,0 @@
-In file included from pure2-bugfix-for-indexed-call.cpp:7:
-pure2-bugfix-for-indexed-call.cpp2: In function ‘int main()’:
-pure2-bugfix-for-indexed-call.cpp2:6:43: error: no match for call to ‘(std::array<void (*)(int), 2>) (cpp2::i32&)’
-    6 |   array_of_functions[index](arguments);
-      |                         ~~~~~~~~~~~~~~~   ^
-pure2-bugfix-for-indexed-call.cpp2:6:43: error: no match for call to ‘(std::array<void (*)(int), 2>) (cpp2::i32&)’
-    6 |   array_of_functions[index](arguments);
-      |                         ~~~~~~~~~~~~~~~   ^

--- a/regression-tests/test-results/gcc-13/pure2-bugfix-for-indexed-call.cpp.output
+++ b/regression-tests/test-results/gcc-13/pure2-bugfix-for-indexed-call.cpp.output
@@ -1,0 +1,8 @@
+In file included from pure2-bugfix-for-indexed-call.cpp:7:
+pure2-bugfix-for-indexed-call.cpp2: In function ‘int main()’:
+pure2-bugfix-for-indexed-call.cpp2:6:43: error: no match for call to ‘(std::array<void (*)(int), 2>) (cpp2::i32&)’
+    6 |   array_of_functions[index](arguments);
+      |                         ~~~~~~~~~~~~~~~   ^
+pure2-bugfix-for-indexed-call.cpp2:6:43: error: no match for call to ‘(std::array<void (*)(int), 2>) (cpp2::i32&)’
+    6 |   array_of_functions[index](arguments);
+      |                         ~~~~~~~~~~~~~~~   ^

--- a/regression-tests/test-results/pure2-bugfix-for-indexed-call.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-indexed-call.cpp
@@ -25,7 +25,7 @@ auto main() -> int{
   std::array array_of_functions {f, f}; 
   auto index {0}; 
   cpp2::i32 arguments {0}; 
-  CPP2_ASSERT_IN_BOUNDS(array_of_functions(arguments), index);
+  CPP2_ASSERT_IN_BOUNDS(array_of_functions, index)(arguments);
   static_cast<void>(std::move(array_of_functions));
   static_cast<void>(std::move(index));
   static_cast<void>(std::move(arguments));

--- a/regression-tests/test-results/pure2-bugfix-for-indexed-call.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-indexed-call.cpp
@@ -1,0 +1,33 @@
+
+#define CPP2_IMPORT_STD          Yes
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "pure2-bugfix-for-indexed-call.cpp2"
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-bugfix-for-indexed-call.cpp2"
+auto f([[maybe_unused]] cpp2::in<cpp2::i32> unnamed_param_1) -> void;
+#line 2 "pure2-bugfix-for-indexed-call.cpp2"
+auto main() -> int;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-bugfix-for-indexed-call.cpp2"
+auto f([[maybe_unused]] cpp2::in<cpp2::i32> unnamed_param_1) -> void{}
+#line 2 "pure2-bugfix-for-indexed-call.cpp2"
+auto main() -> int{
+  std::array array_of_functions {f, f}; 
+  auto index {0}; 
+  cpp2::i32 arguments {0}; 
+  CPP2_ASSERT_IN_BOUNDS(array_of_functions(arguments), index);
+  static_cast<void>(std::move(array_of_functions));
+  static_cast<void>(std::move(index));
+  static_cast<void>(std::move(arguments));
+}
+

--- a/regression-tests/test-results/pure2-bugfix-for-indexed-call.cpp2.output
+++ b/regression-tests/test-results/pure2-bugfix-for-indexed-call.cpp2.output
@@ -1,0 +1,2 @@
+pure2-bugfix-for-indexed-call.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -3322,6 +3322,8 @@ public:
             //  Handle the suffix operators that remain suffix
             //
             else {
+                flush_args();
+
                 assert(i->op);
                 last_was_prefixed = false;
 


### PR DESCRIPTION
Resolves #552.