### PR TITLE
[cpp2util] as: add constexpr branch for any

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1348,6 +1348,9 @@ auto as(X const& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT) -> decltype(auto) {
         }
         return C{x};
     }
+    else if constexpr (!std::is_reference_v<C> && std::is_same_v<CPP2_TYPEOF(x),std::any> && !std::is_same_v<C,std::any>) {
+        return std::any_cast<C>( x );
+    }
     else {
         return nonesuch;
     }


### PR DESCRIPTION
This patches #961. The issue lies in the fact that the as cast for any is defined at https://github.com/hsutter/cppfront/blob/5663493860a5558a3d64c59ac9ee6f0e26dedf99/include/cpp2util.h#L1625-L1630
so the any call hits
https://github.com/hsutter/cppfront/blob/5663493860a5558a3d64c59ac9ee6f0e26dedf99/include/cpp2util.h#L1351-L1353
even though the code provided in the issue is well within the specifications outlined at https://hsutter.github.io/cppfront/cpp2/expressions/

This pr adds another constexpr branch with the same requirements as the function (I think it is the simplest solution). Let me know if you have any suggestions. Thanks!