### PR TITLE
Enable debugging with LLDB (Xcode, Qt Creator, etc)

### DIFF
--- a/regression-tests/test-results/mixed-bounds-safety-with-assert-2.cpp
+++ b/regression-tests/test-results/mixed-bounds-safety-with-assert-2.cpp
@@ -37,6 +37,7 @@ auto add_42_to_subrange(auto& rng, cpp2::in<int> start, cpp2::in<int> end) -> vo
         std::cout << i << "\n";
 }
 
+#line 10 "mixed-bounds-safety-with-assert-2.cpp2"
 auto add_42_to_subrange(auto& rng, cpp2::in<int> start, cpp2::in<int> end) -> void
 {
     if (cpp2::Bounds.has_handler() && !(cpp2::cmp_less_eq(0,start)) ) { cpp2::Bounds.report_violation(""); }

--- a/regression-tests/test-results/mixed-bounds-safety-with-assert.cpp
+++ b/regression-tests/test-results/mixed-bounds-safety-with-assert.cpp
@@ -36,6 +36,7 @@ auto print_subrange(auto const& rng, cpp2::in<int> start, cpp2::in<int> end) -> 
     print_subrange(std::move(v), 1, 13);
 }
 
+#line 9 "mixed-bounds-safety-with-assert.cpp2"
 auto print_subrange(auto const& rng, cpp2::in<int> start, cpp2::in<int> end) -> void{
     if (cpp2::Bounds.has_handler() && !(cpp2::cmp_less_eq(0,start)) ) { cpp2::Bounds.report_violation(""); }
     if (cpp2::Bounds.has_handler() && !(cpp2::cmp_less_eq(end,CPP2_UFCS(ssize)(rng))) ) { cpp2::Bounds.report_violation(""); }

--- a/regression-tests/test-results/mixed-bugfix-for-ufcs-non-local.cpp
+++ b/regression-tests/test-results/mixed-bugfix-for-ufcs-non-local.cpp
@@ -83,8 +83,10 @@ namespace ns {
 #line 21 "mixed-bugfix-for-ufcs-non-local.cpp2"
 template<t<CPP2_UFCS_NONLOCAL(f)(o)> _> auto g() -> void{}// Fails on GCC ([GCC109781][]) and Clang 12 (a lambda expression cannot appear in this context)
 
+#line 23 "mixed-bugfix-for-ufcs-non-local.cpp2"
 auto g([[maybe_unused]] cpp2::in<t<CPP2_UFCS_NONLOCAL(f)(o)>> unnamed_param_1) -> void{}// Fails on Clang 12 (lambda in unevaluated context).
 
+#line 25 "mixed-bugfix-for-ufcs-non-local.cpp2"
 auto g() -> void{
                      if (cpp2::Default.has_handler() && !(CPP2_UFCS(f)(o)) ) { cpp2::Default.report_violation(""); }}
 
@@ -100,5 +102,6 @@ auto g() -> void{
 #line 45 "mixed-bugfix-for-ufcs-non-local.cpp2"
 }
 
+#line 47 "mixed-bugfix-for-ufcs-non-local.cpp2"
 auto main() -> int{}
 

--- a/regression-tests/test-results/mixed-captures-in-expressions-and-postconditions.cpp
+++ b/regression-tests/test-results/mixed-captures-in-expressions-and-postconditions.cpp
@@ -42,6 +42,7 @@ auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void;
 
 std::vector<int> vec {}; 
 
+#line 19 "mixed-captures-in-expressions-and-postconditions.cpp2"
 auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void
 
 #line 22 "mixed-captures-in-expressions-and-postconditions.cpp2"

--- a/regression-tests/test-results/mixed-float-literals.cpp
+++ b/regression-tests/test-results/mixed-float-literals.cpp
@@ -135,6 +135,7 @@ auto literals_cpp2() -> void{
   // 1.E-10F;
 }
 
+#line 114 "mixed-float-literals.cpp2"
 [[nodiscard]] auto main() -> int{
   literals_cpp1();
   literals_cpp2();

--- a/regression-tests/test-results/mixed-forwarding.cpp
+++ b/regression-tests/test-results/mixed-forwarding.cpp
@@ -44,6 +44,7 @@ CPP2_REQUIRES (std::is_same_v<CPP2_TYPEOF(t), std::pair<X,X>>) ;
 #line 11 "mixed-forwarding.cpp2"
 auto copy_from([[maybe_unused]] auto unnamed_param_1) -> void{}
 
+#line 13 "mixed-forwarding.cpp2"
 auto use([[maybe_unused]] auto const& unnamed_param_1) -> void{}
 
 #line 16 "mixed-forwarding.cpp2"
@@ -53,6 +54,7 @@ requires (std::is_same_v<CPP2_TYPEOF(t), std::pair<X,X>>) {
     copy_from(t.first);             // copies
     copy_from(CPP2_FORWARD(t).second);// moves
 }
+#line 20 "mixed-forwarding.cpp2"
 auto apply_explicit_forward(auto&& t) -> void
 requires (std::is_same_v<CPP2_TYPEOF(t), std::pair<X,X>>) {
 #line 21 "mixed-forwarding.cpp2"
@@ -60,6 +62,7 @@ requires (std::is_same_v<CPP2_TYPEOF(t), std::pair<X,X>>) {
     copy_from(CPP2_FORWARD(t).second);// moves
 }
 
+#line 25 "mixed-forwarding.cpp2"
 [[nodiscard]] auto main() -> int{
     std::pair<X,X> t1 {1, 2}; 
     apply_implicit_forward(t1);

--- a/regression-tests/test-results/mixed-hello.cpp
+++ b/regression-tests/test-results/mixed-hello.cpp
@@ -39,6 +39,7 @@ auto main() -> int {
     return s; 
 }
 
+#line 11 "mixed-hello.cpp2"
 auto decorate(std::string& s) -> void{
     s = "[" + s + "]";
 }

--- a/regression-tests/test-results/mixed-increment-decrement.cpp
+++ b/regression-tests/test-results/mixed-increment-decrement.cpp
@@ -188,13 +188,16 @@ requires (bool(Op & 2))  { auto ret = x; ++x; return ret; }
 auto operator++(number_line_pre_increment<0>& x) -> number_line_pre_increment<0>& { return x;  }
 #line 51 "mixed-increment-decrement.cpp2"
 auto operator++(number_line_pre_increment<0>& x,int) -> number_line_pre_increment<0> { auto ret = x; ++x; return ret; }
+#line 52 "mixed-increment-decrement.cpp2"
 auto operator--(number_line_pre_decrement<0>& x) -> number_line_pre_decrement<0>& { return x;  }
 #line 52 "mixed-increment-decrement.cpp2"
 auto operator--(number_line_pre_decrement<0>& x,int) -> number_line_pre_decrement<0> { auto ret = x; ++x; return ret; }
 
+#line 54 "mixed-increment-decrement.cpp2"
 auto operator++(number_line_pre_increment<1>& x) -> number_line_pre_increment<1> const& { return x;  }
 #line 54 "mixed-increment-decrement.cpp2"
 auto operator++(number_line_pre_increment<1>& x,int) -> number_line_pre_increment<1> const { auto ret = x; ++x; return ret; }
+#line 55 "mixed-increment-decrement.cpp2"
 auto operator--(number_line_pre_decrement<1>& x) -> number_line_pre_decrement<1> const& { return x;  }
 #line 55 "mixed-increment-decrement.cpp2"
 auto operator--(number_line_pre_decrement<1>& x,int) -> number_line_pre_decrement<1> const { auto ret = x; ++x; return ret; }

--- a/regression-tests/test-results/mixed-initialization-safety-3-contract-violation.cpp
+++ b/regression-tests/test-results/mixed-initialization-safety-3-contract-violation.cpp
@@ -54,6 +54,7 @@ bool flip_a_coin() {
     print_decorated(std::move(x.value()));
 }
 
+#line 18 "mixed-initialization-safety-3-contract-violation.cpp2"
 auto fill(
     cpp2::out<std::string> x, 
     cpp2::in<std::string> value, 
@@ -66,5 +67,6 @@ auto fill(
     x.construct(CPP2_UFCS(substr)(value, 0, count));
 }
 
+#line 28 "mixed-initialization-safety-3-contract-violation.cpp2"
 auto print_decorated(auto const& x) -> void { std::cout << ">> [" << x << "]\n";  }
 

--- a/regression-tests/test-results/mixed-initialization-safety-3.cpp
+++ b/regression-tests/test-results/mixed-initialization-safety-3.cpp
@@ -48,6 +48,7 @@ auto print_decorated(auto const& x) -> void;
     print_decorated(std::move(x.value()));
 }
 
+#line 16 "mixed-initialization-safety-3.cpp2"
 auto fill(
     cpp2::out<std::string> x, 
     cpp2::in<std::string> value, 
@@ -60,6 +61,7 @@ auto fill(
     x.construct(CPP2_UFCS(substr)(value, 0, count));
 }
 
+#line 26 "mixed-initialization-safety-3.cpp2"
 auto print_decorated(auto const& x) -> void { std::cout << ">> [" << x << "]\n";  }
 
 #line 30 "mixed-initialization-safety-3.cpp2"

--- a/regression-tests/test-results/mixed-inspect-templates.cpp
+++ b/regression-tests/test-results/mixed-inspect-templates.cpp
@@ -42,6 +42,7 @@ struct my_type {};
     (); 
 }
 
+#line 18 "mixed-inspect-templates.cpp2"
 [[nodiscard]] auto fun2(auto const& v) -> std::string{
     if (cpp2::is<std::vector>(v)) {return "std::vector"; }
     if (cpp2::is<std::array>(v)) {return "std::array"; }
@@ -50,6 +51,7 @@ struct my_type {};
     return "unknown"; 
 }
 
+#line 26 "mixed-inspect-templates.cpp2"
 [[nodiscard]] auto main() -> int{
     std::vector<int> vec {1, 2, 3}; 
     std::array<int,4> arr {1, 2, 3, 4}; 

--- a/regression-tests/test-results/mixed-inspect-values.cpp
+++ b/regression-tests/test-results/mixed-inspect-values.cpp
@@ -30,6 +30,7 @@ auto test(auto const& x) -> void;
 #line 5 "mixed-inspect-values.cpp2"
 [[nodiscard]] auto in_2_3(cpp2::in<int> x) -> bool { return cpp2::cmp_less_eq(2,x) && cpp2::cmp_less_eq(x,3);  }
 
+#line 7 "mixed-inspect-values.cpp2"
 [[nodiscard]] auto main() -> int{
     std::variant<double,std::string,double> v {}; 
     v = "rev dodgson";
@@ -54,6 +55,7 @@ auto test(auto const& x) -> void;
     test(3.14);
 }
 
+#line 31 "mixed-inspect-values.cpp2"
 auto test(auto const& x) -> void{
     auto forty_two {42}; 
     std::cout << [&] () -> std::string { auto&& _expr = x;

--- a/regression-tests/test-results/mixed-inspect-with-typeof-of-template-arg-list.cpp
+++ b/regression-tests/test-results/mixed-inspect-with-typeof-of-template-arg-list.cpp
@@ -35,6 +35,7 @@ auto calc() {
     (); 
 }
 
+#line 14 "mixed-inspect-with-typeof-of-template-arg-list.cpp2"
 [[nodiscard]] auto main() -> int{
     return fun(42); 
 }

--- a/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-and-null-contracts.cpp
@@ -46,6 +46,7 @@ auto try_pointer_stuff() -> void{
                 // to show -n
 }
 
+#line 21 "mixed-lifetime-safety-and-null-contracts.cpp2"
 auto call_my_framework(char const* msg) -> void{
     std::cout 
         << "sending error to my framework... [" 

--- a/regression-tests/test-results/mixed-lifetime-safety-pointer-init-4.cpp
+++ b/regression-tests/test-results/mixed-lifetime-safety-pointer-init-4.cpp
@@ -50,6 +50,7 @@ bool flip_a_coin() {
     print_and_decorate(*cpp2::assert_not_null(std::move(p.value())));
 }
 
+#line 21 "mixed-lifetime-safety-pointer-init-4.cpp2"
 auto print_and_decorate(auto const& thing) -> void { 
     std::cout << ">> " << thing << "\n";  }
 

--- a/regression-tests/test-results/mixed-multiple-return-values.cpp
+++ b/regression-tests/test-results/mixed-multiple-return-values.cpp
@@ -62,6 +62,7 @@ bool flip_a_coin() {
     return  { std::move(i.value()), std::move(s.value()) }; 
 }
 
+#line 22 "mixed-multiple-return-values.cpp2"
 auto do_print(cpp2::in<std::string> name, auto const& value) -> void { 
     std::cout << name << " is " << value << "\n";  }
 

--- a/regression-tests/test-results/mixed-out-destruction.cpp
+++ b/regression-tests/test-results/mixed-out-destruction.cpp
@@ -58,12 +58,17 @@ int main() {
 
 #line 22 "mixed-out-destruction.cpp2"
 auto f00() -> void     {   C auto_22_28 {"f00"}; cpp2::deferred_init<X> x; f01(cpp2::out(&x));}
+#line 23 "mixed-out-destruction.cpp2"
 auto f01(cpp2::out<X> x) -> void{C auto_23_28 {"f01"}; x.construct();throw_1();}
 
 #line 27 "mixed-out-destruction.cpp2"
 auto f10() -> void     {   C auto_27_28 {"f10"}; cpp2::deferred_init<X> x; f11(cpp2::out(&x));}
+#line 28 "mixed-out-destruction.cpp2"
 auto f11(cpp2::out<X> x) -> void{C auto_28_28 {"f11"}; f12(cpp2::out(&x));}
+#line 29 "mixed-out-destruction.cpp2"
 auto f12(cpp2::out<X> x) -> void{C auto_29_28 {"f12"}; f13(cpp2::out(&x));throw_1();}
+#line 30 "mixed-out-destruction.cpp2"
 auto f13(cpp2::out<X> x) -> void{C auto_30_28 {"f13"}; f14(cpp2::out(&x));}
+#line 31 "mixed-out-destruction.cpp2"
 auto f14(cpp2::out<X> x) -> void{C auto_31_28 {"f14"}; x.construct();}
 

--- a/regression-tests/test-results/mixed-parameter-passing-generic-out.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing-generic-out.cpp
@@ -38,6 +38,7 @@ auto f(auto x_) -> void{
     x.construct(42);
 }
 
+#line 15 "mixed-parameter-passing-generic-out.cpp2"
 [[nodiscard]] auto main() -> int{
     cpp2::deferred_init<int> a; 
     f(cpp2::out(&a));

--- a/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing-with-forward.cpp
@@ -40,6 +40,7 @@ CPP2_REQUIRES (std::is_same_v<CPP2_TYPEOF(e), std::string>)
 #line 6 "mixed-parameter-passing-with-forward.cpp2"
 auto copy_from([[maybe_unused]] auto unnamed_param_1) -> void{}
 
+#line 8 "mixed-parameter-passing-with-forward.cpp2"
 auto parameter_styles(
     [[maybe_unused]] cpp2::in<std::string> unnamed_param_1, 
     std::string b, 
@@ -76,5 +77,6 @@ requires (std::is_same_v<CPP2_TYPEOF(e), std::string>)
 
 }
 
+#line 42 "mixed-parameter-passing-with-forward.cpp2"
 [[nodiscard]] auto main() -> int{}
 

--- a/regression-tests/test-results/mixed-parameter-passing.cpp
+++ b/regression-tests/test-results/mixed-parameter-passing.cpp
@@ -36,6 +36,7 @@ auto parameter_styles(
 #line 6 "mixed-parameter-passing.cpp2"
 auto copy_from([[maybe_unused]] auto unnamed_param_1) -> void{}
 
+#line 8 "mixed-parameter-passing.cpp2"
 auto parameter_styles(
     [[maybe_unused]] cpp2::in<std::string> unnamed_param_1, 
     std::string b, 
@@ -68,5 +69,6 @@ auto parameter_styles(
 
 }
 
+#line 40 "mixed-parameter-passing.cpp2"
 [[nodiscard]] auto main() -> int{}
 

--- a/regression-tests/test-results/mixed-postexpression-with-capture.cpp
+++ b/regression-tests/test-results/mixed-postexpression-with-capture.cpp
@@ -53,6 +53,7 @@ struct make_strings_ret { std::string a; std::string b; };
 
 std::vector<int> vec {}; 
 
+#line 16 "mixed-postexpression-with-capture.cpp2"
 auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void
 
 #line 19 "mixed-postexpression-with-capture.cpp2"
@@ -64,6 +65,7 @@ auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void
     CPP2_UFCS(push_back)(vec, val);
 }
 
+#line 23 "mixed-postexpression-with-capture.cpp2"
 [[nodiscard]] auto make_string() -> make_string_ret
 
 {
@@ -74,6 +76,7 @@ auto insert_at(cpp2::in<int> where, cpp2::in<int> val) -> void
     ret += " and ";
 cpp2_finally_presuccess.run(); return std::move(ret); }
 
+#line 29 "mixed-postexpression-with-capture.cpp2"
 [[nodiscard]] auto make_strings() -> make_strings_ret
 
 #line 35 "mixed-postexpression-with-capture.cpp2"

--- a/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
+++ b/regression-tests/test-results/mixed-postfix-expression-custom-formatting.cpp
@@ -27,6 +27,7 @@ auto call([[maybe_unused]] auto const& unnamed_param_1, [[maybe_unused]] auto co
 #line 2 "mixed-postfix-expression-custom-formatting.cpp2"
 auto call([[maybe_unused]] auto const& unnamed_param_1, [[maybe_unused]] auto const& unnamed_param_2, [[maybe_unused]] auto const& unnamed_param_3, [[maybe_unused]] auto const& unnamed_param_4, [[maybe_unused]] auto const& unnamed_param_5) -> void{}
 
+#line 4 "mixed-postfix-expression-custom-formatting.cpp2"
 [[nodiscard]] auto test(auto const& a) -> std::string{
     return call(a, 
         ++*cpp2::assert_not_null(CPP2_UFCS(b)(a, a.c)), "hello", /* polite
@@ -38,5 +39,6 @@ auto call([[maybe_unused]] auto const& unnamed_param_1, [[maybe_unused]] auto co
         ); 
 }
 
+#line 15 "mixed-postfix-expression-custom-formatting.cpp2"
 [[nodiscard]] auto main() -> int{}
 

--- a/regression-tests/test-results/mixed-type-safety-1.cpp
+++ b/regression-tests/test-results/mixed-type-safety-1.cpp
@@ -42,6 +42,7 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
 auto print(cpp2::in<std::string> msg, auto const& x) -> void { 
     std::cout << msg << x << "\n";  }
 
+#line 16 "mixed-type-safety-1.cpp2"
 auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void
 {
     cpp2::deferred_init<char const*> bmsg; 

--- a/regression-tests/test-results/pure2-bounds-safety-span.cpp
+++ b/regression-tests/test-results/pure2-bounds-safety-span.cpp
@@ -40,6 +40,7 @@ auto print_and_decorate(auto const& thing) -> void;
     }
 }
 
+#line 15 "pure2-bounds-safety-span.cpp2"
 auto print_and_decorate(auto const& thing) -> void { 
     std::cout << ">> " << thing << "\n";  }
 

--- a/regression-tests/test-results/pure2-break-continue.cpp
+++ b/regression-tests/test-results/pure2-break-continue.cpp
@@ -75,6 +75,7 @@ auto for_break_outer() -> void;
     std::cout <<   "\nfor_break_outer:\n  ";    for_break_outer();
 }
 
+#line 20 "pure2-break-continue.cpp2"
 auto while_continue_inner() -> void
 {
     auto i {0}; 
@@ -93,6 +94,7 @@ auto while_continue_inner() -> void
     }
 }
 
+#line 36 "pure2-break-continue.cpp2"
 auto while_continue_outer() -> void
 {
     auto i {0}; 
@@ -111,6 +113,7 @@ auto while_continue_outer() -> void
 #line 50 "pure2-break-continue.cpp2"
 }
 
+#line 52 "pure2-break-continue.cpp2"
 auto while_break_inner() -> void
 {
     auto i {0}; 
@@ -129,6 +132,7 @@ auto while_break_inner() -> void
     }
 }
 
+#line 68 "pure2-break-continue.cpp2"
 auto while_break_outer() -> void
 {
     auto i {0}; 
@@ -147,6 +151,7 @@ auto while_break_outer() -> void
 #line 82 "pure2-break-continue.cpp2"
 }
 
+#line 84 "pure2-break-continue.cpp2"
 auto do_continue_inner() -> void
 {
     auto i {0}; 
@@ -171,6 +176,7 @@ auto do_continue_inner() -> void
     ++i ; return true; }() && cpp2::cmp_less(i,3));
 }
 
+#line 103 "pure2-break-continue.cpp2"
 auto do_continue_outer() -> void
 {
     auto i {0}; 
@@ -195,6 +201,7 @@ auto do_continue_outer() -> void
     ++i ; return true; }() && cpp2::cmp_less(i,3));
 }
 
+#line 122 "pure2-break-continue.cpp2"
 auto do_break_inner() -> void
 {
     auto i {0}; 
@@ -219,6 +226,7 @@ auto do_break_inner() -> void
     ++i ; return true; }() && cpp2::cmp_less(i,3));
 }
 
+#line 141 "pure2-break-continue.cpp2"
 auto do_break_outer() -> void
 {
     auto i {0}; 
@@ -243,6 +251,7 @@ auto do_break_outer() -> void
     ++i ; return true; }() && cpp2::cmp_less(i,3));
 }
 
+#line 160 "pure2-break-continue.cpp2"
 auto for_continue_inner() -> void
 {
     std::vector vi {0, 1, 2}; 
@@ -262,6 +271,7 @@ auto for_continue_inner() -> void
     }
 }
 
+#line 177 "pure2-break-continue.cpp2"
 auto for_continue_outer() -> void
 {
     std::vector vi {0, 1, 2}; 
@@ -281,6 +291,7 @@ auto for_continue_outer() -> void
 #line 192 "pure2-break-continue.cpp2"
 }
 
+#line 194 "pure2-break-continue.cpp2"
 auto for_break_inner() -> void
 {
     std::vector vi {0, 1, 2}; 
@@ -300,6 +311,7 @@ auto for_break_inner() -> void
     }
 }
 
+#line 211 "pure2-break-continue.cpp2"
 auto for_break_outer() -> void
 {
     std::vector vi {0, 1, 2}; 

--- a/regression-tests/test-results/pure2-bugfix-for-memberwise-base-assignment.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-memberwise-base-assignment.cpp
@@ -48,6 +48,7 @@ auto main() -> int;
 
 #line 2 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Base::Base(){}
+#line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   Base::Base ([[maybe_unused]] Base const& that) { std::cout << "(out this, that)\n"; }
 #line 3 "pure2-bugfix-for-memberwise-base-assignment.cpp2"
   auto Base::operator=([[maybe_unused]] Base const& that) -> Base&  { std::cout << "(out this, that)\n";

--- a/regression-tests/test-results/pure2-bugfix-for-name-lookup-and-value-decoration.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-name-lookup-and-value-decoration.cpp
@@ -29,6 +29,7 @@ using vals_ret = int;
     return std::move(i.value()); 
 }
 
+#line 6 "pure2-bugfix-for-name-lookup-and-value-decoration.cpp2"
 [[nodiscard]] auto main() -> int{
     auto v {vals()}; 
     static_cast<void>(std::move(v));

--- a/regression-tests/test-results/pure2-bugfix-for-ufcs-arguments.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-ufcs-arguments.cpp
@@ -96,16 +96,24 @@ class B {
 
 #line 8 "pure2-bugfix-for-ufcs-arguments.cpp2"
   [[nodiscard]] auto t::f() & -> cpp2::i32 { return print_res(0);  }
+#line 9 "pure2-bugfix-for-ufcs-arguments.cpp2"
   [[nodiscard]] auto t::f([[maybe_unused]] auto const& unnamed_param_2) & -> cpp2::i32 { return print_res(1);  }
+#line 10 "pure2-bugfix-for-ufcs-arguments.cpp2"
   template<typename UnnamedTypeParam1> [[nodiscard]] auto t::f() & -> cpp2::i32 { return print_res(2);  }
+#line 11 "pure2-bugfix-for-ufcs-arguments.cpp2"
   template<typename UnnamedTypeParam1> [[nodiscard]] auto t::f([[maybe_unused]] auto const& unnamed_param_2) & -> cpp2::i32 { return print_res(3);  }
+#line 12 "pure2-bugfix-for-ufcs-arguments.cpp2"
   template<typename UnnamedTypeParam1, typename U> [[nodiscard]] auto t::f([[maybe_unused]] auto const& unnamed_param_2, [[maybe_unused]] auto const& unnamed_param_3) & -> cpp2::i32 { return print_res(4);  }
 
 #line 15 "pure2-bugfix-for-ufcs-arguments.cpp2"
 [[nodiscard]] auto f([[maybe_unused]] cpp2::in<t> unnamed_param_1) -> cpp2::i32 { return print_res(5);  }
+#line 16 "pure2-bugfix-for-ufcs-arguments.cpp2"
 [[nodiscard]] auto f([[maybe_unused]] cpp2::in<t> unnamed_param_1, [[maybe_unused]] auto const& unnamed_param_2) -> cpp2::i32 { return print_res(6);  }
+#line 17 "pure2-bugfix-for-ufcs-arguments.cpp2"
 template<typename UnnamedTypeParam1> [[nodiscard]] auto f([[maybe_unused]] cpp2::in<t> unnamed_param_1) -> cpp2::i32 { return print_res(7);  }
+#line 18 "pure2-bugfix-for-ufcs-arguments.cpp2"
 template<typename UnnamedTypeParam1> [[nodiscard]] auto f([[maybe_unused]] cpp2::in<t> unnamed_param_1, [[maybe_unused]] auto const& unnamed_param_2) -> cpp2::i32 { return print_res(8);  }
+#line 19 "pure2-bugfix-for-ufcs-arguments.cpp2"
 template<typename UnnamedTypeParam1, typename U> [[nodiscard]] auto f([[maybe_unused]] cpp2::in<t> unnamed_param_1, [[maybe_unused]] auto const& unnamed_param_2, [[maybe_unused]] auto const& unnamed_param_3) -> cpp2::i32 { return print_res(9);  }
 
 t m {}; 
@@ -124,6 +132,7 @@ cpp2::i32 auto_33_1 {CPP2_UFCS_TEMPLATE_NONLOCAL(f<t>)(n, 0)};
 cpp2::i32 auto_34_1 {CPP2_UFCS_TEMPLATE_NONLOCAL(f<t,t>)(n, 0, 0)}; 
 cpp2::i32 auto_35_1 {CPP2_UFCS_TEMPLATE_NONLOCAL(f<t,t>)(a<t,t>, 0, 0)}; 
 
+#line 37 "pure2-bugfix-for-ufcs-arguments.cpp2"
 auto main() -> int{
   static_cast<void>(CPP2_UFCS(f)(m));
   static_cast<void>(CPP2_UFCS(f)(m, 0));
@@ -147,6 +156,7 @@ cpp2::i32 auto_56_1 {CPP2_UFCS_QUALIFIED_TEMPLATE_NONLOCAL((ns::t<0,0>::),f<0>)(
 
 namespace ns {
 
+#line 60 "pure2-bugfix-for-ufcs-arguments.cpp2"
   template <int T, int U> template<int V> [[nodiscard]] auto t<T,U>::f([[maybe_unused]] cpp2::in<int> unnamed_param_1) -> cpp2::i32 { return 0;  }
 
 }

--- a/regression-tests/test-results/pure2-bugfix-for-ufcs-name-lookup.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-ufcs-name-lookup.cpp
@@ -60,6 +60,7 @@ auto main() -> int;
 
 #line 11 "pure2-bugfix-for-ufcs-name-lookup.cpp2"
 namespace ns {
+#line 12 "pure2-bugfix-for-ufcs-name-lookup.cpp2"
 [[nodiscard]] constexpr auto f([[maybe_unused]] auto const& unnamed_param_1) -> int { return 1;  }
 }
 

--- a/regression-tests/test-results/pure2-bugfix-for-ufcs-noexcept.cpp
+++ b/regression-tests/test-results/pure2-bugfix-for-ufcs-noexcept.cpp
@@ -32,6 +32,7 @@ auto main() -> int;
 #line 2 "pure2-bugfix-for-ufcs-noexcept.cpp2"
   auto t::swap([[maybe_unused]] t const& that) noexcept -> void{}// Non-`virtual` blocked on #508, idiomatic form on #507.
 
+#line 4 "pure2-bugfix-for-ufcs-noexcept.cpp2"
 auto main() -> int{
   static_assert(noexcept(CPP2_UFCS(swap)(t(), t())));// Fails on Clang 12 (lambda in unevaluated context) and GCC 10 (static assertion failed)
 }

--- a/regression-tests/test-results/pure2-contracts.cpp
+++ b/regression-tests/test-results/pure2-contracts.cpp
@@ -27,6 +27,7 @@ auto main() -> int;
 #line 3 "pure2-contracts.cpp2"
 bool audit {true}; 
 
+#line 5 "pure2-contracts.cpp2"
 auto main() -> int{
     //  A few basic tests
     if (cpp2::Default.has_handler() && !(1 != 2) ) { cpp2::Default.report_violation(CPP2_CONTRACT_MSG("ack, arithmetic is buggy")); }

--- a/regression-tests/test-results/pure2-enum.cpp
+++ b/regression-tests/test-results/pure2-enum.cpp
@@ -114,8 +114,8 @@ auto main() -> int;
 
 #line 1 "pure2-enum.cpp2"
 
-
 #line 1 "pure2-enum.cpp2"
+
 constexpr skat_game::skat_game(cpp2::in<cpp2::i64> _val)
                                                           : _value{ cpp2::unsafe_narrow<cpp2::i8>(_val) } {  }
 constexpr auto skat_game::operator=(cpp2::in<cpp2::i64> _val) -> skat_game&  { 

--- a/regression-tests/test-results/pure2-forward-return.cpp
+++ b/regression-tests/test-results/pure2-forward-return.cpp
@@ -34,8 +34,10 @@ extern int const global;
     return *cpp2::assert_not_null(std::begin(CPP2_FORWARD(rng)));  }
 
 int const global {42}; 
+#line 8 "pure2-forward-return.cpp2"
 [[nodiscard]] auto f() -> int const&{return global; }
 
+#line 10 "pure2-forward-return.cpp2"
 [[nodiscard]] auto main() -> int{
     std::vector v {1, 2, 3}; 
     first(v) = 4;

--- a/regression-tests/test-results/pure2-function-multiple-forward-arguments.cpp
+++ b/regression-tests/test-results/pure2-function-multiple-forward-arguments.cpp
@@ -27,6 +27,7 @@ requires (std::is_same_v<CPP2_TYPEOF(s1), std::string> && std::is_same_v<CPP2_TY
     std::cout << CPP2_FORWARD(s1) << CPP2_FORWARD(s2) << CPP2_FORWARD(s3) << std::endl;
 }
 
+#line 5 "pure2-function-multiple-forward-arguments.cpp2"
 auto main() -> int{
     std::string b {"b"}; 
     std::string c {"c"}; 

--- a/regression-tests/test-results/pure2-hello.cpp
+++ b/regression-tests/test-results/pure2-hello.cpp
@@ -31,12 +31,14 @@ auto decorate(std::string& s) -> void;
     std::cout << "Hello " << name() << "\n";
 }
 
+#line 6 "pure2-hello.cpp2"
 [[nodiscard]] auto name() -> std::string{
     std::string s {"world"}; 
     decorate(s);
     return s; 
 }
 
+#line 12 "pure2-hello.cpp2"
 auto decorate(std::string& s) -> void{
     s = "[" + s + "]";
 }

--- a/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-in-generic-function-multiple-types.cpp
@@ -40,6 +40,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(std::move(o), "optional<int>");
 }
 
+#line 20 "pure2-inspect-expression-in-generic-function-multiple-types.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << std::setw(30) << msg 

--- a/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
+++ b/regression-tests/test-results/pure2-inspect-expression-with-as-in-generic-function.cpp
@@ -27,6 +27,7 @@ auto print_an_int(auto const& x) -> void;
     print_an_int(1.1);
 }
 
+#line 7 "pure2-inspect-expression-with-as-in-generic-function.cpp2"
 auto print_an_int(auto const& x) -> void{
     std::cout 
         << std::setw(30) << cpp2::to_string(x) 

--- a/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-fallback-with-variant-any-optional.cpp
@@ -36,6 +36,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(std::move(o), "optional<string>");
 }
 
+#line 14 "pure2-inspect-fallback-with-variant-any-optional.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << "\n" << msg << "\n    ..." 

--- a/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
+++ b/regression-tests/test-results/pure2-inspect-generic-void-empty-with-variant-any-optional.cpp
@@ -40,6 +40,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(std::move(o), "optional<string>");
 }
 
+#line 18 "pure2-inspect-generic-void-empty-with-variant-any-optional.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << "\n" << msg << "\n    ..." 

--- a/regression-tests/test-results/pure2-interpolation.cpp
+++ b/regression-tests/test-results/pure2-interpolation.cpp
@@ -32,8 +32,11 @@ class item {
 
 #line 3 "pure2-interpolation.cpp2"
     [[nodiscard]] auto item::name() const& -> std::string { return "Dog kennel";  }
+#line 4 "pure2-interpolation.cpp2"
     [[nodiscard]] auto item::color() const& -> std::string { return "mauve";  }
+#line 5 "pure2-interpolation.cpp2"
     [[nodiscard]] auto item::price() const& -> double { return 3.14;  }
+#line 6 "pure2-interpolation.cpp2"
     [[nodiscard]] auto item::count() const& -> int { return 42;  }
 
 #line 9 "pure2-interpolation.cpp2"

--- a/regression-tests/test-results/pure2-intro-example-hello-2022.cpp
+++ b/regression-tests/test-results/pure2-intro-example-hello-2022.cpp
@@ -34,11 +34,13 @@ auto print_it(auto const& x, auto const& len) -> void;
     }
 }
 
+#line 11 "pure2-intro-example-hello-2022.cpp2"
 [[nodiscard]] auto decorate(auto& thing) -> int{
     thing = "[" + thing + "]";
     return CPP2_UFCS(ssize)(thing); 
 }
 
+#line 16 "pure2-intro-example-hello-2022.cpp2"
 auto print_it(auto const& x, auto const& len) -> void { 
     std::cout 
         << ">> " << x 

--- a/regression-tests/test-results/pure2-intro-example-three-loops.cpp
+++ b/regression-tests/test-results/pure2-intro-example-three-loops.cpp
@@ -33,11 +33,13 @@ auto decorate_and_print(auto& thing) -> void;
 auto print(auto const& thing) -> void { 
     std::cout << ">> " << thing << "\n";  }
 
+#line 5 "pure2-intro-example-three-loops.cpp2"
 auto decorate_and_print(auto& thing) -> void{
     thing = "[" + thing + "]";
     print(thing);
 }
 
+#line 10 "pure2-intro-example-three-loops.cpp2"
 [[nodiscard]] auto main() -> int{
     std::vector<std::string> words {
         "hello", "big", "world"}; 

--- a/regression-tests/test-results/pure2-look-up-parameter-across-unnamed-function.cpp
+++ b/regression-tests/test-results/pure2-look-up-parameter-across-unnamed-function.cpp
@@ -39,6 +39,7 @@ using g_ret = int;
     return std::move(ri); // "return;" is implicit"
 }
 
+#line 9 "pure2-look-up-parameter-across-unnamed-function.cpp2"
 [[nodiscard]] auto g() -> g_ret{
         cpp2::deferred_init<int> ri;
 #line 10 "pure2-look-up-parameter-across-unnamed-function.cpp2"
@@ -49,6 +50,7 @@ using g_ret = int;
     return std::move(ri.value()); 
 }
 
+#line 17 "pure2-look-up-parameter-across-unnamed-function.cpp2"
 [[nodiscard]] auto main() -> int{
     std::cout << f() + g() << "\n";
 }

--- a/regression-tests/test-results/pure2-more-wildcards.cpp
+++ b/regression-tests/test-results/pure2-more-wildcards.cpp
@@ -25,6 +25,7 @@
 #line 2 "pure2-more-wildcards.cpp2"
 [[nodiscard]] auto less_than(auto const& value) -> auto { return [_0 = value](auto const& x) mutable -> auto { return cpp2::cmp_less(x,_0); }; }
 
+#line 4 "pure2-more-wildcards.cpp2"
 [[nodiscard]] auto main() -> int
 {
     auto const x {2}; 

--- a/regression-tests/test-results/pure2-print.cpp
+++ b/regression-tests/test-results/pure2-print.cpp
@@ -95,6 +95,7 @@ requires (true) inline CPP2_CONSTEXPR T outer::object_alias = 42;
 #line 12 "pure2-print.cpp2"
         [[nodiscard]] auto outer::mytype::f() -> int { return 42;  }
 
+#line 14 "pure2-print.cpp2"
         [[nodiscard]] auto outer::mytype::g(cpp2::in<int> i) const -> int{
             using namespace ::std;
 
@@ -114,6 +115,7 @@ requires (true) inline CPP2_CONSTEXPR T outer::object_alias = 42;
             return ret; 
         }
 
+#line 33 "pure2-print.cpp2"
         [[nodiscard]] auto outer::mytype::h(cpp2::in<std::string> s, std::map<int const,std::string>& m) -> std::string
 
 #line 36 "pure2-print.cpp2"
@@ -141,6 +143,7 @@ requires (true) inline CPP2_CONSTEXPR T outer::object_alias = 42;
             return [_0 = (s + CPP2_ASSERT_IN_BOUNDS(m, 0))]() mutable -> std::string { return _0;  }(); 
         }
 
+#line 56 "pure2-print.cpp2"
         template<typename T> [[nodiscard]] auto outer::mytype::values([[maybe_unused]] T const& unnamed_param_2) const& -> values_ret{
                 cpp2::deferred_init<int> offset;
                 cpp2::deferred_init<std::string> name;
@@ -149,12 +152,16 @@ requires (true) inline CPP2_CONSTEXPR T outer::object_alias = 42;
             name.construct("plugh");
         return  { std::move(offset.value()), std::move(name.value()) }; }
 
+#line 61 "pure2-print.cpp2"
         outer::mytype::mytype(){}
 
+#line 63 "pure2-print.cpp2"
         outer::mytype::mytype([[maybe_unused]] mytype const& that){}
 
+#line 65 "pure2-print.cpp2"
         outer::mytype::mytype([[maybe_unused]] cpp2::in<int> unnamed_param_2){}
 
+#line 67 "pure2-print.cpp2"
         auto outer::mytype::variadic(auto const& ...x) -> void
 requires ((std::is_convertible_v<CPP2_TYPEOF(x), int> && ...)) {(std::cout << ... << x); }
 
@@ -188,6 +195,7 @@ requires (cpp2::cmp_greater_eq(sizeof...(Args),0u)) {
         (out << ... << args);
     }
 
+#line 100 "pure2-print.cpp2"
     template<typename ...Args> [[nodiscard]] auto outer::all(Args const& ...args) -> bool { 
         return (... && args);  }
 

--- a/regression-tests/test-results/pure2-requires-clauses.cpp
+++ b/regression-tests/test-results/pure2-requires-clauses.cpp
@@ -56,6 +56,7 @@ auto main() -> int;
     template <typename T, typename U> requires( std::is_same_v<T,int> && std::is_same_v<U,int> )
 X<T,U>::X(){}
 
+#line 10 "pure2-requires-clauses.cpp2"
 template<typename T, typename U> [[nodiscard]] auto f
     (auto&& a, auto&& b) -> int
 requires (std::is_same_v<T,int> && std::is_same_v<U,int> && std::is_same_v<CPP2_TYPEOF(a), int> && std::is_same_v<CPP2_TYPEOF(b), int>) 
@@ -65,6 +66,7 @@ requires (std::is_same_v<T,int> && std::is_same_v<U,int> && std::is_same_v<CPP2_
     return CPP2_FORWARD(a) * CPP2_FORWARD(b); 
 }
 
+#line 18 "pure2-requires-clauses.cpp2"
 [[nodiscard]] constexpr auto f(auto const& x) -> int
 requires (true)  { return x;  }
 

--- a/regression-tests/test-results/pure2-return-tuple-operator.cpp
+++ b/regression-tests/test-results/pure2-return-tuple-operator.cpp
@@ -59,6 +59,7 @@ auto main() -> int;
         y.construct(34);
         return  { std::move(x.value()), std::move(y.value()) }; 
     }
+#line 8 "pure2-return-tuple-operator.cpp2"
     [[nodiscard]] auto A::operator*() const& -> operator_dereference_ret{
             cpp2::deferred_init<int> x;
             cpp2::deferred_init<int> y;
@@ -67,6 +68,7 @@ auto main() -> int;
         y.construct(45);
         return  { std::move(x.value()), std::move(y.value()) }; 
     }
+#line 13 "pure2-return-tuple-operator.cpp2"
     [[nodiscard]] auto A::operator[](cpp2::in<int> idx) const& -> operator_subscript_ret{
             cpp2::deferred_init<int> x;
             cpp2::deferred_init<int> y;

--- a/regression-tests/test-results/pure2-synthesize-rightshift-and-rightshifteq.cpp
+++ b/regression-tests/test-results/pure2-synthesize-rightshift-and-rightshifteq.cpp
@@ -27,6 +27,7 @@
     return std::move(x) >> 1; 
 }
 
+#line 7 "pure2-synthesize-rightshift-and-rightshifteq.cpp2"
 [[nodiscard]] auto main() -> int{
     std::cout << f(32, 1) << "\n";
 }

--- a/regression-tests/test-results/pure2-template-parameter-lists.cpp
+++ b/regression-tests/test-results/pure2-template-parameter-lists.cpp
@@ -27,10 +27,14 @@ auto main() -> int;
 
 #line 2 "pure2-template-parameter-lists.cpp2"
 template<typename T, typename U> [[nodiscard]] auto f1(T const& t, U const& u) -> auto { return t + u; }
+#line 3 "pure2-template-parameter-lists.cpp2"
 template<typename T, typename U> [[nodiscard]] auto f2(T const& t, U const& u) -> auto { return t + u; }
+#line 4 "pure2-template-parameter-lists.cpp2"
 template<auto T, auto U> [[nodiscard]] auto f3() -> auto { return T + U; }
+#line 5 "pure2-template-parameter-lists.cpp2"
 template<cpp2::i8 T, cpp2::i16 U> [[nodiscard]] auto f4() -> auto { return T + U; }
 
+#line 7 "pure2-template-parameter-lists.cpp2"
 auto main() -> int{
     std::cout << ("f1: " + cpp2::to_string(f1(1, 1)) + "\n");
     std::cout << ("f2: " + cpp2::to_string(f2(2, 2)) + "\n");

--- a/regression-tests/test-results/pure2-type-safety-1.cpp
+++ b/regression-tests/test-results/pure2-type-safety-1.cpp
@@ -52,11 +52,13 @@ auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void;
     test_generic(std::move(o), "optional<int>");
 }
 
+#line 24 "pure2-type-safety-1.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::string msgx {msg}; 
     print(std::move(msgx) + " is int? ", cpp2::is<int>(x));
 }
 
+#line 29 "pure2-type-safety-1.cpp2"
 auto print(cpp2::in<std::string> msg, cpp2::in<bool> b) -> void{
     cpp2::deferred_init<char const*> bmsg; 
     if (b) { bmsg.construct("true");}

--- a/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
+++ b/regression-tests/test-results/pure2-type-safety-2-with-inspect-expression.cpp
@@ -40,6 +40,7 @@ auto test_generic(auto const& x, auto const& msg) -> void;
     test_generic(std::move(o), "optional<int>");
 }
 
+#line 20 "pure2-type-safety-2-with-inspect-expression.cpp2"
 auto test_generic(auto const& x, auto const& msg) -> void{
     std::cout 
         << std::setw(30) << msg 

--- a/regression-tests/test-results/pure2-types-basics.cpp
+++ b/regression-tests/test-results/pure2-types-basics.cpp
@@ -109,6 +109,7 @@ namespace N {
 #line 11 "pure2-types-basics.cpp2"
     }
 
+#line 13 "pure2-types-basics.cpp2"
     myclass::myclass(cpp2::in<std::string> s)
         : data{ 99 }
         , more{ s }{
@@ -129,6 +130,7 @@ namespace N {
 #line 18 "pure2-types-basics.cpp2"
     }
 
+#line 20 "pure2-types-basics.cpp2"
     myclass::myclass(cpp2::in<int> x, cpp2::in<std::string> s)
         : data{ 77 }
         , more{ s + std::to_string(x) + " plugh" }{
@@ -138,6 +140,7 @@ namespace N {
         print();
     }
 
+#line 27 "pure2-types-basics.cpp2"
     myclass::myclass()
         : more{ std::to_string(3.14159) }{
         // use default initializer for this.data
@@ -147,18 +150,22 @@ namespace N {
         print();
     }
 
+#line 34 "pure2-types-basics.cpp2"
     auto myclass::print() const& -> void{
         std::cout << ("    data: " + cpp2::to_string(data) + ", more: " + cpp2::to_string(more) + "\n");
     }
 
+#line 38 "pure2-types-basics.cpp2"
     auto myclass::print() && -> void{
         std::cout << ("    (move print) data: " + cpp2::to_string(data) + ", more: " + cpp2::to_string(more) + "\n");
     }
 
+#line 42 "pure2-types-basics.cpp2"
     myclass::~myclass() noexcept{
         std::cout << "myclass: destructor\n";
     }
 
+#line 46 "pure2-types-basics.cpp2"
     auto myclass::f(cpp2::in<int> x) const& -> void{
         std::cout << ("N::myclass::f with " + cpp2::to_string(x) + "\n");
     }
@@ -168,13 +175,17 @@ namespace N {
 
 #line 57 "pure2-types-basics.cpp2"
     template<typename T, typename U> [[nodiscard]] auto myclass::f1(T const& t, U const& u) -> auto { return t + u; }
+#line 58 "pure2-types-basics.cpp2"
     template<typename T, typename U> [[nodiscard]] auto myclass::f2(T const& t, U const& u) -> auto { return t + u; }
+#line 59 "pure2-types-basics.cpp2"
     template<auto T, auto U> [[nodiscard]] auto myclass::f3() -> auto { return T + U; }
+#line 60 "pure2-types-basics.cpp2"
     template<cpp2::i8 T, cpp2::i16 U> [[nodiscard]] auto myclass::f4() -> auto { return T + U; }
 
 #line 64 "pure2-types-basics.cpp2"
 }
 
+#line 66 "pure2-types-basics.cpp2"
 auto main() -> int{
     N::myclass x {1}; 
     CPP2_UFCS(f)(x, 53);

--- a/regression-tests/test-results/pure2-types-down-upcast.cpp
+++ b/regression-tests/test-results/pure2-types-down-upcast.cpp
@@ -66,14 +66,19 @@ auto test_down() -> void;
 
 #line 4 "pure2-types-down-upcast.cpp2"
  auto A::const_foo() const -> void{std::cout << "const foo \n"; }
+#line 5 "pure2-types-down-upcast.cpp2"
  auto A::mut_foo() & -> void{std::cout << "foo \n"; }
 
 #line 13 "pure2-types-down-upcast.cpp2"
 auto func_mut(A& a) -> void     {std::cout << ("Call A mut: " + cpp2::to_string(a.i)) << std::endl;}
+#line 14 "pure2-types-down-upcast.cpp2"
 auto func_mut(B& b) -> void     {std::cout << ("Call B mut: " + cpp2::to_string(b.d)) << std::endl;}
+#line 15 "pure2-types-down-upcast.cpp2"
 auto func_const(cpp2::in<A> a) -> void{std::cout << ("Call A const: " + cpp2::to_string(a.i)) << std::endl;}
+#line 16 "pure2-types-down-upcast.cpp2"
 auto func_const(cpp2::in<B> b) -> void{std::cout << ("Call B const: " + cpp2::to_string(b.d)) << std::endl;}
 
+#line 18 "pure2-types-down-upcast.cpp2"
 auto test_const_foo() -> void{
  A s {}; 
   A const* sC {&s}; 
@@ -85,6 +90,7 @@ auto test_const_foo() -> void{
   static_cast<void>(std::move(sC));
 }
 
+#line 29 "pure2-types-down-upcast.cpp2"
 auto test_mut_foo() -> void{
  A s {}; 
   CPP2_UFCS(mut_foo)(s);
@@ -92,6 +98,7 @@ auto test_mut_foo() -> void{
   static_cast<void>(std::move(s));
 }
 
+#line 36 "pure2-types-down-upcast.cpp2"
 auto test_up() -> void{
   B b {}; 
   B const* bC {&b}; 
@@ -111,6 +118,7 @@ auto test_up() -> void{
   static_cast<void>(std::move(bC));
 }
 
+#line 55 "pure2-types-down-upcast.cpp2"
 auto test_down() -> void{
   B b {}; 
   B const* bC {&b}; 
@@ -133,6 +141,7 @@ auto test_down() -> void{
   static_cast<void>(std::move(aC));
 }
 
+#line 77 "pure2-types-down-upcast.cpp2"
 [[nodiscard]] auto main() -> int{
 
   test_const_foo();

--- a/regression-tests/test-results/pure2-types-inheritance.cpp
+++ b/regression-tests/test-results/pure2-types-inheritance.cpp
@@ -95,6 +95,7 @@ Human::~Human() noexcept{}
 #line 6 "pure2-types-inheritance.cpp2"
 namespace N {
 
+#line 8 "pure2-types-inheritance.cpp2"
         template <int I> Machine<I>::Machine([[maybe_unused]] cpp2::in<std::string> unnamed_param_2){}
 
         template <int I> Machine<I>::~Machine() noexcept{}
@@ -113,15 +114,19 @@ namespace N {
         std::cout << (cpp2::to_string(name) + " checks in for the day's shift\n");
     }
 
+#line 25 "pure2-types-inheritance.cpp2"
     auto Cyborg::speak() const -> void { 
         std::cout << (cpp2::to_string(name) + " cracks a few jokes with a coworker\n");  }
 
+#line 28 "pure2-types-inheritance.cpp2"
     auto Cyborg::work() const -> void { 
         std::cout << (cpp2::to_string(name) + " carries some half-tonne crates of Fe2O3 to cold storage\n");  }
 
+#line 31 "pure2-types-inheritance.cpp2"
     auto Cyborg::print() const& -> void { 
         std::cout << ("printing: " + cpp2::to_string(name) + " lives at " + cpp2::to_string(address) + "\n");  }
 
+#line 34 "pure2-types-inheritance.cpp2"
     Cyborg::~Cyborg() noexcept { 
         std::cout << ("Tired but satisfied after another successful day, " + cpp2::to_string(name) + " checks out and goes home to their family\n");  }
 
@@ -131,11 +136,13 @@ auto make_speak(cpp2::in<Human> h) -> void{
     CPP2_UFCS(speak)(h);
 }
 
+#line 43 "pure2-types-inheritance.cpp2"
 auto do_work(cpp2::in<N::Machine<99>> m) -> void{
     std::cout << "-> [vcall: do_work] ";
     CPP2_UFCS(work)(m);
 }
 
+#line 48 "pure2-types-inheritance.cpp2"
 auto main() -> int{
     Cyborg c {"Parsnip"}; 
     CPP2_UFCS(print)(c);

--- a/regression-tests/test-results/pure2-types-smf-and-that-1-provide-everything.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-1-provide-everything.cpp
@@ -62,6 +62,7 @@ auto main() -> int;
         std::cout << "ctor - copy (GENERAL)";
     }
 
+#line 8 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }{
@@ -70,6 +71,7 @@ auto main() -> int;
         std::cout << "ctor - move          ";
     }
 
+#line 13 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     auto myclass::operator=(myclass const& that) -> myclass& {
         name = that.name;
         addr = that.addr + "(AC)";
@@ -80,6 +82,7 @@ auto main() -> int;
 #line 16 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     }
 
+#line 18 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
@@ -89,6 +92,7 @@ auto main() -> int;
 #line 20 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     }
 
+#line 22 "pure2-types-smf-and-that-1-provide-everything.cpp2"
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }{
 

--- a/regression-tests/test-results/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp
@@ -65,6 +65,7 @@ auto main() -> int;
         std::cout << "ctor - copy (GENERAL)";
     }
 
+#line 8 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }{
@@ -73,6 +74,7 @@ auto main() -> int;
         std::cout << "ctor - move          ";
     }
 
+#line 13 "pure2-types-smf-and-that-2-provide-mvconstruct-and-cpassign.cpp2"
     auto myclass::operator=(myclass const& that) -> myclass& {
         name = that.name;
         addr = that.addr + "(AC)";

--- a/regression-tests/test-results/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp
@@ -75,6 +75,7 @@ auto main() -> int;
 #line 6 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     }
 
+#line 8 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name + "(CM)" }
         , addr{ std::move(that).addr }{
@@ -93,6 +94,7 @@ auto main() -> int;
 #line 20 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     }
 
+#line 22 "pure2-types-smf-and-that-3-provide-mvconstruct-and-mvassign.cpp2"
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }{
 

--- a/regression-tests/test-results/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp
+++ b/regression-tests/test-results/pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp
@@ -84,6 +84,7 @@ auto main() -> int;
 #line 16 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     }
 
+#line 18 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     auto myclass::operator=(myclass&& that) noexcept -> myclass& {
         name = std::move(that).name;
         addr = std::move(that).addr;
@@ -93,6 +94,7 @@ auto main() -> int;
 #line 20 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     }
 
+#line 22 "pure2-types-smf-and-that-4-provide-cpassign-and-mvassign.cpp2"
     myclass::myclass(cpp2::in<std::string> x)
         : name{ x }{
 

--- a/regression-tests/test-results/pure2-types-that-parameters.cpp
+++ b/regression-tests/test-results/pure2-types-that-parameters.cpp
@@ -48,6 +48,7 @@ auto main() -> int;
 #line 4 "pure2-types-that-parameters.cpp2"
     myclass::myclass(){}
 
+#line 6 "pure2-types-that-parameters.cpp2"
     myclass::myclass(myclass const& that)
         : name{ that.name }
         , addr{ that.addr }{
@@ -63,6 +64,7 @@ auto main() -> int;
 #line 9 "pure2-types-that-parameters.cpp2"
     }
 
+#line 11 "pure2-types-that-parameters.cpp2"
     myclass::myclass(myclass&& that) noexcept
         : name{ std::move(that).name }
         , addr{ std::move(that).addr }{
@@ -78,6 +80,7 @@ auto main() -> int;
 #line 14 "pure2-types-that-parameters.cpp2"
     }
 
+#line 16 "pure2-types-that-parameters.cpp2"
     auto myclass::print() const& -> void{
         std::cout << ("name '" + cpp2::to_string(name) + "', addr '" + cpp2::to_string(addr) + "'\n");
     }

--- a/regression-tests/test-results/pure2-types-value-types-via-meta-functions.cpp
+++ b/regression-tests/test-results/pure2-types-value-types-via-meta-functions.cpp
@@ -152,6 +152,7 @@ auto main() -> int{
     test<p_widget>();
 }
 
+#line 23 "pure2-types-value-types-via-meta-functions.cpp2"
 template<typename T> auto test() -> void{
     //  should be default constructible
     T a {}; 

--- a/regression-tests/test-results/pure2-ufcs-member-access-and-chaining.cpp
+++ b/regression-tests/test-results/pure2-ufcs-member-access-and-chaining.cpp
@@ -61,12 +61,15 @@ extern int y;
     CPP2_UFCS(no_return)(std::move(res));
 }
 
+#line 26 "pure2-ufcs-member-access-and-chaining.cpp2"
 auto no_return([[maybe_unused]] auto const& unnamed_param_1) -> void{}
 
+#line 28 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto ufcs(cpp2::in<int> i) -> int{
     return i + 2; 
 }
 
+#line 32 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto fun() -> fun_ret{
         cpp2::deferred_init<int> i;
 #line 33 "pure2-ufcs-member-access-and-chaining.cpp2"
@@ -74,6 +77,7 @@ auto no_return([[maybe_unused]] auto const& unnamed_param_1) -> void{}
     return std::move(i.value()); 
 }
 
+#line 37 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto get_i(auto const& r) -> int{
     return r; 
 }

--- a/regression-tests/test-results/pure2-union.cpp
+++ b/regression-tests/test-results/pure2-union.cpp
@@ -80,8 +80,8 @@ auto main() -> int;
 
 #line 1 "pure2-union.cpp2"
 
-
 #line 1 "pure2-union.cpp2"
+
 [[nodiscard]] auto name_or_number::is_name() const& -> bool { return _discriminator == 0; }
 [[nodiscard]] auto name_or_number::name() const& -> std::string const& { 
                                                          if (cpp2::Default.has_handler() && !(is_name()) ) { cpp2::Default.report_violation(""); }return *cpp2::assert_not_null(reinterpret_cast<std::string const*>(&_storage)); }
@@ -196,6 +196,7 @@ auto print_name(cpp2::in<name_or_number> non) -> void{
     }
 }
 
+#line 28 "pure2-union.cpp2"
 auto main() -> int{
     name_or_number x {}; 
     std::cout << ("sizeof(x) is " + cpp2::to_string(sizeof(x)) + "\n");

--- a/regression-tests/test-results/pure2-variadics.cpp
+++ b/regression-tests/test-results/pure2-variadics.cpp
@@ -54,14 +54,18 @@ template<typename ...Args> auto left_fold_print(std::ostream& out, Args const& .
     (out << ... << args);
 }
 
+#line 14 "pure2-variadics.cpp2"
 template<typename ...Args> [[nodiscard]] auto all(Args const& ...args) -> bool { 
     //  Unary left fold expression
     return (... && args);  }
 
+#line 18 "pure2-variadics.cpp2"
 template     <typename ...Args> [[nodiscard]] auto make_string(Args&& ...args) -> auto { return std::string{CPP2_FORWARD(args)...}; }
 
+#line 20 "pure2-variadics.cpp2"
 template  <typename T, typename ...Args> [[nodiscard]] auto make(Args&& ...args) -> auto { return T{CPP2_FORWARD(args)...}; }
 
+#line 22 "pure2-variadics.cpp2"
 auto main() -> int
 {
     x<int,long,std::string> auto_24_5 {}; 

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -809,8 +809,10 @@ namespace meta {
         metafunctions_used = CPP2_UFCS(empty)(args);
     }
 
+#line 66 "reflect.h2"
     [[nodiscard]] auto compiler_services::get_metafunction_name() const& -> std::string_view { return metafunction_name;  }
 
+#line 68 "reflect.h2"
     [[nodiscard]] auto compiler_services::get_argument(cpp2::in<int> index) & -> std::string{
         metafunctions_used = true;
         if (([_0 = 0, _1 = index, _2 = CPP2_UFCS(ssize)(metafunction_args)]{ return cpp2::cmp_less_eq(_0,_1) && cpp2::cmp_less(_1,_2); }())) {
@@ -819,13 +821,16 @@ namespace meta {
         return ""; 
     }
 
+#line 76 "reflect.h2"
     [[nodiscard]] auto compiler_services::get_arguments() & -> std::vector<std::string>{
         metafunctions_used = true;
         return metafunction_args; 
     }
 
+#line 81 "reflect.h2"
     [[nodiscard]] auto compiler_services::arguments_were_used() const& -> bool { return metafunctions_used;  }
 
+#line 83 "reflect.h2"
     [[nodiscard]] auto compiler_services::parse_statement(
 
         std::string_view source
@@ -886,6 +891,7 @@ auto newline_pos{CPP2_UFCS(find)(source, '\n')};
         }return std::move(ret.value()); 
     }
 
+#line 136 "reflect.h2"
     [[nodiscard]] auto compiler_services::position() const -> source_position
 
     {
@@ -904,6 +910,7 @@ auto newline_pos{CPP2_UFCS(find)(source, '\n')};
         }
     }
 
+#line 156 "reflect.h2"
     auto compiler_services::error(cpp2::in<std::string_view> msg) const& -> void
     {
         auto message {cpp2::as_<std::string>(msg)}; 
@@ -919,6 +926,7 @@ auto newline_pos{CPP2_UFCS(find)(source, '\n')};
         throw(std::runtime_error(("  ==> programming bug found in metafunction @" + cpp2::to_string(metafunction_name) + " - contract violation - see previous errors")));
     }
 
+#line 173 "reflect.h2"
     [[nodiscard]] auto compiler_services::has_handler() const& -> auto { return true;  }
 
     compiler_services::~compiler_services() noexcept{}
@@ -946,8 +954,10 @@ compiler_services::compiler_services(compiler_services const& that)
         if (cpp2::Default.has_handler() && !(n) ) { cpp2::Default.report_violation(CPP2_CONTRACT_MSG("a meta::declaration must point to a valid declaration_node, not null")); }
     }
 
+#line 240 "reflect.h2"
     [[nodiscard]] auto declaration_base::position() const -> source_position { return CPP2_UFCS(position)((*cpp2::assert_not_null(n)));  }
 
+#line 242 "reflect.h2"
     [[nodiscard]] auto declaration_base::print() const& -> std::string { return CPP2_UFCS(pretty_print_visualize)((*cpp2::assert_not_null(n)), 0);  }
 
     declaration_base::~declaration_base() noexcept{}
@@ -967,63 +977,104 @@ declaration_base::declaration_base(declaration_base const& that)
 
     }
 
+#line 262 "reflect.h2"
     [[nodiscard]] auto declaration::is_public() const& -> bool { return CPP2_UFCS(is_public)((*cpp2::assert_not_null(n))); }
+#line 263 "reflect.h2"
     [[nodiscard]] auto declaration::is_protected() const& -> bool { return CPP2_UFCS(is_protected)((*cpp2::assert_not_null(n))); }
+#line 264 "reflect.h2"
     [[nodiscard]] auto declaration::is_private() const& -> bool { return CPP2_UFCS(is_private)((*cpp2::assert_not_null(n))); }
+#line 265 "reflect.h2"
     [[nodiscard]] auto declaration::is_default_access() const& -> bool { return CPP2_UFCS(is_default_access)((*cpp2::assert_not_null(n)));  }
 
+#line 267 "reflect.h2"
     auto declaration::default_to_public() & -> void { static_cast<void>(CPP2_UFCS(make_public)((*cpp2::assert_not_null(n)))); }
+#line 268 "reflect.h2"
     auto declaration::default_to_protected() & -> void { static_cast<void>(CPP2_UFCS(make_protected)((*cpp2::assert_not_null(n))));  }
+#line 269 "reflect.h2"
     auto declaration::default_to_private() & -> void { static_cast<void>(CPP2_UFCS(make_private)((*cpp2::assert_not_null(n)))); }
 
+#line 271 "reflect.h2"
     [[nodiscard]] auto declaration::make_public() & -> bool { return CPP2_UFCS(make_public)((*cpp2::assert_not_null(n))); }
+#line 272 "reflect.h2"
     [[nodiscard]] auto declaration::make_protected() & -> bool { return CPP2_UFCS(make_protected)((*cpp2::assert_not_null(n))); }
+#line 273 "reflect.h2"
     [[nodiscard]] auto declaration::make_private() & -> bool { return CPP2_UFCS(make_private)((*cpp2::assert_not_null(n))); }
 
+#line 275 "reflect.h2"
     [[nodiscard]] auto declaration::has_name() const& -> bool { return CPP2_UFCS(has_name)((*cpp2::assert_not_null(n))); }
+#line 276 "reflect.h2"
     [[nodiscard]] auto declaration::has_name(cpp2::in<std::string_view> s) const& -> bool { return CPP2_UFCS(has_name)((*cpp2::assert_not_null(n)), s); }
 
+#line 278 "reflect.h2"
     [[nodiscard]] auto declaration::name() const& -> std::string_view{
         if (has_name()) {return CPP2_UFCS(as_string_view)((*cpp2::assert_not_null(CPP2_UFCS(name)(*cpp2::assert_not_null(n))))); }
         else          { return ""; }
     }
 
+#line 283 "reflect.h2"
     [[nodiscard]] auto declaration::has_initializer() const& -> bool { return CPP2_UFCS(has_initializer)((*cpp2::assert_not_null(n)));  }
 
+#line 285 "reflect.h2"
     [[nodiscard]] auto declaration::is_global() const& -> bool { return CPP2_UFCS(is_global)((*cpp2::assert_not_null(n))); }
+#line 286 "reflect.h2"
     [[nodiscard]] auto declaration::is_function() const& -> bool { return CPP2_UFCS(is_function)((*cpp2::assert_not_null(n))); }
+#line 287 "reflect.h2"
     [[nodiscard]] auto declaration::is_object() const& -> bool { return CPP2_UFCS(is_object)((*cpp2::assert_not_null(n))); }
+#line 288 "reflect.h2"
     [[nodiscard]] auto declaration::is_base_object() const& -> bool { return CPP2_UFCS(is_base_object)((*cpp2::assert_not_null(n))); }
+#line 289 "reflect.h2"
     [[nodiscard]] auto declaration::is_member_object() const& -> bool { return CPP2_UFCS(is_member_object)((*cpp2::assert_not_null(n)));  }
+#line 290 "reflect.h2"
     [[nodiscard]] auto declaration::is_type() const& -> bool { return CPP2_UFCS(is_type)((*cpp2::assert_not_null(n))); }
+#line 291 "reflect.h2"
     [[nodiscard]] auto declaration::is_namespace() const& -> bool { return CPP2_UFCS(is_namespace)((*cpp2::assert_not_null(n))); }
+#line 292 "reflect.h2"
     [[nodiscard]] auto declaration::is_alias() const& -> bool { return CPP2_UFCS(is_alias)((*cpp2::assert_not_null(n))); }
 
+#line 294 "reflect.h2"
     [[nodiscard]] auto declaration::is_type_alias() const& -> bool { return CPP2_UFCS(is_type_alias)((*cpp2::assert_not_null(n))); }
+#line 295 "reflect.h2"
     [[nodiscard]] auto declaration::is_namespace_alias() const& -> bool { return CPP2_UFCS(is_namespace_alias)((*cpp2::assert_not_null(n)));  }
+#line 296 "reflect.h2"
     [[nodiscard]] auto declaration::is_object_alias() const& -> bool { return CPP2_UFCS(is_object_alias)((*cpp2::assert_not_null(n))); }
 
+#line 298 "reflect.h2"
     [[nodiscard]] auto declaration::is_function_expression() const& -> bool { return CPP2_UFCS(is_function_expression)((*cpp2::assert_not_null(n)));  }
 
+#line 300 "reflect.h2"
     [[nodiscard]] auto declaration::as_function() const& -> function_declaration { return function_declaration(n, (*this));  }
+#line 301 "reflect.h2"
     [[nodiscard]] auto declaration::as_object() const& -> object_declaration { return object_declaration(n, (*this)); }
+#line 302 "reflect.h2"
     [[nodiscard]] auto declaration::as_type() const& -> type_declaration { return type_declaration(n, (*this)); }
+#line 303 "reflect.h2"
     [[nodiscard]] auto declaration::as_alias() const& -> alias_declaration { return alias_declaration(n, (*this)); }
 
+#line 305 "reflect.h2"
     [[nodiscard]] auto declaration::get_parent() const& -> declaration { return declaration((*cpp2::assert_not_null(n)).parent_declaration, (*this)); }
 
+#line 307 "reflect.h2"
     [[nodiscard]] auto declaration::parent_is_function() const& -> bool { return CPP2_UFCS(parent_is_function)((*cpp2::assert_not_null(n))); }
+#line 308 "reflect.h2"
     [[nodiscard]] auto declaration::parent_is_object() const& -> bool { return CPP2_UFCS(parent_is_object)((*cpp2::assert_not_null(n))); }
+#line 309 "reflect.h2"
     [[nodiscard]] auto declaration::parent_is_type() const& -> bool { return CPP2_UFCS(parent_is_type)((*cpp2::assert_not_null(n))); }
+#line 310 "reflect.h2"
     [[nodiscard]] auto declaration::parent_is_namespace() const& -> bool { return CPP2_UFCS(parent_is_namespace)((*cpp2::assert_not_null(n))); }
+#line 311 "reflect.h2"
     [[nodiscard]] auto declaration::parent_is_alias() const& -> bool { return CPP2_UFCS(parent_is_alias)((*cpp2::assert_not_null(n))); }
 
+#line 313 "reflect.h2"
     [[nodiscard]] auto declaration::parent_is_type_alias() const& -> bool { return CPP2_UFCS(parent_is_type_alias)((*cpp2::assert_not_null(n))); }
+#line 314 "reflect.h2"
     [[nodiscard]] auto declaration::parent_is_namespace_alias() const& -> bool { return CPP2_UFCS(parent_is_namespace_alias)((*cpp2::assert_not_null(n)));  }
+#line 315 "reflect.h2"
     [[nodiscard]] auto declaration::parent_is_object_alias() const& -> bool { return CPP2_UFCS(parent_is_object_alias)((*cpp2::assert_not_null(n))); }
 
+#line 317 "reflect.h2"
     [[nodiscard]] auto declaration::parent_is_polymorphic() const& -> bool { return CPP2_UFCS(parent_is_polymorphic)((*cpp2::assert_not_null(n)));  }
 
+#line 319 "reflect.h2"
     auto declaration::mark_for_removal_from_enclosing_type() & -> void
 
     {
@@ -1050,40 +1101,69 @@ declaration::declaration(declaration const& that)
         if (cpp2::Default.has_handler() && !(CPP2_UFCS(is_function)((*cpp2::assert_not_null(n)))) ) { cpp2::Default.report_violation(""); }
     }
 
+#line 345 "reflect.h2"
     [[nodiscard]] auto function_declaration::index_of_parameter_named(cpp2::in<std::string_view> s) const& -> int { return CPP2_UFCS(index_of_parameter_named)((*cpp2::assert_not_null(n)), s); }
+#line 346 "reflect.h2"
     [[nodiscard]] auto function_declaration::has_parameter_named(cpp2::in<std::string_view> s) const& -> bool { return CPP2_UFCS(has_parameter_named)((*cpp2::assert_not_null(n)), s); }
+#line 347 "reflect.h2"
     [[nodiscard]] auto function_declaration::has_in_parameter_named(cpp2::in<std::string_view> s) const& -> bool { return CPP2_UFCS(has_in_parameter_named)((*cpp2::assert_not_null(n)), s); }
+#line 348 "reflect.h2"
     [[nodiscard]] auto function_declaration::has_out_parameter_named(cpp2::in<std::string_view> s) const& -> bool { return CPP2_UFCS(has_out_parameter_named)((*cpp2::assert_not_null(n)), s); }
+#line 349 "reflect.h2"
     [[nodiscard]] auto function_declaration::has_move_parameter_named(cpp2::in<std::string_view> s) const& -> bool { return CPP2_UFCS(has_move_parameter_named)((*cpp2::assert_not_null(n)), s); }
+#line 350 "reflect.h2"
     [[nodiscard]] auto function_declaration::first_parameter_name() const& -> std::string { return CPP2_UFCS(first_parameter_name)((*cpp2::assert_not_null(n))); }
 
+#line 352 "reflect.h2"
     [[nodiscard]] auto function_declaration::has_parameter_with_name_and_pass(cpp2::in<std::string_view> s, cpp2::in<passing_style> pass) const& -> bool { 
                                                   return CPP2_UFCS(has_parameter_with_name_and_pass)((*cpp2::assert_not_null(n)), s, pass);  }
+#line 354 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_function_with_this() const& -> bool { return CPP2_UFCS(is_function_with_this)((*cpp2::assert_not_null(n))); }
+#line 355 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_virtual() const& -> bool { return CPP2_UFCS(is_virtual_function)((*cpp2::assert_not_null(n))); }
+#line 356 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_defaultable() const& -> bool { return CPP2_UFCS(is_defaultable_function)((*cpp2::assert_not_null(n))); }
+#line 357 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_constructor() const& -> bool { return CPP2_UFCS(is_constructor)((*cpp2::assert_not_null(n))); }
+#line 358 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_default_constructor() const& -> bool { return CPP2_UFCS(is_default_constructor)((*cpp2::assert_not_null(n))); }
+#line 359 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_move() const& -> bool { return CPP2_UFCS(is_move)((*cpp2::assert_not_null(n))); }
+#line 360 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_swap() const& -> bool { return CPP2_UFCS(is_swap)((*cpp2::assert_not_null(n))); }
+#line 361 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_constructor_with_that() const& -> bool { return CPP2_UFCS(is_constructor_with_that)((*cpp2::assert_not_null(n))); }
+#line 362 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_constructor_with_in_that() const& -> bool { return CPP2_UFCS(is_constructor_with_in_that)((*cpp2::assert_not_null(n))); }
+#line 363 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_constructor_with_move_that() const& -> bool { return CPP2_UFCS(is_constructor_with_move_that)((*cpp2::assert_not_null(n)));  }
+#line 364 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_assignment() const& -> bool { return CPP2_UFCS(is_assignment)((*cpp2::assert_not_null(n))); }
+#line 365 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_assignment_with_that() const& -> bool { return CPP2_UFCS(is_assignment_with_that)((*cpp2::assert_not_null(n))); }
+#line 366 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_assignment_with_in_that() const& -> bool { return CPP2_UFCS(is_assignment_with_in_that)((*cpp2::assert_not_null(n))); }
+#line 367 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_assignment_with_move_that() const& -> bool { return CPP2_UFCS(is_assignment_with_move_that)((*cpp2::assert_not_null(n)));  }
+#line 368 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_destructor() const& -> bool { return CPP2_UFCS(is_destructor)((*cpp2::assert_not_null(n))); }
 
+#line 370 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_copy_or_move() const& -> bool { return is_constructor_with_that() || is_assignment_with_that(); }
 
+#line 372 "reflect.h2"
     [[nodiscard]] auto function_declaration::has_declared_return_type() const& -> bool { return CPP2_UFCS(has_declared_return_type)((*cpp2::assert_not_null(n))); }
+#line 373 "reflect.h2"
     [[nodiscard]] auto function_declaration::has_deduced_return_type() const& -> bool { return CPP2_UFCS(has_deduced_return_type)((*cpp2::assert_not_null(n))); }
+#line 374 "reflect.h2"
     [[nodiscard]] auto function_declaration::has_bool_return_type() const& -> bool { return CPP2_UFCS(has_bool_return_type)((*cpp2::assert_not_null(n))); }
+#line 375 "reflect.h2"
     [[nodiscard]] auto function_declaration::has_non_void_return_type() const& -> bool { return CPP2_UFCS(has_non_void_return_type)((*cpp2::assert_not_null(n))); }
 
+#line 377 "reflect.h2"
     [[nodiscard]] auto function_declaration::unnamed_return_type() const& -> std::string { return CPP2_UFCS(unnamed_return_type_to_string)((*cpp2::assert_not_null(n))); }
 
+#line 379 "reflect.h2"
     [[nodiscard]] auto function_declaration::get_parameters() const& -> std::vector<object_declaration>
 
     {
@@ -1094,12 +1174,16 @@ declaration::declaration(declaration const& that)
         return ret; 
     }
 
+#line 389 "reflect.h2"
     [[nodiscard]] auto function_declaration::is_binary_comparison_function() const& -> bool { return CPP2_UFCS(is_binary_comparison_function)((*cpp2::assert_not_null(n)));  }
 
+#line 391 "reflect.h2"
     auto function_declaration::default_to_virtual() & -> void { static_cast<void>(CPP2_UFCS(make_function_virtual)((*cpp2::assert_not_null(n)))); }
 
+#line 393 "reflect.h2"
     [[nodiscard]] auto function_declaration::make_virtual() & -> bool { return CPP2_UFCS(make_function_virtual)((*cpp2::assert_not_null(n))); }
 
+#line 395 "reflect.h2"
     auto function_declaration::add_initializer(cpp2::in<std::string_view> source) & -> void
 
 #line 398 "reflect.h2"
@@ -1137,9 +1221,12 @@ declaration::declaration(declaration const& that)
         if (cpp2::Default.has_handler() && !(CPP2_UFCS(is_object)((*cpp2::assert_not_null(n)))) ) { cpp2::Default.report_violation(""); }
     }
 
+#line 432 "reflect.h2"
     [[nodiscard]] auto object_declaration::is_const() const& -> bool { return CPP2_UFCS(is_const)((*cpp2::assert_not_null(n))); }
+#line 433 "reflect.h2"
     [[nodiscard]] auto object_declaration::has_wildcard_type() const& -> bool { return CPP2_UFCS(has_wildcard_type)((*cpp2::assert_not_null(n)));  }
 
+#line 435 "reflect.h2"
     [[nodiscard]] auto object_declaration::type() const& -> std::string{
         auto ret {CPP2_UFCS(object_type)((*cpp2::assert_not_null(n)))}; 
         require(!(contains(ret, "(*ERROR*)")), 
@@ -1147,6 +1234,7 @@ declaration::declaration(declaration const& that)
         return ret; 
     }
 
+#line 442 "reflect.h2"
     [[nodiscard]] auto object_declaration::initializer() const& -> std::string{
         auto ret {CPP2_UFCS(object_initializer)((*cpp2::assert_not_null(n)))}; 
         require(!(contains(ret, "(*ERROR*)")), 
@@ -1170,6 +1258,7 @@ declaration::declaration(declaration const& that)
         if (cpp2::Default.has_handler() && !(CPP2_UFCS(is_type)((*cpp2::assert_not_null(n)))) ) { cpp2::Default.report_violation(""); }
     }
 
+#line 468 "reflect.h2"
     auto type_declaration::reserve_names(cpp2::in<std::string_view> name, auto&& ...etc) const& -> void
     {                           // etc is not declared ':string_view' for compatibility with GCC 10.x
         for ( 
@@ -1182,10 +1271,14 @@ declaration::declaration(declaration const& that)
         }
     }
 
+#line 480 "reflect.h2"
     [[nodiscard]] auto type_declaration::is_polymorphic() const& -> bool { return CPP2_UFCS(is_polymorphic)((*cpp2::assert_not_null(n))); }
+#line 481 "reflect.h2"
     [[nodiscard]] auto type_declaration::is_final() const& -> bool { return CPP2_UFCS(is_type_final)((*cpp2::assert_not_null(n))); }
+#line 482 "reflect.h2"
     [[nodiscard]] auto type_declaration::make_final() & -> bool { return CPP2_UFCS(make_type_final)((*cpp2::assert_not_null(n))); }
 
+#line 484 "reflect.h2"
     [[nodiscard]] auto type_declaration::get_member_functions() const& -> std::vector<function_declaration>
 
     {
@@ -1197,6 +1290,7 @@ declaration::declaration(declaration const& that)
         return ret; 
     }
 
+#line 495 "reflect.h2"
     [[nodiscard]] auto type_declaration::get_member_functions_needing_initializer() const& -> std::vector<function_declaration>
 
     {
@@ -1212,6 +1306,7 @@ declaration::declaration(declaration const& that)
         return ret; 
     }
 
+#line 510 "reflect.h2"
     [[nodiscard]] auto type_declaration::get_member_objects() const& -> std::vector<object_declaration>
 
     {
@@ -1222,6 +1317,7 @@ declaration::declaration(declaration const& that)
         return ret; 
     }
 
+#line 520 "reflect.h2"
     [[nodiscard]] auto type_declaration::get_member_types() const& -> std::vector<type_declaration>
 
     {
@@ -1232,6 +1328,7 @@ declaration::declaration(declaration const& that)
         return ret; 
     }
 
+#line 530 "reflect.h2"
     [[nodiscard]] auto type_declaration::get_member_aliases() const& -> std::vector<alias_declaration>
 
     {
@@ -1242,6 +1339,7 @@ declaration::declaration(declaration const& that)
         return ret; 
     }
 
+#line 540 "reflect.h2"
     [[nodiscard]] auto type_declaration::get_members() const& -> std::vector<declaration>
 
     {
@@ -1252,6 +1350,7 @@ declaration::declaration(declaration const& that)
         return ret; 
     }
 
+#line 550 "reflect.h2"
     [[nodiscard]] auto type_declaration::query_declared_value_set_functions() const& -> query_declared_value_set_functions_ret
 
 #line 557 "reflect.h2"
@@ -1268,6 +1367,7 @@ declaration::declaration(declaration const& that)
         inout_this_move_that.construct(std::move(declared).inout_this_move_that != nullptr);
     return  { std::move(out_this_in_that.value()), std::move(out_this_move_that.value()), std::move(inout_this_in_that.value()), std::move(inout_this_move_that.value()) }; }
 
+#line 565 "reflect.h2"
     auto type_declaration::add_member(cpp2::in<std::string_view> source) & -> void
     {
         auto decl {parse_statement(source)}; 
@@ -1282,9 +1382,12 @@ declaration::declaration(declaration const& that)
                  std::string("unexpected error while attempting to add member:\n") + source);
     }
 
+#line 579 "reflect.h2"
     auto type_declaration::remove_marked_members() & -> void { CPP2_UFCS(type_remove_marked_members)((*cpp2::assert_not_null(n)));  }
+#line 580 "reflect.h2"
     auto type_declaration::remove_all_members() & -> void { CPP2_UFCS(type_remove_all_members)((*cpp2::assert_not_null(n))); }
 
+#line 582 "reflect.h2"
     auto type_declaration::disable_member_function_generation() & -> void { CPP2_UFCS(type_disable_member_function_generation)((*cpp2::assert_not_null(n)));  }
 
     type_declaration::type_declaration(type_declaration const& that)
@@ -1455,12 +1558,14 @@ auto value(meta::type_declaration& t) -> void
     CPP2_UFCS(basic_value)(t);
 }
 
+#line 855 "reflect.h2"
 auto weakly_ordered_value(meta::type_declaration& t) -> void
 {
     CPP2_UFCS(weakly_ordered)(t);
     CPP2_UFCS(basic_value)(t);
 }
 
+#line 861 "reflect.h2"
 auto partially_ordered_value(meta::type_declaration& t) -> void
 {
     CPP2_UFCS(partially_ordered)(t);

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <cstdio>
 #include <optional>
+#include <filesystem>
 
 namespace cpp2 {
 
@@ -103,6 +104,14 @@ static cmdline_processor::register_flag cmd_clean_cpp1(
     "clean-cpp1",
     "Emit clean Cpp1 without #line directives",
     []{ flag_clean_cpp1 = true; }
+);
+
+static auto flag_absolute_line_directives = false;
+static cmdline_processor::register_flag cmd_absolute_line_directives(
+    9,
+    "absolute-line-directives",
+    "Emit absolute paths in #line directives",
+    [] { flag_absolute_line_directives = true; }
 );
 
 static auto flag_import_std = false;
@@ -661,7 +670,9 @@ public:
     )
         -> void
     {
-        cpp2_filename = cpp2_filename_;
+        cpp2_filename = (flag_absolute_line_directives) ?
+            std::filesystem::absolute(std::filesystem::path(cpp2_filename_)).string() :
+            cpp2_filename_;
         assert(
             !is_open()
             && !pcomments
@@ -5736,6 +5747,18 @@ public:
                     printer.print_cpp2("public: ", n.position());
                 }
             }
+        }
+
+        //  Print a line directive before every function definition, excluding lambdas.
+        //  This is needed to enable debugging with lldb.
+        if (
+            printer.get_phase() == printer.phase2_func_defs
+            && n.is_function()
+            && n.has_name()
+            && n.initializer
+            )
+        {
+            printer.print_extra("");
         }
 
         //  If this is a function definition and the function is inside

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -106,12 +106,12 @@ static cmdline_processor::register_flag cmd_clean_cpp1(
     []{ flag_clean_cpp1 = true; }
 );
 
-static auto flag_absolute_line_directives = false;
-static cmdline_processor::register_flag cmd_absolute_line_directives(
+static auto flag_line_paths = false;
+static cmdline_processor::register_flag cmd_line_paths(
     9,
-    "absolute-line-directives",
+    "line-paths",
     "Emit absolute paths in #line directives",
-    [] { flag_absolute_line_directives = true; }
+    [] { flag_line_paths = true; }
 );
 
 static auto flag_import_std = false;
@@ -670,7 +670,7 @@ public:
     )
         -> void
     {
-        cpp2_filename = (flag_absolute_line_directives) ?
+        cpp2_filename = (flag_line_paths) ?
             std::filesystem::absolute(std::filesystem::path(cpp2_filename_)).string() :
             cpp2_filename_;
         assert(


### PR DESCRIPTION
Debugging with LLDB (used by Xcode and Qt Creator) requires the following:

- Print line directives before each function definition
- Use absolute paths for filenames in line directives

### Changes in this PR

1. Print line directives before each function definition
2. Add a new command line option to use absolute paths in line directives (defaults to off). LLDB users will have to turn this on.
3. Update the `test-results` with the new line directives preceding function definitions

I manually verified the line numbers in the updated `test-results` and also tested the debugging experience.

The implementation in this PR is significantly simpler than the previous one (#785, now closed) thanks to the recent refactoring that Herb made in `to_cpp1.h`.