### PR TITLE
Make regression tests only run on `main`

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -2,8 +2,12 @@ name: Regression tests
 
 on:
   pull_request:
+    branches:
+      - main
     types: [opened, synchronize, reopened]
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@
 *.exe
 source/gen_version.bat
 build*/
-docs/venv/*
+venv/*
 *.ifc
 
 # Visual Studio cache directory


### PR DESCRIPTION
I think this is the right way to express they should run on `main` and PRs on `main`... it doesn't need to run on the `docs` branch.

@jarzec does this diff look right to accomplish that?