### PR TITLE
CI: Unify execution conditions of test workflows

### DIFF
--- a/.github/workflows/build-cppfront.yaml
+++ b/.github/workflows/build-cppfront.yaml
@@ -1,11 +1,13 @@
 name: Multi-platform Build of cppfront
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
+    branches-ignore:
+      - docs
+  push:
+    branches-ignore:
+      - docs
+  workflow_dispatch:
+
 jobs:
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches-ignore:
       - docs
-    types: [opened, synchronize, reopened]
   push:
     branches-ignore:
       - docs


### PR DESCRIPTION
Unifies the execution conditions of the two testing workflows:
 - `.github/workflows/build-cppfront.yaml`
 - `.github/workflows/regression-tests.yml`

Adds exclusion of the `docs` branch instead of limiting the tests to the `main` branch only.
Adds the [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) event for the `.github/workflows/build-cppfront.yaml` (already active in `.github/workflows/build-cppfront.yaml`). This allows [manual execution of the workflow](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) through the GitHub interface as soon as the workflow definition is included in the `main` branch.

After the proposed change both testing workflows will execute automatically on development branches used e.g. for preparing PRs.

This change is another follow-up of https://github.com/hsutter/cppfront/pull/975.