### PR TITLE
[CI] Fix `g++-13` regression test job

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -20,8 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        compiler: [g++-10, g++-13, clang++-15]
+        compiler: [g++-10, clang++-15]
         include:
+          - os: ubuntu-24.04
+            compiler: g++-13
           - os: ubuntu-20.04
             compiler: clang++-12
           - os: macos-14


### PR DESCRIPTION
From what I can gather something has changed with the GitHub Actions images.

The `g++-13` regression test job previously ran fine on the `ubuntu-latest` image but that [stopped working](https://github.com/hsutter/cppfront/commit/4b1b255e605f0ec06899c53fe58eb4da3fdc7747) on 16 May, with the error: `The compiler 'g++-13' is not installed`.

I've updated it to run on `ubuntu-2404`, which is [documented](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) as having gcc 13 installed.

(Note there's still a separate task failing for `clang++-15` on `ubuntu-latest` which I'll try and fix in a separate PR.)

EDIT: The `clang++-15` job fix is PR #1077