### PR TITLE
[CI] Replace `ubuntu-latest` with an explicit ubuntu version

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         compiler: [g++-10, clang++-15]
         include:
           - os: ubuntu-24.04


### PR DESCRIPTION
`ubuntu-latest` is an alias which over time changes and points at newer ubuntu images. Different ubuntu images have different compiler versions installed and newer images drop older compiler versions.

So to prevent the CI jobs from failing when the `ubuntu-latest` alias changes I've modified the workflow to use a specific ubuntu version for the `g++-10` and `clang++-15` jobs, and this `ubuntu-22.04` image is [documented](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) to have gcc 10 and clang 15 installed.