### PR TITLE
Only #include <stdfloat> on MSVC when in C++23 mode to remove a warning

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -197,7 +197,9 @@
         #endif
         #include <stdexcept>
         #if __has_include(<stdfloat>)
-            #include <stdfloat>
+            #if (defined(_MSC_VER) && _HAS_CXX23) || !defined(_MSC_VER)
+                #include <stdfloat>
+            #endif
         #endif
         #ifdef __cpp_lib_jthread
             #include <stop_token>


### PR DESCRIPTION
The `__has_include` test for `<stdfloat>` returns true even in C++20 because the file exists, and the `<stdfloat>` header emits an error when not compiled with C++23.

Fixes #929