### PR TITLE
CI `run-tests` script now attempts to detect Apple Clang 15 and other unsupported regression-tests compiler versions

### DIFF
--- a/regression-tests/run-tests.sh
+++ b/regression-tests/run-tests.sh
@@ -130,8 +130,15 @@ if [[ "$cxx_compiler" == *"cl.exe"* ]]; then
     compiler_version=$(cl.exe)
 else
     compiler_cmd="$cxx_compiler -I../../../include -std=c++20 -pthread -o "
-    
     compiler_version=$("$cxx_compiler" --version)
+
+    # We don't currently support Apple Clang 15 so try and switch to 14
+    if [[ "$compiler_version" == *"Apple clang version 15.0"* ]]; then
+        printf "Found Apple Clang 15, attempting to switch to Apple Clang 14"
+        cxx_compiler=$(xcodebuild -find clang++)
+        compiler_version=$("$cxx_compiler" --version)
+    fi
+
     if [[ "$compiler_version" == *"Apple clang version 14.0"* ]]; then
         exec_out_dir="$expected_results_dir/apple-clang-14"
     elif [[ "$compiler_version" == *"clang version 12.0"* ]]; then 

--- a/regression-tests/run-tests.sh
+++ b/regression-tests/run-tests.sh
@@ -131,22 +131,22 @@ if [[ "$cxx_compiler" == *"cl.exe"* ]]; then
 else
     compiler_cmd="$cxx_compiler -I../../../include -std=c++20 -pthread -o "
     
-    compiler_ver=$("$cxx_compiler" --version)
-    if [[ "$compiler_ver" == *"Apple clang version 14.0"* ]]; then
+    compiler_version=$("$cxx_compiler" --version)
+    if [[ "$compiler_version" == *"Apple clang version 14.0"* ]]; then
         exec_out_dir="$expected_results_dir/apple-clang-14"
-    elif [[ "$compiler_ver" == *"clang version 12.0"* ]]; then 
+    elif [[ "$compiler_version" == *"clang version 12.0"* ]]; then 
         exec_out_dir="$expected_results_dir/clang-12"
-    elif [[ "$compiler_ver" == *"clang version 15.0"* ]]; then 
+    elif [[ "$compiler_version" == *"clang version 15.0"* ]]; then 
         exec_out_dir="$expected_results_dir/clang-15"
-    elif [[ "$compiler_ver" == *"g++-10"* ]]; then
+    elif [[ "$compiler_version" == *"g++-10"* ]]; then
         exec_out_dir="$expected_results_dir/gcc-10"
-    elif [[ "$compiler_ver" == *"g++-12"* ||
-            "$compiler_ver" == *"g++-13"*
+    elif [[ "$compiler_version" == *"g++-12"* ||
+            "$compiler_version" == *"g++-13"*
          ]]; then
         exec_out_dir="$expected_results_dir/gcc-13"
+    else
+        printf "Unhandled compiler version:\n$compiler_version\n\n"
     fi
-
-    compiler_version=$("$cxx_compiler" --version)
 fi
 
 if [[ -d "$exec_out_dir" ]]; then
@@ -154,7 +154,8 @@ if [[ -d "$exec_out_dir" ]]; then
 
     printf "Directory with reference compilation/execution files to use:\n$exec_out_dir\n\n"
 else
-    printf "not found for compiler: '$cxx_compiler'\n\n"
+    printf "Directory with reference compilation/execution files not found for compiler: '$cxx_compiler'\n\n"
+    exit 2
 fi
 
 ################


### PR DESCRIPTION
After investigating some spurious macOS regression-test job failures, I found that the `macos-13` [GitHub runner](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md) has both Apple Clang 14 and 15 installed.

It appears that on some runs, running `clang++` incorrectly selects Apple Clang 15, which is currently unsupported as a compiler version for the regression-tests. For example, see this [log file](https://pipelinesghubeus8.actions.githubusercontent.com/P0ELWR4zeACuLLNGFIvV2HtYX5YtHJnpF65NFez9JahqM2Rk03/_apis/pipelines/1/runs/308/signedlogcontent/4?urlExpires=2024-02-07T06%3A35%3A52.5187795Z&urlSigningMethod=HMACV1&urlSignature=8xjIzaw6%2FzRNPALNC8yjzwhEWlA%2FAE80B9eXLi6%2Bg0Y%3D) for [this failed job](https://github.com/hsutter/cppfront/actions/runs/7810216607/job/21303297024?pr=971).

This PR makes 2 changes:
- If Apple Clang 15 is detected it tries to switch to 14 instead
- Prints an error message and aborts the job if an unsupported compiler version is found

CC @jarzec 