### PR TITLE
Bugfix for nonconst has in generated flag_enums.

### DIFF
--- a/regression-tests/test-results/pure2-enum.cpp
+++ b/regression-tests/test-results/pure2-enum.cpp
@@ -83,7 +83,7 @@ public: constexpr auto operator^=(file_attributes const& that) & -> void;
 public: [[nodiscard]] constexpr auto operator|(file_attributes const& that) const& -> file_attributes;
 public: [[nodiscard]] constexpr auto operator&(file_attributes const& that) const& -> file_attributes;
 public: [[nodiscard]] constexpr auto operator^(file_attributes const& that) const& -> file_attributes;
-public: [[nodiscard]] constexpr auto has(file_attributes const& that) & -> bool;
+public: [[nodiscard]] constexpr auto has(file_attributes const& that) const& -> bool;
 public: constexpr auto set(file_attributes const& that) & -> void;
 public: constexpr auto clear(file_attributes const& that) & -> void;
 public: static const file_attributes cached;
@@ -202,7 +202,7 @@ constexpr auto file_attributes::operator^=(file_attributes const& that) & -> voi
 [[nodiscard]] constexpr auto file_attributes::operator|(file_attributes const& that) const& -> file_attributes { return _value | that._value; }
 [[nodiscard]] constexpr auto file_attributes::operator&(file_attributes const& that) const& -> file_attributes { return _value & that._value; }
 [[nodiscard]] constexpr auto file_attributes::operator^(file_attributes const& that) const& -> file_attributes { return _value ^ that._value; }
-[[nodiscard]] constexpr auto file_attributes::has(file_attributes const& that) & -> bool { return _value & that._value; }
+[[nodiscard]] constexpr auto file_attributes::has(file_attributes const& that) const& -> bool { return _value & that._value; }
 constexpr auto file_attributes::set(file_attributes const& that) & -> void { _value |= that._value; }
 constexpr auto file_attributes::clear(file_attributes const& that) & -> void { _value &= ~that._value; }
 inline CPP2_CONSTEXPR file_attributes file_attributes::cached = 1;

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -1741,7 +1741,7 @@ std::string value{"-1"};
         CPP2_UFCS(add_member)(t, ("    operator| : (       this, that ) -> " + cpp2::to_string(CPP2_UFCS(name)(t)) + "  == _value |  that._value;"));
         CPP2_UFCS(add_member)(t, ("    operator& : (       this, that ) -> " + cpp2::to_string(CPP2_UFCS(name)(t)) + "  == _value &  that._value;"));
         CPP2_UFCS(add_member)(t, ("    operator^ : (       this, that ) -> " + cpp2::to_string(CPP2_UFCS(name)(t)) + "  == _value ^  that._value;"));
-        CPP2_UFCS(add_member)(t, "    has       : ( inout this, that ) -> bool         == _value &  that._value;");
+        CPP2_UFCS(add_member)(t, "    has       : (       this, that ) -> bool         == _value &  that._value;");
         CPP2_UFCS(add_member)(t, "    set       : ( inout this, that )                 == _value |= that._value;");
         CPP2_UFCS(add_member)(t, "    clear     : ( inout this, that )                 == _value &= that._value~;");
     }

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -1098,7 +1098,7 @@ basic_enum: (
         t.add_member( "    operator| : (       this, that ) -> (t.name())$  == _value |  that._value;");
         t.add_member( "    operator& : (       this, that ) -> (t.name())$  == _value &  that._value;");
         t.add_member( "    operator^ : (       this, that ) -> (t.name())$  == _value ^  that._value;");
-        t.add_member( "    has       : ( inout this, that ) -> bool         == _value &  that._value;");
+        t.add_member( "    has       : (       this, that ) -> bool         == _value &  that._value;");
         t.add_member( "    set       : ( inout this, that )                 == _value |= that._value;");
         t.add_member( "    clear     : ( inout this, that )                 == _value &= that._value~;");
     }


### PR DESCRIPTION
In flag_enums the `has` function is marked as `inout` and not as `in`.