### PR TITLE
Fix tests after addition of .. support

### DIFF
--- a/regression-tests/test-results/pure2-ufcs-member-access-and-chaining.cpp
+++ b/regression-tests/test-results/pure2-ufcs-member-access-and-chaining.cpp
@@ -8,29 +8,42 @@
 
 #line 1 "pure2-ufcs-member-access-and-chaining.cpp2"
 
+#line 48 "pure2-ufcs-member-access-and-chaining.cpp2"
+class mytype;
+    
 
 //=== Cpp2 type definitions and function declarations ===========================
 
 #line 1 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto main() -> int;
 
-#line 26 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 29 "pure2-ufcs-member-access-and-chaining.cpp2"
 auto no_return([[maybe_unused]] auto const& unnamed_param_1) -> void;
 
 [[nodiscard]] auto ufcs(cpp2::impl::in<int> i) -> int;
 using fun_ret = int;
 
 
-#line 32 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 35 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto fun() -> fun_ret;
 
-#line 37 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 40 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto get_i(auto const& r) -> int;
 
-#line 41 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 44 "pure2-ufcs-member-access-and-chaining.cpp2"
 //  And a test for non-local UFCS, which shouldn't do a [&] capture
 [[nodiscard]] auto f([[maybe_unused]] auto const& unnamed_param_1) -> int;
 extern int y;
+
+class mytype {
+    public: static auto hun(cpp2::impl::in<int> i) -> void;
+    public: mytype() = default;
+    public: mytype(mytype const&) = delete; /* No 'that' constructor, suppress copy */
+    public: auto operator=(mytype const&) -> void = delete;
+
+#line 50 "pure2-ufcs-member-access-and-chaining.cpp2"
+};
+
 
 //=== Cpp2 function definitions =================================================
 
@@ -59,30 +72,36 @@ extern int y;
     CPP2_UFCS(no_return)(42);
 
     CPP2_UFCS(no_return)(cpp2::move(res));
+
+    mytype obj {}; 
+    cpp2::move(obj).hun(42);// explicit non-UFCS
 }
 
-#line 26 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 29 "pure2-ufcs-member-access-and-chaining.cpp2"
 auto no_return([[maybe_unused]] auto const& unnamed_param_1) -> void{}
 
-#line 28 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 31 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto ufcs(cpp2::impl::in<int> i) -> int{
     return i + 2; 
 }
 
-#line 32 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 35 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto fun() -> fun_ret{
         cpp2::impl::deferred_init<int> i;
-#line 33 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 36 "pure2-ufcs-member-access-and-chaining.cpp2"
     i.construct(42);
     return std::move(i.value()); 
 }
 
-#line 37 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 40 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto get_i(auto const& r) -> int{
     return r; 
 }
 
-#line 42 "pure2-ufcs-member-access-and-chaining.cpp2"
+#line 45 "pure2-ufcs-member-access-and-chaining.cpp2"
 [[nodiscard]] auto f([[maybe_unused]] auto const& unnamed_param_1) -> int { return 0;  }
 int y {CPP2_UFCS_NONLOCAL(f)(0)}; 
+
+#line 49 "pure2-ufcs-member-access-and-chaining.cpp2"
+    auto mytype::hun(cpp2::impl::in<int> i) -> void{}
 


### PR DESCRIPTION
Updates test after the support for `..` for non-UFCS was added: the generated `pure2-ufcs-member-access-and-chaining.cpp` updated after the changes in the .cpp2.