### PR TITLE
Friendlier error message when user puts semicolon after type definition closing brace

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -8432,6 +8432,18 @@ private:
 
         }
 
+        if (
+            n->is_type()
+            && n->initializer
+            && !done() && curr().type() == lexeme::Semicolon
+            )
+        {
+            if (n->initializer->is_compound() && n->has_name()) {
+                error("Cpp2 does not allow a semicolon after the closing brace of a type definition");
+                return {};
+            }
+        }
+
         //  A type initializer must be a compound expression
         if (
             n->is_type()


### PR DESCRIPTION
Due to C and C++ habit I occasionally write this:

```
mytype: type = {

};  // <-- oops
```

I thought a friendlier error message might be useful for this specific case.

Before this PR:
```
error: unexpected text at end of Cpp2 code section (at ';')
error: parse failed for section starting here
```

After this PR:

```
error: Cpp2 does not allow a semicolon after the closing brace of a type definition
```