### PR TITLE
feat: Support function types - an attempt to rebase #526 with current main

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -370,6 +370,17 @@ using _uchar     = unsigned char;    // normally use u8 instead
 
 //-----------------------------------------------------------------------
 //
+//  fn_t<R(ArgTypes...)>       For emitted Cpp2 function types
+//
+//-----------------------------------------------------------------------
+//
+template<typename T>
+    requires std::is_function_v<T>
+using fn_t = T;
+
+
+//-----------------------------------------------------------------------
+//
 //  String utilities
 //
 

--- a/source/parse.h
+++ b/source/parse.h
@@ -5493,7 +5493,7 @@ auto stack_value(T& var, std::type_identity_t<T> const& value)
     return finally([&var, old = std::exchange(var, value)]() {
         var = old;
     });
-};
+}
 
 
 //-----------------------------------------------------------------------
@@ -6731,7 +6731,7 @@ private:
                     }
                 }
             }
-            if (auto l = get_if<function_type_node::list>(&f->type->returns)) {
+            if ([[maybe_unused]] auto l = get_if<function_type_node::list>(&f->type->returns)) {
                 //error(
                 //    "a function type can't have an anonymous return type",
                 //    false,

--- a/source/sema.h
+++ b/source/sema.h
@@ -688,6 +688,7 @@ public:
                 if (is_uninitialized_decl(*sym)) {
                     if (
                         sym->declaration->is_object()
+                        && !sym->declaration->parent_is_object()
                         && !sym->declaration->parent_is_namespace()
                         )
                     {


### PR DESCRIPTION
Hand-merged #526 into current main code

Some basic examples compile, but `reflect.h2` doesn't yet, needs investigation

My main additional change so far to the #526 diffs is that I've commented out some of the new error message emissions on what appeared to be trial parses(?), because the presence of the error message stopped further processing and caused programs like `f: (x: int) { }` to fail