### PR TITLE
Update trailing comma Windows tests

### DIFF
--- a/regression-tests/test-results/msvc-2022-c++20/pure2-trailing-comma-assert.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-trailing-comma-assert.cpp.output
@@ -1,0 +1,1 @@
+pure2-trailing-comma-assert.cpp

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-trailing-comma-assert.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-trailing-comma-assert.cpp.output
@@ -1,0 +1,1 @@
+pure2-trailing-comma-assert.cpp


### PR DESCRIPTION
Update Windows reference test tiles for `pure2-trailing-comma-assert.cpp2`.
The multi-platform build test is fixed by #1127.