### PR TITLE
removed harmfull check in out<T>

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -788,7 +788,7 @@ public:
     }
 
     auto construct(auto&& ...args) -> void {
-        if (has_t || called_construct()) {
+        if (has_t) {
             if constexpr (requires { *t = T(CPP2_FORWARD(args)...); }) {
                 Default.enforce( t );
                 *t = T(CPP2_FORWARD(args)...);


### PR DESCRIPTION
fixes #1012 by removing the check that ignored the invariant 
`called_construct()` implies `dt->init`