### PR TITLE
Small tweak to `run-tests-msvc-2022.bat`: change absolute path to relative

### DIFF
--- a/regression-tests/test-results/msvc-2022/run-tests-msvc-2022.bat
+++ b/regression-tests/test-results/msvc-2022/run-tests-msvc-2022.bat
@@ -11,7 +11,7 @@ cl 1>NUL 2> MSVC-version.output
 for %%f in (*.cpp) do (
     set /a count+=1
     echo [!count!] Starting MSVC cl.exe %%f
-    cl.exe %%f -Fe"test" -nologo -std:c++latest -MD -EHsc -I c:\github\cppfront\include -experimental:module >> %%f.output 2>&1
+    cl.exe %%f -Fe"test" -nologo -std:c++latest -MD -EHsc -I ..\..\..\include -experimental:module >> %%f.output 2>&1
     del %%f
     IF EXIST "test.exe" (
         set /a exe_count+=1


### PR DESCRIPTION
Replace `c:\github\cppfront\include` absolute path with a relative path; allows users to run the bat file with a different checkout directory of cppfront.

Note: The failing Windows test is the `pure2-main-args` test which is fixed by #947

EDIT: The above note no longer applies; I rebased to bring in the changes from #947 that were merged into `main`