### PR TITLE
Remove forward slash as command line switch

### DIFF
--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -63,7 +63,7 @@ auto main(
     {
         if (
             arg.text.starts_with("-")
-            || arg.text.starts_with("/")
+            || (arg.text.starts_with("/") && arg.text.find('.') != std::string::npos)
             )
         {
             auto ambiguous = cmdline.flags_starting_with(arg.text.substr(1));

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -63,7 +63,7 @@ auto main(
     {
         if (
             arg.text.starts_with("-")
-            || (arg.text.starts_with("/") && arg.text.find('.') != std::string::npos)
+            || (arg.text.starts_with("/") && !contains(arg.text, '.'))
             )
         {
             auto ambiguous = cmdline.flags_starting_with(arg.text.substr(1));


### PR DESCRIPTION
Fixes #1174. According to the docs, forward slashes are not used for any flags (and I can't think of a good reason for them to be, given the problems it would cause, like the mentioned issue), so this pr just removes forward slashes for command line options.