### PR TITLE
Make `cpp2::move` `constexpr`

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -485,13 +485,13 @@ concept valid_custom_is_operator = predicate_member_fun<X, F, &F::op_is>
 
 template <typename T>
     requires (std::is_copy_constructible_v<std::remove_cvref_t<T>>)
-auto move(T&& t) -> decltype(auto) {
+constexpr auto move(T&& t) -> decltype(auto) {
     return std::move(t);
 }
 
 template <typename T>
     requires (!std::is_copy_constructible_v<std::remove_cvref_t<T>>)
-auto move(T&& t) -> decltype(auto) {
+constexpr auto move(T&& t) -> decltype(auto) {
     return std::forward<T>(t);
 }
 

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -485,13 +485,13 @@ concept valid_custom_is_operator = predicate_member_fun<X, F, &F::op_is>
 
 template <typename T>
     requires (std::is_copy_constructible_v<std::remove_cvref_t<T>>)
-constexpr auto move(T&& t) -> decltype(auto) {
+inline constexpr auto move(T&& t) -> decltype(auto) {
     return std::move(t);
 }
 
 template <typename T>
     requires (!std::is_copy_constructible_v<std::remove_cvref_t<T>>)
-constexpr auto move(T&& t) -> decltype(auto) {
+inline constexpr auto move(T&& t) -> decltype(auto) {
     return std::forward<T>(t);
 }
 


### PR DESCRIPTION
The two `cpp2::move` functions are now marked as `constexpr`. See #1105