### PR TITLE
More elegant solution for pure2-main-args.cpp2

### DIFF
--- a/regression-tests/pure2-main-args.cpp2
+++ b/regression-tests/pure2-main-args.cpp2
@@ -1,10 +1,9 @@
 main: (args) = {
-    exe: std::string = args.argv[0];
-    pos:= exe.find_last_of("/\\");
-    if pos != std::string::npos {
-        pos++;
-        exe = exe.substr(pos, exe.size() - pos);
-    }
+    // Explicit call to string is necessary
+    // std::filesystem::path is base on and implicitly convertible to
+    // - std::string (on POSIX systems)
+    // - std::wstring (on Windows)
+    exe : _ = std::filesystem::path(args.argv[0]).filename().string();
     std::cout
         << "args.argc            is (args.argc)$\n"
         << "args.argv[0]         is (exe)$\n"

--- a/regression-tests/test-results/pure2-main-args.cpp
+++ b/regression-tests/test-results/pure2-main-args.cpp
@@ -19,13 +19,12 @@ auto main(int const argc_, char** argv_) -> int;
 #line 1 "pure2-main-args.cpp2"
 auto main(int const argc_, char** argv_) -> int{
     auto const args = cpp2::make_args(argc_, argv_); 
-#line 2 "pure2-main-args.cpp2"
-    std::string exe {CPP2_ASSERT_IN_BOUNDS_LITERAL(args.argv, 0)}; 
-    auto pos {CPP2_UFCS(find_last_of)(exe, "/\\")}; 
-    if (pos != std::string::npos) {
-        ++pos;
-        exe = CPP2_UFCS(substr)(exe, pos, CPP2_UFCS(size)(exe) - std::move(pos));
-    }
+    // Explicit call to string is necessary
+    // std::filesystem::path is base on and implicitly convertible to
+    // - std::string (on POSIX systems)
+    // - std::wstring (on Windows)
+#line 6 "pure2-main-args.cpp2"
+    auto exe {CPP2_UFCS(string)(CPP2_UFCS(filename)(std::filesystem::path(CPP2_ASSERT_IN_BOUNDS_LITERAL(args.argv, 0))))}; 
     std::cout 
         << ("args.argc            is " + cpp2::to_string(args.argc) + "\n") 
         << ("args.argv[0]         is " + cpp2::to_string(std::move(exe)) + "\n");


### PR DESCRIPTION
In #947 @bluetarpmedia proposed an improvement/fix for pure2-main-args.cpp2 that manually extracts the filename from `args.argv[0]`.
Here I propose a solution using `std::filesystem::path` that I find a bit more elegant.
Unfortunately, due to differences between the implementation details of `std::filesystem::path` between POSIX and Windows the type can be used directly in Cpp2 string interpolation only on POSIX systems. For that reason the solution is not as elegant as it could have been if it wasn't the case.