### PR TITLE
Update `pure2-main-args` test to work on CI agent as well as locally

### DIFF
--- a/regression-tests/pure2-main-args.cpp2
+++ b/regression-tests/pure2-main-args.cpp2
@@ -1,5 +1,12 @@
-main: (args) =
+main: (args) = {
+    exe: std::string = args.argv[0];
+    pos:= exe.find_last_of("/\\");
+    if pos != std::string::npos {
+        pos++;
+        exe = exe.substr(pos, exe.size() - pos);
+    }
     std::cout
         << "args.argc            is (args.argc)$\n"
-        << "args.argv[0]         is (args.argv[0])$\n"
+        << "args.argv[0]         is (exe)$\n"
         ;
+}

--- a/regression-tests/test-results/apple-clang-14/pure2-main-args.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14/pure2-main-args.cpp.execution
@@ -1,2 +1,2 @@
 args.argc            is 1
-args.argv[0]         is ./test.exe
+args.argv[0]         is test.exe

--- a/regression-tests/test-results/clang-12/pure2-main-args.cpp.execution
+++ b/regression-tests/test-results/clang-12/pure2-main-args.cpp.execution
@@ -1,2 +1,2 @@
 args.argc            is 1
-args.argv[0]         is ./test.exe
+args.argv[0]         is test.exe

--- a/regression-tests/test-results/gcc-10/pure2-main-args.cpp.execution
+++ b/regression-tests/test-results/gcc-10/pure2-main-args.cpp.execution
@@ -1,2 +1,2 @@
 args.argc            is 1
-args.argv[0]         is ./test.exe
+args.argv[0]         is test.exe

--- a/regression-tests/test-results/gcc-13/pure2-main-args.cpp.execution
+++ b/regression-tests/test-results/gcc-13/pure2-main-args.cpp.execution
@@ -1,2 +1,2 @@
 args.argc            is 1
-args.argv[0]         is ./test.exe
+args.argv[0]         is test.exe

--- a/regression-tests/test-results/pure2-main-args.cpp
+++ b/regression-tests/test-results/pure2-main-args.cpp
@@ -17,10 +17,18 @@ auto main(int const argc_, char** argv_) -> int;
 //=== Cpp2 function definitions =================================================
 
 #line 1 "pure2-main-args.cpp2"
-auto main(int const argc_, char** argv_) -> int { 
+auto main(int const argc_, char** argv_) -> int{
     auto const args = cpp2::make_args(argc_, argv_); 
 #line 2 "pure2-main-args.cpp2"
+    std::string exe {CPP2_ASSERT_IN_BOUNDS_LITERAL(args.argv, 0)}; 
+    auto pos {CPP2_UFCS(find_last_of)(exe, "/\\")}; 
+    if (pos != std::string::npos) {
+        ++pos;
+        exe = CPP2_UFCS(substr)(exe, pos, CPP2_UFCS(size)(exe) - std::move(pos));
+    }
     std::cout 
         << ("args.argc            is " + cpp2::to_string(args.argc) + "\n") 
-        << ("args.argv[0]         is " + cpp2::to_string(CPP2_ASSERT_IN_BOUNDS_LITERAL(args.argv, 0)) + "\n"); }
+        << ("args.argv[0]         is " + cpp2::to_string(std::move(exe)) + "\n");
+
+}
 


### PR DESCRIPTION
Strip any leading directory path from the `argv[0]` program name in `pure2-main-args` test so that there is a consistent result in the GitHub CI agent as well as when run locally.