### PR TITLE
Correct the feature test macro for including `syncstream` header

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -198,7 +198,7 @@
         #include <streambuf>
         #include <string>
         #include <string_view>
-        #ifdef __cpp_lib_syncstream
+        #ifdef __cpp_lib_syncbuf
             #include <syncstream>
         #endif
         #include <system_error>


### PR DESCRIPTION
Verified that `__cpp_lib_syncbuf` is the correct macro by checking:
- Repro on [Godbolt](https://godbolt.org/z/rvajMMYPK) for 3 major compilers
- https://en.cppreference.com/w/cpp/feature_test
