### PR TITLE
Allow const declarations without wildcard

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -6541,7 +6541,7 @@ private:
             assert (n->id.index() == type_id_node::unqualified);
         }
         else {
-            return {};
+            return n;
         }
         if (curr().type() == lexeme::Multiply) {
             error("'T*' is not a valid Cpp2 type; use '*T' for a pointer instead", false);


### PR DESCRIPTION
Addresses #1138, case D.

d0836be2bff6a65d6ffb081a3d4cb14ccc49c25f suppresses the error, but returning a default object drops the pc_qualifiers.