### PR TITLE
[CI] Fix regression tests

### DIFF
--- a/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
-../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
- 1134 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1135:1: error: lambda-expression in template parameter type
+ 1135 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1172:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1172 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
- 1134 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1135:1: error: lambda-expression in template parameter type
+ 1135 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1172:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1172 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
- 1134 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1135:1: error: lambda-expression in template parameter type
+ 1135 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1172:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1172 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
- 1134 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1135:1: error: lambda-expression in template parameter type
+ 1135 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1172:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1172 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
-../../../include/cpp2util.h:1134:1: error: lambda-expression in template parameter type
- 1134 | [LAMBDADEFCAPT]< \
+../../../include/cpp2util.h:1135:1: error: lambda-expression in template parameter type
+ 1135 | [LAMBDADEFCAPT]< \
       | ^
-../../../include/cpp2util.h:1171:59: note: in expansion of macro ‘CPP2_UFCS_’
- 1171 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
+../../../include/cpp2util.h:1172:59: note: in expansion of macro ‘CPP2_UFCS_’
+ 1172 | #define CPP2_UFCS_NONLOCAL(...)                           CPP2_UFCS_(,CPP2_UFCS_IDENTITY,CPP2_UFCS_IDENTITY,(),,__VA_ARGS__)
       |                                                           ^~~~~~~~~~
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
@@ -6,7 +6,7 @@ pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' b
 pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(9): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(9): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-..\..\..\include\cpp2util.h(638): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&)'
+..\..\..\include\cpp2util.h(639): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&)'
 pure2-assert-expected-not-null.cpp2(14): error C2039: 'expected': is not a member of 'std'
 predefined C++ types (compiler internal)(347): note: see declaration of 'std'
 pure2-assert-expected-not-null.cpp2(14): error C2062: type 'int' unexpected
@@ -19,4 +19,4 @@ pure2-assert-expected-not-null.cpp2(14): note: while trying to match the argumen
 pure2-assert-expected-not-null.cpp2(14): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(15): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(15): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-..\..\..\include\cpp2util.h(638): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&)'
+..\..\..\include\cpp2util.h(639): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&)'


### PR DESCRIPTION
Update a couple of test-results caused by line number changes in cpp2util.h

- gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
- msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output