### PR TITLE
Add `..` syntax to select a member function only

### DIFF
--- a/regression-tests/pure2-ufcs-member-access-and-chaining.cpp2
+++ b/regression-tests/pure2-ufcs-member-access-and-chaining.cpp2
@@ -21,6 +21,9 @@ main: () -> int = {
     42.no_return();
 
     res.no_return();
+
+    obj: mytype = ();
+    obj..hun(42);   // explicit non-UFCS
 }
 
 no_return: (_) = { }
@@ -41,3 +44,7 @@ get_i: (r:_) -> int = {
 //  And a test for non-local UFCS, which shouldn't do a [&] capture
 f: (_)->int = 0;
 y: int = 0.f();
+
+mytype: type = {
+    hun: (i: int) = { }
+}

--- a/regression-tests/test-results/msvc-2022-c++latest/MSVC-version.output
+++ b/regression-tests/test-results/msvc-2022-c++latest/MSVC-version.output
@@ -1,3 +1,3 @@
-Microsoft (R) C/C++ Optimizing Compiler Version 19.39.33523 for x86
+Microsoft (R) C/C++ Optimizing Compiler Version 19.40.33811 for x64
 Copyright (C) Microsoft Corporation.  All rights reserved.
 

--- a/source/lex.h
+++ b/source/lex.h
@@ -83,6 +83,7 @@ enum class lexeme : std::int8_t {
     Semicolon,
     Comma,
     Dot,
+    DotDot,
     Ellipsis,
     QuestionMark,
     At,
@@ -180,6 +181,7 @@ auto _as(lexeme l)
     break;case lexeme::Semicolon:           return "Semicolon";
     break;case lexeme::Comma:               return "Comma";
     break;case lexeme::Dot:                 return "Dot";
+    break;case lexeme::DotDot:              return "DotDot";
     break;case lexeme::Ellipsis:            return "Ellipsis";
     break;case lexeme::QuestionMark:        return "QuestionMark";
     break;case lexeme::At:                  return "At";
@@ -845,9 +847,9 @@ auto lex_line(
 
         if (
             i >= 3
-            && (tokens[i-3] != "::" && tokens[i-3] != ".")
+            && (tokens[i-3] != "::" && tokens[i-3].type() != lexeme::Dot && tokens[i - 3].type() != lexeme::DotDot)
             && (tokens[i-2] == "unique" || tokens[i-2] == "shared")
-            && tokens[i-1] == "."
+            && tokens[i-1].type() == lexeme::Dot
             && tokens[i] == "new"
             )
         {
@@ -1402,10 +1404,11 @@ auto lex_line(
 
             //G
             //G punctuator: one of
-            //G     '...' '.'
+            //G     '.' '..' '...'
             break;case '.':
-                if (peek1 == '.' && peek2 == '.') { store(3, lexeme::Ellipsis); }
-                else { store(1, lexeme::Dot); }
+                if      (peek1 == '.' && peek2 == '.') { store(3, lexeme::Ellipsis); }
+                else if (peek1 == '.')                 { store(2, lexeme::DotDot); }
+                else                                   { store(1, lexeme::Dot); }
 
             //G     '::' ':'
             break;case ':':

--- a/source/parse.h
+++ b/source/parse.h
@@ -36,10 +36,6 @@ auto violates_lifetime_safety = false;
 auto is_prefix_operator(token const& tok)
     -> bool
 {
-    //if (to_passing_style(tok) != passing_style::invalid) {
-    //    return true;
-    //}
-
     switch (tok.type()) {
     break;case lexeme::Not:
           case lexeme::Minus:
@@ -1682,7 +1678,7 @@ auto postfix_expression_node::get_first_token_ignoring_this() const
         expr->get_token()
         && *expr->get_token() == "this"
         && std::ssize(ops) == 1
-        && ops[0].op->type() == lexeme::Dot
+        && (ops[0].op->type() == lexeme::Dot || ops[0].op->type() == lexeme::DotDot)
         )
     {
         return ops[0].id_expr->get_token();
@@ -5820,6 +5816,7 @@ private:
     //G     postfix-expression '[' expression-list? ','? ']'
     //G     postfix-expression '(' expression-list? ','? ')'
     //G     postfix-expression '.' id-expression
+    //G     postfix-expression '..' id-expression
     //G
     auto postfix_expression()
         -> std::unique_ptr<postfix_expression_node>
@@ -5837,7 +5834,8 @@ private:
                 || curr().type() == lexeme::LeftBracket
                 || curr().type() == lexeme::LeftParen
                 || curr().type() == lexeme::Dot
-            )
+                || curr().type() == lexeme::DotDot
+                )
             )
         {
             //  * and & can't be unary operators if followed by a (, identifier, or literal
@@ -5916,7 +5914,10 @@ private:
                     break;
                 }
             }
-            else if (term.op->type() == lexeme::Dot)
+            else if (
+                term.op->type() == lexeme::Dot
+                || term.op->type() == lexeme::DotDot
+                )
             {
                 term.id_expr = id_expression();
                 if (!term.id_expr) {

--- a/source/sema.h
+++ b/source/sema.h
@@ -449,13 +449,6 @@ public:
 
             //  Now we have the lookup result, but based on lookup constraints flags
             //  we may decide it's unsuitable for this lookup and not use it...
-            //
-            //  TODO: The initial versions of these conditions are written to make the
-            //  new lookup results exactly match the prior lookup results, so we don't
-            //  introduce regressions. However, not all these wrinkles may be needed
-            //  or desirable, so after we know we didn't introduce regressions we can
-            //  consider tweaking/simplifying them -- which is easier now that they're
-            //  collected all in one place
             if (
                 result
                 //  If we were told not to look beyond the current function
@@ -481,33 +474,6 @@ public:
             }
 
         }
-
-        ////--------- START TEMPORARY REGRESSION TEST CODE FOR G_D_O OPTIMIZATION VERIFICATION ---------
-        ////  Now do a regression test violation check
-        ////
-        //if (
-        //    flag_internal_debug
-        //    && result_old != result
-        //    )
-        //{
-        //    std::cerr << "\n  Internal compiler error - see cppfront-ice-data.out for debug information\n\n";
-
-        //    auto out = std::ofstream{"cppfront-ice-data.out"};
-
-        //    out << "g_d_o arguments:\n";
-        //    out << "    " << static_cast<void const*>(&t) << " -> " << t.as_string_view() << " @ " << t.position().to_string()
-        //        << ", token order # " << t.get_global_token_order() << "\n";
-        //    out << "    look_beyond_current_function: " << std::boolalpha << look_beyond_current_function << "\n";
-        //    out << "    include_implicit_this:        " << std::boolalpha << include_implicit_this        << "\n";
-
-        //    out << "result_old:    "       << static_cast<void const*>(result_old) << "\n";
-        //    out << "result:        "       << static_cast<void const*>(result    ) << "\n\n";
-
-        //    debug_print(out);
-
-        //    exit(EXIT_FAILURE);
-        //}
-        ////--------- END TEMPORARY REGRESSION TEST CODE FOR G_D_O OPTIMIZATION VERIFICATION -----------
 
         return result;
     }

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -272,9 +272,6 @@ private:
     )
         -> void
     {
-if (s.starts_with("..")) {
-    s == s;
-}
         //  Take ownership of (and reset) just_printed_line_directive value
         auto line_directive_already_done = std::exchange(just_printed_line_directive, false);
 

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -272,6 +272,9 @@ private:
     )
         -> void
     {
+if (s.starts_with("..")) {
+    s == s;
+}
         //  Take ownership of (and reset) just_printed_line_directive value
         auto line_directive_already_done = std::exchange(just_printed_line_directive, false);
 
@@ -3419,7 +3422,11 @@ public:
                         args.reset();
                     }
 
-                    auto print = print_to_string(*i->id_expr, false /*not a local name*/, i->op->type() == lexeme::Dot);
+                    auto print = print_to_string(
+                        *i->id_expr, 
+                        false, // not a local name
+                        i->op->type() == lexeme::Dot || i->op->type() == lexeme::DotDot // member access
+                    );
                     suffix.emplace_back( print, i->id_expr->position() );
                 }
 
@@ -3449,6 +3456,9 @@ public:
                         prefix.emplace_back( "CPP2_ASSERT_IN_BOUNDS(", i->op->position() );
                     }
                     suffix.emplace_back( ", ", i->op->position() );
+                }
+                else if( i->op->type() == lexeme::DotDot) {
+                    suffix.emplace_back(".", i->op->position());
                 }
                 else {
                     suffix.emplace_back( i->op->to_string(), i->op->position() );


### PR DESCRIPTION
With this PR, `x.f()` is still UFCS, but `x..f()` will now find only a member function.

For now I like that the default is UFCS, but as we get more experience I'm open to changing the default so that `.` is member selection and `..` is UFCS (which would be a breaking change, but a mechanical one).

Also: Remove the old version of `get_declaration_of` now that the new lookup seems stable.