### PR TITLE
Update CTAD description in hello-world.md

### DIFF
--- a/docs/welcome/hello-world.md
+++ b/docs/welcome/hello-world.md
@@ -38,7 +38,7 @@ All grammar is context-free. In particular, we (the human reading the code, and 
 
 <a id="CTAD"></a>
 
-- Declaring `words` uses **"CTAD"** (C++'s normal [constructor template argument deduction](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction)) to declare its `words` variable.
+- Declaring `words` uses **"CTAD"** (C++'s normal [constructor template argument deduction](https://en.cppreference.com/w/cpp/language/class_template_argument_deduction)) to deduce the type of elements in the `vector`.
 
 - Calling `words[0]` and `words[1]` is **bounds-checked by default**. From Cpp2 code, ordinary `std::vector` subscript accesses are safely bounds-checked by default without requiring any upgrade to your favorite standard library, and that's true for any similar subscript of something whose size can be queried using `std::size()` and `std::ssize()`, and for which `std::begin()` returns a random access iterator, including any in-house integer-indexed container types you already have that can easily provide `std::size()` and `std::ssize()` if they don't already.
 


### PR DESCRIPTION
The original text seemed a bit circular:
>Declaring `words` uses CTAD (...) to declare its `words` variable.

So I've updated it to hopefully reflect the intention.