### PR TITLE
Ignore Visual Studio and VSCode cache/workspace directories in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@
 *.exe
 source/gen_version.bat
 build*/
+
+# Visual Studio cache directory
+.vs/
+
+# VSCode workspace directory
+.vscode/


### PR DESCRIPTION
Add `.vs` and `.vscode` to `.gitignore`

Visual Studio creates the `.vs` cache directory when opening the `cppfront` folder.
VSCode creates the `.vscode` workspace directory if any workspace settings are specified.