### PR TITLE
Throw runtime error for range with last == numeric_limits<T>::max()

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -2307,8 +2307,15 @@ public:
         , last{ l }
     {
         //  Represent all ranges as half-open; after this we can forget the flag
-        if (include_last) {
-            ++last;
+        if (include_last) { 
+            if constexpr (std::integral<TT>) {
+                if (last == std::numeric_limits<TT>::max()) {
+                    throw std::runtime_error(
+                        "range with last == numeric_limits<T>::max() will "
+                        "overflow");
+                }
+            }
+            ++last; 
         }
     }
 


### PR DESCRIPTION
Addresses #1180. The short of the issue is that if we create a numeric range with last == numeric_limits<T>::max(), the `++last` in the constructor causes overflow, which is not great to say the least. I can't think of a clean way to address this issue since a core aspect of c++ iterators is their asymmetry, so I figured it's better just to report an error if we notice a user trying to create an erroneous range. Open to suggestions.