### PR TITLE
Default-define out-of-line dtors for types with fwd-declared unique_ptr members

### DIFF
--- a/.github/workflows/build-cppfront.yaml
+++ b/.github/workflows/build-cppfront.yaml
@@ -38,6 +38,9 @@ jobs:
           - runs-on: macos-latest
             compiler: clang++
             cxx-std: 'c++20'
+          - runs-on: ubuntu-22.04
+            compiler: clang++-15
+            cxx-std: 'c++20'
           - runs-on: ubuntu-24.04
             compiler: clang++-16
             cxx-std: 'c++20'
@@ -47,6 +50,9 @@ jobs:
           - runs-on: ubuntu-24.04
             compiler: clang++-18
             cxx-std: 'c++20'
+          - runs-on: ubuntu-24.04
+            compiler: clang++-18
+            cxx-std: 'c++2b'
           - runs-on: ubuntu-24.04
             compiler: g++-14
             cxx-std: 'c++2b'


### PR DESCRIPTION
Some of the node types in `parse.h` have `std::unique_ptr` of forward-declared types as members without having destructors deferred to when the pointed-to types are defined. If the default deleter is used this is [IFNDR](https://en.cppreference.com/w/cpp/language/ndr). Despite that, all compilers seem to have been compiling such code without problem. Only recently Clang >=15 with C++23 enabled started to raise errors in such situations. This is likely due to the added `constexpr` in the default deleter, which seemed to have change changed implementation decisions.

This PR adds out-of-line defaulted destructors for such cases to fix the possible compiler errors. It also enables a build test for Clang 18 with C++23 to ensure the solution works.