### PR TITLE
Feature to allow multiple translation unit compilations of generated pure headers

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -3131,6 +3131,43 @@ public:
     auto parent_is_polymorphic() const -> bool
         { return  parent_declaration && parent_declaration->is_polymorphic(); }
 
+    auto is_inline() const -> bool
+    {
+        return is_alias()
+            || is_constexpr
+            || template_parameters != nullptr;
+    }
+
+    auto parent_is_inline() const -> bool
+    {
+        for (auto p = parent_declaration; p; p = p->parent_declaration)
+        {
+            if (p->is_inline())
+                return true;
+        }
+        return false;
+    }
+
+    auto last_parent_function_is_not_inline() const -> bool
+    {
+        auto p = parent_declaration;
+
+        if (!p)
+            return false;
+
+        auto pp = p->parent_declaration;
+        if (!p->is_function())
+            p = nullptr;
+
+        while (pp) {
+            if (pp->is_function())
+                p = pp;
+            pp = pp->parent_declaration;
+        }
+
+        return p && !p->is_inline();
+    }
+
     enum which {
         functions = 1,
         objects   = 2,


### PR DESCRIPTION
The purpose of this PR is to allow including pure headers into multiple translation units without ODR violations.

First and foremost it splits `phase2_func_defs` into `phase2_inline_defs` and `phase3_regular_defs`. Produced .h file gets all declarations (as before), alias definitions and anything template-related, while the rest go to .hpp.

A flag `-tu-compatible-h2` is added that stops generated hpp files from including other hpps as it is not necessary to produce a buildable source, but the default behaviour is unchanged. When using the flag it is important to include the resulting .hpp at least somewhere as it is never included automatically.

With a simple-ish cmake functions it makes it possible to produce automatically both header with declarations and inline definitions and a cpp with non-inline definitions. As an example, in my hobby project cmake parses h2s, finds #cppinclude lines and adds them to a new .cpp as regular #include, than includes the generated .hpp.