### PR TITLE
MSVC regression-test job in CI now builds and links with C++ standard library modules to enable `import std.compat;`

### DIFF
--- a/regression-tests/run-tests.sh
+++ b/regression-tests/run-tests.sh
@@ -149,10 +149,14 @@ fi
 # in order to support `import std.compat;`.
 regression_test_link_obj=""
 if [[ "$cxx_compiler" == *"cl.exe"* ]]; then
+    echo "Building std.compat module"
     (cd $exec_out_dir; \
-    cl.exe -nologo -std:c++latest -MD -EHsc -c "%VCToolsInstallDir%\modules\std.compat.ixx")
+    cl.exe -nologo -std:c++latest -MD -EHsc -c "${VCToolsInstallDir}/modules/std.compat.ixx")
     regression_test_link_obj="std.compat.obj"
 fi
+
+#Temp
+exit
 
 ################
 failed_tests=()

--- a/regression-tests/run-tests.sh
+++ b/regression-tests/run-tests.sh
@@ -151,8 +151,8 @@ regression_test_link_obj=""
 if [[ "$cxx_compiler" == *"cl.exe"* ]]; then
     echo "Building std and std.compat modules"
     (cd $exec_out_dir; \
-    cl.exe -nologo -std:c++latest -MD -EHsc -c "${VCToolsInstallDir}/modules/std.ixx")
-    cl.exe -nologo -std:c++latest -MD -EHsc -c "${VCToolsInstallDir}/modules/std.compat.ixx")
+     cl.exe -nologo -std:c++latest -MD -EHsc -c "${VCToolsInstallDir}/modules/std.ixx";
+     cl.exe -nologo -std:c++latest -MD -EHsc -c "${VCToolsInstallDir}/modules/std.compat.ixx")
     regression_test_link_obj="std.obj std.compat.obj"
 fi
 

--- a/regression-tests/run-tests.sh
+++ b/regression-tests/run-tests.sh
@@ -151,7 +151,7 @@ skipped_tests=()
 echo "Running regression tests"
 for test_file in $tests; do
     test_name=${test_file%.*}
-    expeced_output="$expected_results_dir/$test_file.output"
+    expected_output="$expected_results_dir/$test_file.output"
     generated_cpp_name=$test_name.cpp
     expected_src="$expected_results_dir/$generated_cpp_name"
     test_bin="test.exe"
@@ -174,13 +174,13 @@ for test_file in $tests; do
     ########
     # Run the translation test
     echo "        Generating Cpp1 code"
-    ./"$cppfront_cmd" "$test_file" -o "$expected_src" $opt > "$expeced_output" 2>&1
+    ./"$cppfront_cmd" "$test_file" -o "$expected_src" $opt > "$expected_output" 2>&1
 
     failure=0
     compiler_issue=0
     ########
     # The C++1 generation output has to exist and to be tracked by git
-    check_file "$expeced_output" "Cpp1 generation output file"
+    check_file "$expected_output" "Cpp1 generation output file"
 
     ########
     # Check the generated code
@@ -239,7 +239,7 @@ for test_file in $tests; do
                 fi
             fi
         fi
-    elif [[ $(cat "$expeced_output") != *"error"* ]]; then
+    elif [[ $(cat "$expected_output") != *"error"* ]]; then
          echo "            Missing generated src file treated as failure"
          echo "                Failing compilation message needs to contain 'error'"
          failure=1

--- a/regression-tests/run-tests.sh
+++ b/regression-tests/run-tests.sh
@@ -145,14 +145,15 @@ if [[ $? -ne 0 ]]; then
 fi
 
 ################
-# Build the `std.compat` module so that the regression tests can link it (currently only supported by MSVC)
+# Build the `std` and `std.compat` modules so that the regression tests can use them (currently only supported by MSVC)
 # in order to support `import std.compat;`.
 regression_test_link_obj=""
 if [[ "$cxx_compiler" == *"cl.exe"* ]]; then
-    echo "Building std.compat module"
+    echo "Building std and std.compat modules"
     (cd $exec_out_dir; \
+    cl.exe -nologo -std:c++latest -MD -EHsc -c "${VCToolsInstallDir}/modules/std.ixx")
     cl.exe -nologo -std:c++latest -MD -EHsc -c "${VCToolsInstallDir}/modules/std.compat.ixx")
-    regression_test_link_obj="std.compat.obj"
+    regression_test_link_obj="std.obj std.compat.obj"
 fi
 
 #Temp

--- a/regression-tests/run-tests.sh
+++ b/regression-tests/run-tests.sh
@@ -156,9 +156,6 @@ if [[ "$cxx_compiler" == *"cl.exe"* ]]; then
     regression_test_link_obj="std.obj std.compat.obj"
 fi
 
-#Temp
-exit
-
 ################
 failed_tests=()
 failed_compilations=()


### PR DESCRIPTION
* Re-enable the `-import-std` / `pure` behaviour
* The CI build script now compiles the `std` and `std.compat` modules and links the `std.obj` and `std.compat.obj` files when building the regression test binaries.

See #950 for more details.