### PR TITLE
Emit the `[[maybe_unused]]` attribute on anonymous objects to silence C++ compiler warnings

### DIFF
--- a/regression-tests/test-results/mixed-out-destruction.cpp
+++ b/regression-tests/test-results/mixed-out-destruction.cpp
@@ -57,18 +57,18 @@ int main() {
 #line 1 "mixed-out-destruction.cpp2"
 
 #line 22 "mixed-out-destruction.cpp2"
-auto f00() -> void     {   C auto_1 {"f00"}; cpp2::deferred_init<X> x; f01(cpp2::out(&x));}
+auto f00() -> void     {   [[maybe_unused]] C auto_1 {"f00"}; cpp2::deferred_init<X> x; f01(cpp2::out(&x));}
 #line 23 "mixed-out-destruction.cpp2"
-auto f01(cpp2::out<X> x) -> void{C auto_1 {"f01"}; x.construct();throw_1();}
+auto f01(cpp2::out<X> x) -> void{[[maybe_unused]] C auto_1 {"f01"}; x.construct();throw_1();}
 
 #line 27 "mixed-out-destruction.cpp2"
-auto f10() -> void     {   C auto_1 {"f10"}; cpp2::deferred_init<X> x; f11(cpp2::out(&x));}
+auto f10() -> void     {   [[maybe_unused]] C auto_1 {"f10"}; cpp2::deferred_init<X> x; f11(cpp2::out(&x));}
 #line 28 "mixed-out-destruction.cpp2"
-auto f11(cpp2::out<X> x) -> void{C auto_1 {"f11"}; f12(cpp2::out(&x));}
+auto f11(cpp2::out<X> x) -> void{[[maybe_unused]] C auto_1 {"f11"}; f12(cpp2::out(&x));}
 #line 29 "mixed-out-destruction.cpp2"
-auto f12(cpp2::out<X> x) -> void{C auto_1 {"f12"}; f13(cpp2::out(&x));throw_1();}
+auto f12(cpp2::out<X> x) -> void{[[maybe_unused]] C auto_1 {"f12"}; f13(cpp2::out(&x));throw_1();}
 #line 30 "mixed-out-destruction.cpp2"
-auto f13(cpp2::out<X> x) -> void{C auto_1 {"f13"}; f14(cpp2::out(&x));}
+auto f13(cpp2::out<X> x) -> void{[[maybe_unused]] C auto_1 {"f13"}; f14(cpp2::out(&x));}
 #line 31 "mixed-out-destruction.cpp2"
-auto f14(cpp2::out<X> x) -> void{C auto_1 {"f14"}; x.construct();}
+auto f14(cpp2::out<X> x) -> void{[[maybe_unused]] C auto_1 {"f14"}; x.construct();}
 

--- a/regression-tests/test-results/pure2-last-use.cpp
+++ b/regression-tests/test-results/pure2-last-use.cpp
@@ -461,7 +461,7 @@ auto issue_313() -> void{
     *cpp2::assert_not_null(identity(a)) = *cpp2::assert_not_null(identity(a));
 
     auto b {cpp2_new<int>(0)}; 
-    int auto_1 {*cpp2::assert_not_null(identity(b)) = *cpp2::assert_not_null(identity(b))}; 
+    [[maybe_unused]] int auto_1 {*cpp2::assert_not_null(identity(b)) = *cpp2::assert_not_null(identity(b))}; 
 
     auto c {cpp2_new<int>(0)}; 
     if (*cpp2::assert_not_null(identity(c)) * *cpp2::assert_not_null(identity(c))) {}

--- a/regression-tests/test-results/pure2-requires-clauses.cpp
+++ b/regression-tests/test-results/pure2-requires-clauses.cpp
@@ -76,7 +76,7 @@ requires (std::same_as<T,cpp2::i32>) T const v {0};
 
 #line 22 "pure2-requires-clauses.cpp2"
 auto main() -> int{
-    X<int,int> auto_1 {}; 
+    [[maybe_unused]] X<int,int> auto_1 {}; 
     std::cout << f<int,int>(2, 5) 
               << f(0);
 }

--- a/regression-tests/test-results/pure2-statement-scope-parameters.cpp
+++ b/regression-tests/test-results/pure2-statement-scope-parameters.cpp
@@ -46,14 +46,14 @@ auto& i{local_int};
 #line 14 "pure2-statement-scope-parameters.cpp2"
     std::cout << std::move(local_int) << "\n";// prints 43
 
-    std::chrono::duration<cpp2::i32> auto_1 {0}; 
+    [[maybe_unused]] std::chrono::duration<cpp2::i32> auto_1 {0}; 
 {
 [[maybe_unused]] std::chrono::duration<cpp2::i32> unnamed_param_1{0};
 #line 17 "pure2-statement-scope-parameters.cpp2"
     {}
 }
 #line 18 "pure2-statement-scope-parameters.cpp2"
-    std::in_place_t auto_2 {}; 
+    [[maybe_unused]] std::in_place_t auto_2 {}; 
 {
 [[maybe_unused]] std::in_place_t unnamed_param_1{};
 #line 19 "pure2-statement-scope-parameters.cpp2"

--- a/regression-tests/test-results/pure2-types-basics.cpp
+++ b/regression-tests/test-results/pure2-types-basics.cpp
@@ -194,9 +194,9 @@ auto main() -> int{
     std::cout << ("f2: " + cpp2::to_string(CPP2_UFCS(f2)(x, 2, 2)) + "\n");
     std::cout << ("f3: " + cpp2::to_string(CPP2_UFCS_TEMPLATE(f3<3,3>)(x)) + "\n");
     std::cout << ("f4: " + cpp2::to_string(CPP2_UFCS_TEMPLATE(f4<4,4>)(x)) + "\n");
-    N::myclass auto_1 {"abracadabra"}; 
-    N::myclass auto_2 {}; 
-    N::myclass auto_3 {1, "hair"}; 
+    [[maybe_unused]] N::myclass auto_1 {"abracadabra"}; 
+    [[maybe_unused]] N::myclass auto_2 {}; 
+    [[maybe_unused]] N::myclass auto_3 {1, "hair"}; 
 
     // Invoke the single-param operator=s as actual assignments
     std::cout << "x's state before assignments: ";

--- a/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
+++ b/regression-tests/test-results/pure2-types-order-independence-and-nesting.cpp
@@ -150,7 +150,7 @@ namespace N {
 #line 35 "pure2-types-order-independence-and-nesting.cpp2"
     auto X::exx(cpp2::in<int> count) const& -> void{
         //  Exercise '_' anonymous objects too while we're at it
-        cpp2::finally auto_1 {[&]() mutable -> void { std::cout << ("leaving call to 'why(" + cpp2::to_string(count) + ")'\n");  }}; 
+        [[maybe_unused]] cpp2::finally auto_1 {[&]() mutable -> void { std::cout << ("leaving call to 'why(" + cpp2::to_string(count) + ")'\n");  }}; 
         if (cpp2::cmp_less(count,5)) {
             CPP2_UFCS(why)((*cpp2::assert_not_null(py)), count + 1);// use Y object from X
         }

--- a/regression-tests/test-results/pure2-types-ordering-via-meta-functions.cpp
+++ b/regression-tests/test-results/pure2-types-ordering-via-meta-functions.cpp
@@ -134,6 +134,6 @@ auto main() -> int{
         std::cout << "more\n";
     }
 
-    mystruct auto_1 {}; 
+    [[maybe_unused]] mystruct auto_1 {}; 
 }
 

--- a/regression-tests/test-results/pure2-variadics.cpp
+++ b/regression-tests/test-results/pure2-variadics.cpp
@@ -121,7 +121,7 @@ template  <typename T, typename ...Args> [[nodiscard]] auto make(Args&& ...args)
 #line 43 "pure2-variadics.cpp2"
 auto main() -> int
 {
-    x<int,long,std::string> auto_1 {}; 
+    [[maybe_unused]] x<int,long,std::string> auto_1 {}; 
 
     std::cout << std::string("xyzzy", 3) << "\n";
     std::cout << make_string("plugh", cpp2::u8{3}) << "\n";

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -6744,6 +6744,17 @@ public:
             }
             //  Otherwise, emit the type
             else {
+                //  If this is an anonymous object (named "_"), we'll generate a unique name below
+                //  but first we need to emit the `maybe_unused` attribute before its type, unless
+                //  we're at namespace scope.
+                if (
+                    n.has_name("_")
+                    && !n.parent_is_namespace()
+                    )
+                {
+                    printer.print_cpp2("[[maybe_unused]] ", n.position());
+                }
+
                 //  If there isn't an initializer, use cpp2::deferred_init<T>
                 if (!n.initializer) {
                     if (n.parent_is_function()) {


### PR DESCRIPTION
C++ compilers at high warning levels warn about unused variables or class members.

This PR adds `[[maybe_unused]]` to anonymous objects (named `_`) at function and class scope (excludes namespace scope, since it's not needed there).

Using this code as an example:
```
foo: type = {
    _: double = 90.0;
}

_: foo = ();

ns: namespace = {
    _: bool = true;
}

main: () -> int = {
    _: int = 0;
    return 0;
}
```
Before this PR, Clang produces these warnings (with `-Wall`). Similar warnings with MSVC and GCC.
```
main.cpp2:12:9: warning: unused variable 'auto_1' [-Wunused-variable]
   12 |     int auto_1 {0}; 
      |         ^~~~~~
main.cpp2:2:21: warning: private field 'auto_1' is not used [-Wunused-private-field]
    2 |     private: double auto_1 {90.0}; 
      |                     ^
```
After this PR, there are no warnings, since the relevant code lowers to:
```
private: [[maybe_unused]] double auto_1 {90.0}; 
```
and
```
[[maybe_unused]] int auto_1 {0}; 
```