### PR TITLE
Update test-results for ubuntu clang 12, gcc 13 and gcc 14

### DIFF
--- a/regression-tests/test-results/clang-12-c++20/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/clang-12-c++20/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,118 +1,118 @@
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: error: a lambda expression cannot appear in this context
 template<t<CPP2_UFCS_NONLOCAL(f)(o)> UnnamedTypeParam1_1> bool inline constexpr v0 = false;// Fails on GCC ([GCC109781][]) and Clang 12 (a lambda expression cannot appear in this context)
            ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:15:3: error: a lambda expression cannot appear in this context
 t<CPP2_UFCS_NONLOCAL(f)(o)> inline constexpr v1 = t<true>();// Fails on Clang 12 (lambda in unevaluated context).
   ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: error: a lambda expression cannot appear in this context
 template<t<CPP2_UFCS_NONLOCAL(f)(o)> UnnamedTypeParam1_2> auto g() -> void;
            ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:23:42: error: a lambda expression cannot appear in this context
 auto g([[maybe_unused]] cpp2::impl::in<t<CPP2_UFCS_NONLOCAL(f)(o)>> unnamed_param_1) -> void;
                                          ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:27:29: error: a lambda expression cannot appear in this context
 [[nodiscard]] auto h() -> t<CPP2_UFCS_NONLOCAL(f)(o)>;
                             ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: error: a lambda expression cannot appear in this context
 template<t<CPP2_UFCS_NONLOCAL(f)(o)> UnnamedTypeParam1_3> using a = bool;// Fails on GCC ([GCC109781][]) and Clang 12 (a lambda expression cannot appear in this context)
            ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: error: a lambda expression cannot appear in this context
 template<t<CPP2_UFCS_NONLOCAL(f)(o)> UnnamedTypeParam1_4> auto inline constexpr b = false;// Fails on GCC ([GCC109781][]).
            ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:35:13: error: a lambda expression cannot appear in this context
 using c = t<CPP2_UFCS_NONLOCAL(f)(o)>;// Fails on Clang 12 (lambda in unevaluated context) and Clang 12 (a lambda expression cannot appear in this context)
             ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:37:29: error: a lambda expression cannot appear in this context
 auto inline constexpr d = t<CPP2_UFCS_NONLOCAL(f)(o)>();// Fails on Clang 12 (lambda in unevaluated context).
                             ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: error: a lambda expression cannot appear in this context
 template<t<CPP2_UFCS_NONLOCAL(f)(o)> UnnamedTypeParam1_2> auto g() -> void{}// Fails on GCC ([GCC109781][]) and Clang 12 (a lambda expression cannot appear in this context)
            ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:23:42: error: a lambda expression cannot appear in this context
 auto g([[maybe_unused]] cpp2::impl::in<t<CPP2_UFCS_NONLOCAL(f)(o)>> unnamed_param_1) -> void{}// Fails on Clang 12 (lambda in unevaluated context).
                                          ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:27:29: error: a lambda expression cannot appear in this context
 [[nodiscard]] auto h() -> t<CPP2_UFCS_NONLOCAL(f)(o)> { return o;  }// Fails on Clang 12 (lambda in unevaluated context).
                             ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 mixed-bugfix-for-ufcs-non-local.cpp2:41:85: error: lambda expression in an unevaluated operand
   inline CPP2_CONSTEXPR bool u::c = [](cpp2::impl::in<std::type_identity_t<decltype(CPP2_UFCS_NONLOCAL(f)(o))>> x) mutable -> auto { return x; }(true);// Fails on Clang 12 (lambda in unevaluated context).
                                                                                     ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 13 errors generated.

--- a/regression-tests/test-results/clang-12-c++20/pure2-bugfix-for-ufcs-noexcept.cpp.output
+++ b/regression-tests/test-results/clang-12-c++20/pure2-bugfix-for-ufcs-noexcept.cpp.output
@@ -1,10 +1,10 @@
 pure2-bugfix-for-ufcs-noexcept.cpp2:5:26: error: lambda expression in an unevaluated operand
   static_assert(noexcept(CPP2_UFCS(swap)(t(), t())));// Fails on Clang 12 (lambda in unevaluated context) and GCC 10 (static assertion failed)
                          ^
-../../../include/cpp2util.h:1160:59: note: expanded from macro 'CPP2_UFCS'
+../../../include/cpp2util.h:1166:59: note: expanded from macro 'CPP2_UFCS'
 #define CPP2_UFCS(...)                                    CPP2_UFCS_(&,CPP2_UFCS_EMPTY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 1 error generated.

--- a/regression-tests/test-results/clang-12-c++20/pure2-bugfix-for-ufcs-sfinae.cpp.output
+++ b/regression-tests/test-results/clang-12-c++20/pure2-bugfix-for-ufcs-sfinae.cpp.output
@@ -1,19 +1,19 @@
 pure2-bugfix-for-ufcs-sfinae.cpp2:1:78: error: lambda expression in an unevaluated operand
 template<typename T> [[nodiscard]] auto f() -> std::type_identity_t<decltype(CPP2_UFCS_NONLOCAL(a)(T()))>;
                                                                              ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 pure2-bugfix-for-ufcs-sfinae.cpp2:1:78: error: lambda expression in an unevaluated operand
 template<typename T> [[nodiscard]] auto f() -> std::type_identity_t<decltype(CPP2_UFCS_NONLOCAL(a)(T()))>{}// Fails on Clang 12 (lambda in unevaluated context).
                                                                              ^
-../../../include/cpp2util.h:1165:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
+../../../include/cpp2util.h:1171:59: note: expanded from macro 'CPP2_UFCS_NONLOCAL'
 #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
                                                           ^
-../../../include/cpp2util.h:1127:66: note: expanded from macro 'CPP2_UFCS_'
+../../../include/cpp2util.h:1133:66: note: expanded from macro 'CPP2_UFCS_'
 #define CPP2_UFCS_(LAMBDADEFCAPT,SFINAE,MVFWD,QUALID,TEMPKW,...) \
                                                                  ^
 2 errors generated.

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1128:1: error: lambda-expression in template parameter type
- 1128 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
+ 1134 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1165:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1165 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid


### PR DESCRIPTION
Update test-results for ubuntu clang 12, gcc 13 and gcc 14 after changes to `cpp2util.h` from d13615317734b611042dcba5af623611bcc054f2