### PR TITLE
to_cpp1: Remove missing initializer assert

### DIFF
--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -6719,7 +6719,9 @@ public:
 
             //  Emit "auto" for deduced types (of course)
             if (type->is_wildcard()) {
-                assert(n.initializer);
+                if(!n.initializer) {
+                    return;
+                }
                 emit( *type, n.position() );
             }
             //  Otherwise, emit the type


### PR DESCRIPTION
Patches #1123

The program is ill formed, and semantic analysis detects the issue, but because errors are checked after lowering, it hits an assert when spitting out the cpp code, causing the crash. We could, of course, check for errors generated by semantic analysis before lowering, but this pr simply swaps out the assert for a return, so as to maintain the current structure.