### PR TITLE
Match C++ standard used in compiler-specific run-tests scripts to the CI script

### DIFF
--- a/regression-tests/test-results/apple-clang-14/run-tests-apple-clang.sh
+++ b/regression-tests/test-results/apple-clang-14/run-tests-apple-clang.sh
@@ -9,7 +9,7 @@ clang++ --version > clang-version.output 2>&1
 for f in *.cpp
 do
     printf "Starting apple clang++ %s\n" "$f"
-    clang++ -I../../../include -std=c++20 -pthread -o test.exe $f > $f.output 2>&1
+    clang++ -I../../../include -std=c++2b -pthread -o test.exe $f > $f.output 2>&1
     rm -f $f
     let count=count+1
     if test -f "test.exe"; then

--- a/regression-tests/test-results/clang-12/run-tests-clang-12.sh
+++ b/regression-tests/test-results/clang-12/run-tests-clang-12.sh
@@ -10,7 +10,7 @@ for f in *.cpp
 do
     let count=count+1
     printf "[%s] Starting clang++-12 %s\n" "$count" "$f"
-    clang++-12 -I../../../include -std=c++20 -pthread -Wunused-parameter -o test.exe $f > $f.output 2>&1
+    clang++-12 -I../../../include -std=c++2b -pthread -Wunused-parameter -o test.exe $f > $f.output 2>&1
     rm -f $f
     if test -f "test.exe"; then
         let exe_count=exe_count+1

--- a/regression-tests/test-results/gcc-13/run-tests-gcc-13.sh
+++ b/regression-tests/test-results/gcc-13/run-tests-gcc-13.sh
@@ -10,7 +10,7 @@ for f in *.cpp
 do
     let count=count+1
     printf "[%s] Starting gcc 13 %s\n" "$count" "$f"
-    g++ -I../../../include -std=c++20 -pthread -Wold-style-cast -Wunused-parameter -o test.exe $f > $f.output 2>&1
+    g++ -I../../../include -std=c++2b -pthread -Wold-style-cast -Wunused-parameter -o test.exe $f > $f.output 2>&1
     rm -f $f
     if test -f "test.exe"; then
         let exe_count=exe_count+1


### PR DESCRIPTION
f0018d757d09aae09d18a25a6b22bc3e24eecf85 modified the set C++ standard for some compilers in the CI script, but did not do so for the compiler-specific run-tests scripts. This fixes the discrepancy by matching setting in the compiler-specific scripts to that of the CI script (since the above commit apparently did update the tests results according to the newly set standard in the CI script).

(It would be more robust to avoid the possibility of such a discrepancy by avoiding having such settings in multiple scripts.)