### PR TITLE
Starting over on function types - initial support for function types in <> lists

### DIFF
--- a/docs/cpp2/contracts.md
+++ b/docs/cpp2/contracts.md
@@ -57,7 +57,7 @@ Contract groups are useful to enable or disable or [set custom handlers](#violat
 
 You can create new contract groups just by creating new objects that have a `.report_violation` function. The object's name is the contract group's name. The object can be at any scope: local, global, or heap.
 
-For example, here are some ways to use contract groups of type [`cpp2::contract_group`](#violation_handlers), which is a convenient group type:
+For example, here are some ways to use contract groups of type [`cpp2::contract_group`](#violation-handlers), which is a convenient group type:
 
 ``` cpp title="Using contract groups" hl_lines="1 4 6 10-12"
 group_a: cpp2::contract_group = ();          // a global group

--- a/docs/cpp2/functions.md
+++ b/docs/cpp2/functions.md
@@ -12,7 +12,9 @@ func: ( /* no parameters */ ) = { /* empty body */ }
 ```
 
 
-## <a id="parameters"></a> Parameters
+## <a id="function-signatures"></a> Function signatures: Parameters, returns, and using function types
+
+### <a id="parameters"></a> Parameters
 
 The parameter list is a [list](common.md#lists) enclosed by `(` `)` parentheses. Each parameter is declared using the [same unified syntax](declarations.md) as used for all declarations. For example:
 
@@ -72,7 +74,7 @@ wrap_f: (
 ```
 
 
-## <a id="return-values"></a> Return values
+### <a id="return-values"></a> Return values
 
 A function can return either of the following. The default is `#!cpp -> void`.
 
@@ -152,7 +154,7 @@ main: () = {
 ```
 
 
-### <a id="nodiscard-outputs"></a> Function outputs are not implicitly discardable
+#### <a id="nodiscard-outputs"></a> Function outputs are not implicitly discardable
 
 A function's outputs are its return values, and the "out" state of any `out` and `inout` parameters.
 
@@ -200,9 +202,29 @@ main: ()
 > - A function call written in Cpp2 `x.f()` member call syntax always treats a non-`#!cpp void` return type as not discardable, even if the function was written in Cpp1 syntax that did not write `[[nodiscard]]`.
 
 
+### <a id = "function-types"></a> Using function types
+
+The same function parameter/return syntax can be used as a function type, for example to instantiate `std::function` or to declare a pointer to function variable. For example:
+
+``` cpp title="Using function types with std::function and *pfunc" hl_lines="4 7"
+decorate_int: (i: i32) -> std::string = "--> (i)$ <--";
+
+main: () = {
+    pf1: std::function< (i: i32) -> std::string > = decorate_int&;
+    std::cout << "pf1(123) returned \"(pf1(123))$\"\n";
+
+    pf2: * (i: i32) -> std::string = decorate_int&;
+    std::cout << "pf2(456) returned \"(pf2(456))$\"\n";
+}
+//  Prints:
+//    pf1 returned "--> 123 <--"
+//    pf2 returned "--> 456 <--"
+```
+
+
 ## <a id="control flow"></a> Control flow
 
-## <a id="branches"></a> `#!cpp if`, `#!cpp else` — Branches
+### <a id="branches"></a> `#!cpp if`, `#!cpp else` — Branches
 
 `if` and `else` are like always in C++, except that `(` `)` parentheses around the condition are not required. Instead, `{` `}` braces around a branch body *are* required. For example:
 
@@ -216,7 +238,7 @@ else {
 ```
 
 
-## <a id="loops"></a> `#!cpp for`, `#!cpp while`, `#!cpp do` — Loops
+### <a id="loops"></a> `#!cpp for`, `#!cpp while`, `#!cpp do` — Loops
 
 **`#!cpp do`** and **`#!cpp while`** are like always in C++, except that `(` `)` parentheses around the condition are not required. Instead, `{` `}` braces around the loop body *are* required.
 
@@ -296,7 +318,7 @@ Line by line:
 - `next i++`: The end-of-loop-iteration statement. Note `++` is always postfix in Cpp2.
 
 
-### Loop names, `#!cpp break`, and `#!cpp continue`
+#### Loop names, `#!cpp break`, and `#!cpp continue`
 
 Loops can be named using the usual **name `:`** syntax that introduces all names, and `#!cpp break` and `#!cpp continue` can refer to those names. For example:
 

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -518,15 +518,17 @@ inline std::string join(List const& list) {
 //
 //  Conveniences for expressing Cpp1 references (rarely useful)
 // 
-//  Note: Only needed in rare cases to take full control of matching a
-//        Cpp1 signature exactly. Most cases don't need this, for example
-//        a Cpp1 virtual function signature declaration like
+//  Note: Only needed in rare cases to take full control of matching an
+//        odd Cpp1 signature exactly. Most cases don't need this... for
+//        example, a Cpp1 virtual function signature declaration like
 // 
-//              virtual void f(int&) const
+//              virtual void myfunc(int& val) const
 // 
 //        can already be directly overriden by a Cpp2 declaration of
 // 
-//              f: (override this, inout val : int)
+//              myfunc: (override this, inout val: int)
+//                  // identical to this in Cpp1 syntax:
+//                  //  void myfunc(int& val) const override
 // 
 //        without any need to say cpp1_ref on the int parameter.
 // 

--- a/regression-tests/pure2-function-typeids.cpp2
+++ b/regression-tests/pure2-function-typeids.cpp2
@@ -11,6 +11,10 @@ g_move : (move  s: std::string) = std::cout << "I hear you've moving, (s)$?\n";
 h_forward: (inout s: std::string) -> forward std::string = { std::cout << "Inout (s)$ ... "; return s; }
 h_out    : (      s: std::string) ->         std::string = { std::cout << "In (s)$ ... "; return "yohoho"; }
 
+f1: (a: std::function< (x:int) -> int >) -> int = a(1);
+f2: (a:              * (x:int) -> int  ) -> int = a(2);
+g :                    (x:int) -> int           = x+42;
+
 
 main: () = 
 {
@@ -80,4 +84,9 @@ main: () =
     //  Test out return
     std::cout << "fh_out returned: (fh_out(gandalf))$\n";
     std::cout << "ph_out returned: (ph_out(galadriel))$\n";
+
+
+    //  --- Tests for function parameters
+    std::cout << "(f1(g&))$\n";
+    std::cout << "(f2(g&))$\n";
 }

--- a/regression-tests/pure2-function-typeids.cpp2
+++ b/regression-tests/pure2-function-typeids.cpp2
@@ -5,64 +5,79 @@ f: () = std::cout << "hello world!\n";
 
 g_in   : (      s: std::string) = std::cout << "Come in, (s)$\n";
 g_inout: (inout s: std::string) = std::cout << "Come in awhile, but take some biscuits on your way out, (s)$!\n";
-g_out  : (out   s: std::string) = s = "Gandalf";
+g_out  : (out   s: std::string) = s = "A Powerful Mage";
 g_move : (move  s: std::string) = std::cout << "I hear you've moving, (s)$?\n";
 
-h_out    : (      s: std::string) ->         std::string = { std::cout << "In (s)$ ... "; return "yohoho"; }
 h_forward: (inout s: std::string) -> forward std::string = { std::cout << "Inout (s)$ ... "; return s; }
+h_out    : (      s: std::string) ->         std::string = { std::cout << "In (s)$ ... "; return "yohoho"; }
 
 
 main: () = 
 {
     //  --- Test basic/degenerate cases
 
-    //  Ordinary pointer to function, deduced (always worked)
-    pf := f&;
-    pf();
-
     //  Test std::function< void() >
     ff: std::function< () -> void > = f&;
     ff();
+
+    //  Ordinary pointer to function, deduced (always worked)
+    pf: * () -> void = f&;
+    pf();
 
 
     //  --- Tests for parameters
     //      Note: Not forward parameters which imply a template...
     //            function type-ids are for single function signatures
 
-    fg_in   : std::function< (inout s: std::string) -> void > = g_in&;
+    fg_in   : std::function< (      s: std::string) -> void > = g_in&;
     fg_inout: std::function< (inout s: std::string) -> void > = g_inout&;
     fg_out  : std::function< (out   s: std::string) -> void > = g_out&;
     fg_move : std::function< (move  s: std::string) -> void > = g_move&;
+    pg_in   :              * (      s: std::string) -> void   = g_in&;
+    pg_inout:              * (inout s: std::string) -> void   = g_inout&;
+    pg_out  :              * (out   s: std::string) -> void   = g_out&;
+    pg_move :              * (move  s: std::string) -> void   = g_move&;
 
     frodo: std::string = "Frodo";
+    sam  : std::string = "Sam";
 
     //  Test in param
     fg_in(frodo);
+    pg_in(sam);
 
     //  Test inout
     fg_inout(frodo);
+    pg_inout(sam);
 
     //  Test out
-    gandalf: std::string;
+    gandalf  : std::string;
+    galadriel: std::string;
     fg_out(out gandalf);
-    std::cout << "fg_out initialized the arg to: (gandalf)$\n";
+    std::cout << "fg_out initialized gandalf to: (gandalf)$\n";
+    pg_out(out galadriel);
+    std::cout << "pg_out initialized galadriel to: (galadriel)$\n";
+    gandalf   = "Gandalf";
+    galadriel = "Galadriel";
 
     //  Test move
     fg_move(frodo); // last use, so (move frodo) is not required
+    pg_move(sam);   // last use, so (move sam) is not required
 
 
     //  --- Tests for single anonymous returns
     //      Note: Not multiple named return values... function-type-ids 
     //      are for Cpp1-style (single anonymous, possibly void) returns
 
-    fh_out    : std::function< (      s: std::string) ->         std::string > = h_out&;
     fh_forward: std::function< (inout s: std::string) -> forward std::string > = h_forward&;
-
-    //  Test out return
-    std::cout << "fh_out returned: (fh_out(gandalf))$\n";
+    fh_out    : std::function< (      s: std::string) ->         std::string > = h_out&;
+    ph_forward:              * (inout s: std::string) -> forward std::string   = h_forward&;
+    ph_out    :              * (      s: std::string) ->         std::string   = h_out&;
 
     //  Test forward return
     std::cout << "fh_forward returned: (fh_forward(gandalf))$\n";
+    std::cout << "ph_forward returned: (ph_forward(galadriel))$\n";
 
-    _ = gandalf;
+    //  Test out return
+    std::cout << "fh_out returned: (fh_out(gandalf))$\n";
+    std::cout << "ph_out returned: (ph_out(galadriel))$\n";
 }

--- a/regression-tests/pure2-function-typeids.cpp2
+++ b/regression-tests/pure2-function-typeids.cpp2
@@ -1,0 +1,68 @@
+
+//  --- Scaffolding
+
+f: () = std::cout << "hello world!\n";
+
+g_in   : (      s: std::string) = std::cout << "Come in, (s)$\n";
+g_inout: (inout s: std::string) = std::cout << "Come in awhile, but take some biscuits on your way out, (s)$!\n";
+g_out  : (out   s: std::string) = s = "Gandalf";
+g_move : (move  s: std::string) = std::cout << "I hear you've moving, (s)$?\n";
+
+h_out    : (      s: std::string) ->         std::string = { std::cout << "In (s)$ ... "; return "yohoho"; }
+h_forward: (inout s: std::string) -> forward std::string = { std::cout << "Inout (s)$ ... "; return s; }
+
+
+main: () = 
+{
+    //  --- Test basic/degenerate cases
+
+    //  Ordinary pointer to function, deduced (always worked)
+    pf := f&;
+    pf();
+
+    //  Test std::function< void() >
+    ff: std::function< () -> void > = f&;
+    ff();
+
+
+    //  --- Tests for parameters
+    //      Note: Not forward parameters which imply a template...
+    //            function type-ids are for single function signatures
+
+    fg_in   : std::function< (inout s: std::string) -> void > = g_in&;
+    fg_inout: std::function< (inout s: std::string) -> void > = g_inout&;
+    fg_out  : std::function< (out   s: std::string) -> void > = g_out&;
+    fg_move : std::function< (move  s: std::string) -> void > = g_move&;
+
+    frodo: std::string = "Frodo";
+
+    //  Test in param
+    fg_in(frodo);
+
+    //  Test inout
+    fg_inout(frodo);
+
+    //  Test out
+    gandalf: std::string;
+    fg_out(out gandalf);
+    std::cout << "fg_out initialized the arg to: (gandalf)$\n";
+
+    //  Test move
+    fg_move(frodo); // last use, so (move frodo) is not required
+
+
+    //  --- Tests for single anonymous returns
+    //      Note: Not multiple named return values... function-type-ids 
+    //      are for Cpp1-style (single anonymous, possibly void) returns
+
+    fh_out    : std::function< (      s: std::string) ->         std::string > = h_out&;
+    fh_forward: std::function< (inout s: std::string) -> forward std::string > = h_forward&;
+
+    //  Test out return
+    std::cout << "fh_out returned: (fh_out(gandalf))$\n";
+
+    //  Test forward return
+    std::cout << "fh_forward returned: (fh_forward(gandalf))$\n";
+
+    _ = gandalf;
+}

--- a/regression-tests/pure2-function-typeids.cpp2
+++ b/regression-tests/pure2-function-typeids.cpp2
@@ -16,6 +16,11 @@ f2: (a:              * (x:int) -> int  ) -> int = a(2);
 g :                    (x:int) -> int           = x+42;
 
 
+// --- Tests for type aliases
+
+A_h_forward: type == (inout s: std::string) -> forward std::string;
+
+
 main: () = 
 {
     //  --- Test basic/degenerate cases
@@ -77,9 +82,12 @@ main: () =
     ph_forward:              * (inout s: std::string) -> forward std::string   = h_forward&;
     ph_out    :              * (      s: std::string) ->         std::string   = h_out&;
 
+    ph_forward2: * A_h_forward = h_forward&;
+
     //  Test forward return
     std::cout << "fh_forward returned: (fh_forward(gandalf))$\n";
     std::cout << "ph_forward returned: (ph_forward(galadriel))$\n";
+    std::cout << "ph_forward2 returned: (ph_forward2(galadriel))$\n";
 
     //  Test out return
     std::cout << "fh_out returned: (fh_out(gandalf))$\n";
@@ -89,4 +97,6 @@ main: () =
     //  --- Tests for function parameters
     std::cout << "(f1(g&))$\n";
     std::cout << "(f2(g&))$\n";
+
+
 }

--- a/regression-tests/test-results/clang-12-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/pure2-function-typeids.cpp.execution
@@ -1,8 +1,14 @@
 hello world!
 hello world!
 Come in, Frodo
+Come in, Sam
 Come in awhile, but take some biscuits on your way out, Frodo!
-fg_out initialized the arg to: Gandalf
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
 I hear you've moving, Frodo?
-In Gandalf ... fh_out returned: yohoho
+I hear you've moving, Sam?
 Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho

--- a/regression-tests/test-results/clang-12-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/pure2-function-typeids.cpp.execution
@@ -10,6 +10,7 @@ I hear you've moving, Frodo?
 I hear you've moving, Sam?
 Inout Gandalf ... fh_forward returned: Gandalf
 Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
 In Gandalf ... fh_out returned: yohoho
 In Galadriel ... ph_out returned: yohoho
 43

--- a/regression-tests/test-results/clang-12-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/pure2-function-typeids.cpp.execution
@@ -12,3 +12,5 @@ Inout Gandalf ... fh_forward returned: Gandalf
 Inout Galadriel ... ph_forward returned: Galadriel
 In Gandalf ... fh_out returned: yohoho
 In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/clang-12-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/pure2-function-typeids.cpp.execution
@@ -1,0 +1,8 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in awhile, but take some biscuits on your way out, Frodo!
+fg_out initialized the arg to: Gandalf
+I hear you've moving, Frodo?
+In Gandalf ... fh_out returned: yohoho
+Inout Gandalf ... fh_forward returned: Gandalf

--- a/regression-tests/test-results/clang-12-c++20/run-tests-clang-12.sh
+++ b/regression-tests/test-results/clang-12-c++20/run-tests-clang-12.sh
@@ -20,5 +20,6 @@ do
     fi
 done
 rm -f *.obj *.exp *.lib
+find . -type f -exec bash -c "[ ! -s \"{}\" ] && rm \"{}\"" \;
 printf "\nDone: %s .cpp tests compiled\n" "$count"
 printf "\n      %s .cpp executables generated and run\n" "$exe_count"

--- a/regression-tests/test-results/gcc-10-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-function-typeids.cpp.execution
@@ -1,8 +1,14 @@
 hello world!
 hello world!
 Come in, Frodo
+Come in, Sam
 Come in awhile, but take some biscuits on your way out, Frodo!
-fg_out initialized the arg to: Gandalf
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
 I hear you've moving, Frodo?
-In Gandalf ... fh_out returned: yohoho
+I hear you've moving, Sam?
 Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho

--- a/regression-tests/test-results/gcc-10-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-function-typeids.cpp.execution
@@ -10,6 +10,7 @@ I hear you've moving, Frodo?
 I hear you've moving, Sam?
 Inout Gandalf ... fh_forward returned: Gandalf
 Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
 In Gandalf ... fh_out returned: yohoho
 In Galadriel ... ph_out returned: yohoho
 43

--- a/regression-tests/test-results/gcc-10-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-function-typeids.cpp.execution
@@ -12,3 +12,5 @@ Inout Gandalf ... fh_forward returned: Gandalf
 Inout Galadriel ... ph_forward returned: Galadriel
 In Gandalf ... fh_out returned: yohoho
 In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/gcc-10-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-function-typeids.cpp.execution
@@ -1,0 +1,8 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in awhile, but take some biscuits on your way out, Frodo!
+fg_out initialized the arg to: Gandalf
+I hear you've moving, Frodo?
+In Gandalf ... fh_out returned: yohoho
+Inout Gandalf ... fh_forward returned: Gandalf

--- a/regression-tests/test-results/gcc-10-c++20/run-tests-gcc-10.sh
+++ b/regression-tests/test-results/gcc-10-c++20/run-tests-gcc-10.sh
@@ -20,5 +20,6 @@ do
     fi
 done
 rm -f *.obj *.exp *.lib
+find . -type f -exec bash -c "[ ! -s \"{}\" ] && rm \"{}\"" \;
 printf "\nDone: %s .cpp tests compiled\n" "$count"
 printf "\n      %s .cpp executables generated and run\n" "$exe_count"

--- a/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | 
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 |     ~finally() noexcept { f(); }
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | 
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 |     ~finally() noexcept { f(); }
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | 
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 |     ~finally() noexcept { f(); }
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | 
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 |     ~finally() noexcept { f(); }
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | 
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 |     ~finally() noexcept { f(); }
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-function-typeids.cpp.execution
@@ -1,8 +1,14 @@
 hello world!
 hello world!
 Come in, Frodo
+Come in, Sam
 Come in awhile, but take some biscuits on your way out, Frodo!
-fg_out initialized the arg to: Gandalf
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
 I hear you've moving, Frodo?
-In Gandalf ... fh_out returned: yohoho
+I hear you've moving, Sam?
 Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-function-typeids.cpp.execution
@@ -10,6 +10,7 @@ I hear you've moving, Frodo?
 I hear you've moving, Sam?
 Inout Gandalf ... fh_forward returned: Gandalf
 Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
 In Gandalf ... fh_out returned: yohoho
 In Galadriel ... ph_out returned: yohoho
 43

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-function-typeids.cpp.execution
@@ -12,3 +12,5 @@ Inout Gandalf ... fh_forward returned: Gandalf
 Inout Galadriel ... ph_forward returned: Galadriel
 In Gandalf ... fh_out returned: yohoho
 In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-function-typeids.cpp.execution
@@ -1,0 +1,8 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in awhile, but take some biscuits on your way out, Frodo!
+fg_out initialized the arg to: Gandalf
+I hear you've moving, Frodo?
+In Gandalf ... fh_out returned: yohoho
+Inout Gandalf ... fh_forward returned: Gandalf

--- a/regression-tests/test-results/gcc-14-c++2b/run-tests-gcc-14.sh
+++ b/regression-tests/test-results/gcc-14-c++2b/run-tests-gcc-14.sh
@@ -20,5 +20,6 @@ do
     fi
 done
 rm -f *.obj *.exp *.lib
+find . -type f -exec bash -c "[ ! -s \"{}\" ] && rm \"{}\"" \;
 printf "\nDone: %s .cpp tests compiled\n" "$count"
 printf "\n      %s .cpp executables generated and run\n" "$exe_count"

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.execution
@@ -1,8 +1,14 @@
 hello world!
 hello world!
 Come in, Frodo
+Come in, Sam
 Come in awhile, but take some biscuits on your way out, Frodo!
-fg_out initialized the arg to: Gandalf
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
 I hear you've moving, Frodo?
-In Gandalf ... fh_out returned: yohoho
+I hear you've moving, Sam?
 Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.execution
@@ -10,6 +10,7 @@ I hear you've moving, Frodo?
 I hear you've moving, Sam?
 Inout Gandalf ... fh_forward returned: Gandalf
 Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
 In Gandalf ... fh_out returned: yohoho
 In Galadriel ... ph_out returned: yohoho
 43

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.execution
@@ -12,3 +12,5 @@ Inout Gandalf ... fh_forward returned: Gandalf
 Inout Galadriel ... ph_forward returned: Galadriel
 In Gandalf ... fh_out returned: yohoho
 In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.execution
@@ -1,0 +1,8 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in awhile, but take some biscuits on your way out, Frodo!
+fg_out initialized the arg to: Gandalf
+I hear you've moving, Frodo?
+In Gandalf ... fh_out returned: yohoho
+Inout Gandalf ... fh_forward returned: Gandalf

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-function-typeids.cpp.output
@@ -1,0 +1,1 @@
+pure2-function-typeids.cpp

--- a/regression-tests/test-results/msvc-2022-c++latest/run-tests-msvc-2022.bat
+++ b/regression-tests/test-results/msvc-2022-c++latest/run-tests-msvc-2022.bat
@@ -26,6 +26,7 @@ for %%f in (*.cpp) do (
     )
 )
 del pure2-*.obj mixed-*.obj *.exp *.lib
+..\..\rm-empty-files.bat
 echo.
 echo Done: %count% .cpp tests compiled
 echo.

--- a/regression-tests/test-results/pure2-function-typeids.cpp
+++ b/regression-tests/test-results/pure2-function-typeids.cpp
@@ -31,6 +31,11 @@ auto g_move(std::string&& s) -> void;
 [[nodiscard]] auto g   (cpp2::impl::in<int> x) -> int;
 
 #line 19 "pure2-function-typeids.cpp2"
+// --- Tests for type aliases
+
+using A_h_forward = std::string&(std::string& s);
+
+#line 24 "pure2-function-typeids.cpp2"
 auto main() -> int;
 
 //=== Cpp2 function definitions =================================================
@@ -61,7 +66,7 @@ auto g_move(std::string&& s) -> void { std::cout << "I hear you've moving, " + c
 #line 16 "pure2-function-typeids.cpp2"
 [[nodiscard]] auto g   (cpp2::impl::in<int> x) -> int { return x + 42; }
 
-#line 19 "pure2-function-typeids.cpp2"
+#line 24 "pure2-function-typeids.cpp2"
 auto main() -> int
 {
     //  --- Test basic/degenerate cases
@@ -74,7 +79,7 @@ auto main() -> int
     void(*pf)()  = &f; 
     cpp2::move(pf)();
 
-#line 32 "pure2-function-typeids.cpp2"
+#line 37 "pure2-function-typeids.cpp2"
     //  --- Tests for parameters
     //      Note: Not forward parameters which imply a template...
     //            function type-ids are for single function signatures
@@ -113,7 +118,7 @@ auto main() -> int
     cpp2::move(fg_move)(cpp2::move(frodo));// last use, so (move frodo) is not required
     cpp2::move(pg_move)(cpp2::move(sam));// last use, so (move sam) is not required
 
-#line 71 "pure2-function-typeids.cpp2"
+#line 76 "pure2-function-typeids.cpp2"
     //  --- Tests for single anonymous returns
     //      Note: Not multiple named return values... function-type-ids 
     //      are for Cpp1-style (single anonymous, possibly void) returns
@@ -123,17 +128,22 @@ auto main() -> int
     std::string&(*ph_forward)(  std::string& s)  = &h_forward; 
     std::string(*ph_out)(cpp2::impl::in<std::string> s)  = &h_out; 
 
+    A_h_forward* ph_forward2 {&h_forward}; 
+
     //  Test forward return
     std::cout << "fh_forward returned: " + cpp2::to_string(cpp2::move(fh_forward)(gandalf.value())) + "\n";
     std::cout << "ph_forward returned: " + cpp2::to_string(cpp2::move(ph_forward)(galadriel.value())) + "\n";
+    std::cout << "ph_forward2 returned: " + cpp2::to_string(cpp2::move(ph_forward2)(galadriel.value())) + "\n";
 
     //  Test out return
     std::cout << "fh_out returned: " + cpp2::to_string(cpp2::move(fh_out)(cpp2::move(gandalf.value()))) + "\n";
     std::cout << "ph_out returned: " + cpp2::to_string(cpp2::move(ph_out)(cpp2::move(galadriel.value()))) + "\n";
 
-#line 89 "pure2-function-typeids.cpp2"
+#line 97 "pure2-function-typeids.cpp2"
     //  --- Tests for function parameters
     std::cout << "" + cpp2::to_string(f1(&g)) + "\n";
     std::cout << "" + cpp2::to_string(f2(&g)) + "\n";
+
+#line 102 "pure2-function-typeids.cpp2"
 }
 

--- a/regression-tests/test-results/pure2-function-typeids.cpp
+++ b/regression-tests/test-results/pure2-function-typeids.cpp
@@ -1,0 +1,108 @@
+
+#define CPP2_IMPORT_STD          Yes
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "pure2-function-typeids.cpp2"
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-function-typeids.cpp2"
+
+//  --- Scaffolding
+
+#line 4 "pure2-function-typeids.cpp2"
+auto f() -> void;
+
+auto g_in(      cpp2::impl::in<std::string> s) -> void;
+auto g_inout(std::string& s) -> void;
+auto g_out(cpp2::impl::out<std::string> s) -> void;
+auto g_move(std::string&& s) -> void;
+
+[[nodiscard]] auto h_out(cpp2::impl::in<std::string> s) -> std::string;
+[[nodiscard]] auto h_forward(std::string& s) -> std::string&;
+
+#line 15 "pure2-function-typeids.cpp2"
+auto main() -> int;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-function-typeids.cpp2"
+
+#line 4 "pure2-function-typeids.cpp2"
+auto f() -> void { std::cout << "hello world!\n";  }
+
+#line 6 "pure2-function-typeids.cpp2"
+auto g_in(      cpp2::impl::in<std::string> s) -> void { std::cout << "Come in, " + cpp2::to_string(s) + "\n"; }
+#line 7 "pure2-function-typeids.cpp2"
+auto g_inout(std::string& s) -> void { std::cout << "Come in awhile, but take some biscuits on your way out, " + cpp2::to_string(s) + "!\n";  }
+#line 8 "pure2-function-typeids.cpp2"
+auto g_out(cpp2::impl::out<std::string> s) -> void { s.construct("Gandalf"); }
+#line 9 "pure2-function-typeids.cpp2"
+auto g_move(std::string&& s) -> void { std::cout << "I hear you've moving, " + cpp2::to_string(cpp2::move(s)) + "?\n"; }
+
+#line 11 "pure2-function-typeids.cpp2"
+[[nodiscard]] auto h_out(cpp2::impl::in<std::string> s) -> std::string{std::cout << "In " + cpp2::to_string(s) + " ... ";return "yohoho"; }
+#line 12 "pure2-function-typeids.cpp2"
+[[nodiscard]] auto h_forward(std::string& s) -> std::string&{std::cout << "Inout " + cpp2::to_string(s) + " ... "; return s; }
+
+#line 15 "pure2-function-typeids.cpp2"
+auto main() -> int
+{
+    //  --- Test basic/degenerate cases
+
+    //  Ordinary pointer to function, deduced (always worked)
+    auto pf {&f}; 
+    cpp2::move(pf)();
+
+    //  Test std::function< void() >
+    std::function<void()> ff {&f}; 
+    cpp2::move(ff)();
+
+#line 28 "pure2-function-typeids.cpp2"
+    //  --- Tests for parameters
+    //      Note: Not forward parameters which imply a template...
+    //            function type-ids are for single function signatures
+
+    std::function<void(std::string& s)> fg_in {&g_in}; 
+    std::function<void(std::string& s)> fg_inout {&g_inout}; 
+    std::function<void(cpp2::impl::out<std::string> s)> fg_out {&g_out}; 
+    std::function<void(std::string&& s)> fg_move {&g_move}; 
+
+    std::string frodo {"Frodo"}; 
+
+    //  Test in param
+    cpp2::move(fg_in)(frodo);
+
+    //  Test inout
+    cpp2::move(fg_inout)(frodo);
+
+    //  Test out
+    cpp2::impl::deferred_init<std::string> gandalf; 
+    cpp2::move(fg_out)(cpp2::impl::out(&gandalf));
+    std::cout << "fg_out initialized the arg to: " + cpp2::to_string(gandalf.value()) + "\n";
+
+    //  Test move
+    cpp2::move(fg_move)(cpp2::move(frodo));// last use, so (move frodo) is not required
+
+#line 54 "pure2-function-typeids.cpp2"
+    //  --- Tests for single anonymous returns
+    //      Note: Not multiple named return values... function-type-ids 
+    //      are for Cpp1-style (single anonymous, possibly void) returns
+
+    std::function<std::string(cpp2::impl::in<std::string> s)> fh_out {&h_out}; 
+    std::function<std::string&(std::string& s)> fh_forward {&h_forward}; 
+
+    //  Test out return
+    std::cout << "fh_out returned: " + cpp2::to_string(cpp2::move(fh_out)(gandalf.value())) + "\n";
+
+    //  Test forward return
+    std::cout << "fh_forward returned: " + cpp2::to_string(cpp2::move(fh_forward)(gandalf.value())) + "\n";
+
+    static_cast<void>(cpp2::move(gandalf.value()));
+}
+

--- a/regression-tests/test-results/pure2-function-typeids.cpp
+++ b/regression-tests/test-results/pure2-function-typeids.cpp
@@ -23,8 +23,8 @@ auto g_inout(std::string& s) -> void;
 auto g_out(cpp2::impl::out<std::string> s) -> void;
 auto g_move(std::string&& s) -> void;
 
-[[nodiscard]] auto h_out(cpp2::impl::in<std::string> s) -> std::string;
 [[nodiscard]] auto h_forward(std::string& s) -> std::string&;
+[[nodiscard]] auto h_out(cpp2::impl::in<std::string> s) -> std::string;
 
 #line 15 "pure2-function-typeids.cpp2"
 auto main() -> int;
@@ -41,68 +41,83 @@ auto g_in(      cpp2::impl::in<std::string> s) -> void { std::cout << "Come in, 
 #line 7 "pure2-function-typeids.cpp2"
 auto g_inout(std::string& s) -> void { std::cout << "Come in awhile, but take some biscuits on your way out, " + cpp2::to_string(s) + "!\n";  }
 #line 8 "pure2-function-typeids.cpp2"
-auto g_out(cpp2::impl::out<std::string> s) -> void { s.construct("Gandalf"); }
+auto g_out(cpp2::impl::out<std::string> s) -> void { s.construct("A Powerful Mage"); }
 #line 9 "pure2-function-typeids.cpp2"
 auto g_move(std::string&& s) -> void { std::cout << "I hear you've moving, " + cpp2::to_string(cpp2::move(s)) + "?\n"; }
 
 #line 11 "pure2-function-typeids.cpp2"
-[[nodiscard]] auto h_out(cpp2::impl::in<std::string> s) -> std::string{std::cout << "In " + cpp2::to_string(s) + " ... ";return "yohoho"; }
-#line 12 "pure2-function-typeids.cpp2"
 [[nodiscard]] auto h_forward(std::string& s) -> std::string&{std::cout << "Inout " + cpp2::to_string(s) + " ... "; return s; }
+#line 12 "pure2-function-typeids.cpp2"
+[[nodiscard]] auto h_out(cpp2::impl::in<std::string> s) -> std::string{std::cout << "In " + cpp2::to_string(s) + " ... ";return "yohoho"; }
 
 #line 15 "pure2-function-typeids.cpp2"
 auto main() -> int
 {
     //  --- Test basic/degenerate cases
 
-    //  Ordinary pointer to function, deduced (always worked)
-    auto pf {&f}; 
-    cpp2::move(pf)();
-
     //  Test std::function< void() >
     std::function<void()> ff {&f}; 
     cpp2::move(ff)();
+
+    //  Ordinary pointer to function, deduced (always worked)
+    void(*pf)()  = &f; 
+    cpp2::move(pf)();
 
 #line 28 "pure2-function-typeids.cpp2"
     //  --- Tests for parameters
     //      Note: Not forward parameters which imply a template...
     //            function type-ids are for single function signatures
 
-    std::function<void(std::string& s)> fg_in {&g_in}; 
+    std::function<void(cpp2::impl::in<std::string> s)> fg_in {&g_in}; 
     std::function<void(std::string& s)> fg_inout {&g_inout}; 
     std::function<void(cpp2::impl::out<std::string> s)> fg_out {&g_out}; 
     std::function<void(std::string&& s)> fg_move {&g_move}; 
+    void(*pg_in)(cpp2::impl::in<    std::string> s)  = &g_in; 
+    void(*pg_inout)(          std::string& s)  = &g_inout; 
+    void(*pg_out)(cpp2::impl::out<std::string> s)  = &g_out; 
+    void(*pg_move)(           std::string&& s)  = &g_move; 
 
     std::string frodo {"Frodo"}; 
+    std::string sam {"Sam"}; 
 
     //  Test in param
     cpp2::move(fg_in)(frodo);
+    cpp2::move(pg_in)(sam);
 
     //  Test inout
     cpp2::move(fg_inout)(frodo);
+    cpp2::move(pg_inout)(sam);
 
     //  Test out
     cpp2::impl::deferred_init<std::string> gandalf; 
+    cpp2::impl::deferred_init<std::string> galadriel; 
     cpp2::move(fg_out)(cpp2::impl::out(&gandalf));
-    std::cout << "fg_out initialized the arg to: " + cpp2::to_string(gandalf.value()) + "\n";
+    std::cout << "fg_out initialized gandalf to: " + cpp2::to_string(gandalf.value()) + "\n";
+    cpp2::move(pg_out)(cpp2::impl::out(&galadriel));
+    std::cout << "pg_out initialized galadriel to: " + cpp2::to_string(galadriel.value()) + "\n";
+    gandalf.value() = "Gandalf";
+    galadriel.value() = "Galadriel";
 
     //  Test move
     cpp2::move(fg_move)(cpp2::move(frodo));// last use, so (move frodo) is not required
+    cpp2::move(pg_move)(cpp2::move(sam));// last use, so (move sam) is not required
 
-#line 54 "pure2-function-typeids.cpp2"
+#line 67 "pure2-function-typeids.cpp2"
     //  --- Tests for single anonymous returns
     //      Note: Not multiple named return values... function-type-ids 
     //      are for Cpp1-style (single anonymous, possibly void) returns
 
-    std::function<std::string(cpp2::impl::in<std::string> s)> fh_out {&h_out}; 
     std::function<std::string&(std::string& s)> fh_forward {&h_forward}; 
-
-    //  Test out return
-    std::cout << "fh_out returned: " + cpp2::to_string(cpp2::move(fh_out)(gandalf.value())) + "\n";
+    std::function<std::string(cpp2::impl::in<std::string> s)> fh_out {&h_out}; 
+    std::string&(*ph_forward)(  std::string& s)  = &h_forward; 
+    std::string(*ph_out)(cpp2::impl::in<std::string> s)  = &h_out; 
 
     //  Test forward return
     std::cout << "fh_forward returned: " + cpp2::to_string(cpp2::move(fh_forward)(gandalf.value())) + "\n";
+    std::cout << "ph_forward returned: " + cpp2::to_string(cpp2::move(ph_forward)(galadriel.value())) + "\n";
 
-    static_cast<void>(cpp2::move(gandalf.value()));
+    //  Test out return
+    std::cout << "fh_out returned: " + cpp2::to_string(cpp2::move(fh_out)(cpp2::move(gandalf.value()))) + "\n";
+    std::cout << "ph_out returned: " + cpp2::to_string(cpp2::move(ph_out)(cpp2::move(galadriel.value()))) + "\n";
 }
 

--- a/regression-tests/test-results/pure2-function-typeids.cpp
+++ b/regression-tests/test-results/pure2-function-typeids.cpp
@@ -26,7 +26,11 @@ auto g_move(std::string&& s) -> void;
 [[nodiscard]] auto h_forward(std::string& s) -> std::string&;
 [[nodiscard]] auto h_out(cpp2::impl::in<std::string> s) -> std::string;
 
-#line 15 "pure2-function-typeids.cpp2"
+[[nodiscard]] auto f1(cpp2::impl::in<std::function<int(cpp2::impl::in<int> x)>> a) -> int;
+[[nodiscard]] auto f2(int(*a)(cpp2::impl::in<int> x)) -> int;
+[[nodiscard]] auto g   (cpp2::impl::in<int> x) -> int;
+
+#line 19 "pure2-function-typeids.cpp2"
 auto main() -> int;
 
 //=== Cpp2 function definitions =================================================
@@ -50,7 +54,14 @@ auto g_move(std::string&& s) -> void { std::cout << "I hear you've moving, " + c
 #line 12 "pure2-function-typeids.cpp2"
 [[nodiscard]] auto h_out(cpp2::impl::in<std::string> s) -> std::string{std::cout << "In " + cpp2::to_string(s) + " ... ";return "yohoho"; }
 
+#line 14 "pure2-function-typeids.cpp2"
+[[nodiscard]] auto f1(cpp2::impl::in<std::function<int(cpp2::impl::in<int> x)>> a) -> int { return a(1);  }
 #line 15 "pure2-function-typeids.cpp2"
+[[nodiscard]] auto f2(int(*a)(cpp2::impl::in<int> x)) -> int { return a(2); }
+#line 16 "pure2-function-typeids.cpp2"
+[[nodiscard]] auto g   (cpp2::impl::in<int> x) -> int { return x + 42; }
+
+#line 19 "pure2-function-typeids.cpp2"
 auto main() -> int
 {
     //  --- Test basic/degenerate cases
@@ -63,7 +74,7 @@ auto main() -> int
     void(*pf)()  = &f; 
     cpp2::move(pf)();
 
-#line 28 "pure2-function-typeids.cpp2"
+#line 32 "pure2-function-typeids.cpp2"
     //  --- Tests for parameters
     //      Note: Not forward parameters which imply a template...
     //            function type-ids are for single function signatures
@@ -102,7 +113,7 @@ auto main() -> int
     cpp2::move(fg_move)(cpp2::move(frodo));// last use, so (move frodo) is not required
     cpp2::move(pg_move)(cpp2::move(sam));// last use, so (move sam) is not required
 
-#line 67 "pure2-function-typeids.cpp2"
+#line 71 "pure2-function-typeids.cpp2"
     //  --- Tests for single anonymous returns
     //      Note: Not multiple named return values... function-type-ids 
     //      are for Cpp1-style (single anonymous, possibly void) returns
@@ -119,5 +130,10 @@ auto main() -> int
     //  Test out return
     std::cout << "fh_out returned: " + cpp2::to_string(cpp2::move(fh_out)(cpp2::move(gandalf.value()))) + "\n";
     std::cout << "ph_out returned: " + cpp2::to_string(cpp2::move(ph_out)(cpp2::move(galadriel.value()))) + "\n";
+
+#line 89 "pure2-function-typeids.cpp2"
+    //  --- Tests for function parameters
+    std::cout << "" + cpp2::to_string(f1(&g)) + "\n";
+    std::cout << "" + cpp2::to_string(f2(&g)) + "\n";
 }
 

--- a/regression-tests/test-results/pure2-function-typeids.cpp2.output
+++ b/regression-tests/test-results/pure2-function-typeids.cpp2.output
@@ -1,0 +1,2 @@
+pure2-function-typeids.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/source/parse.h
+++ b/source/parse.h
@@ -1332,10 +1332,10 @@ struct type_id_node
     source_position pos;
 
     std::vector<token const*> pc_qualifiers;
-    token const* address_of                 = {};
-    token const* dereference_of             = {};
-    int dereference_cnt                     = {};
-    token const* suspicious_initialization  = {};
+    token const*              address_of                = {};
+    token const*              dereference_of            = {};
+    int                       dereference_cnt           = {};
+    token const*              suspicious_initialization = {};
 
     enum active { empty=0, qualified, unqualified, function, keyword };
     std::variant<

--- a/source/parse.h
+++ b/source/parse.h
@@ -9185,7 +9185,7 @@ private:
         //  Type alias
         if (*a->type == "type")
         {
-            auto t = type_id();
+            auto t = type_id(false, false, true);
             if (!t) {
                 errors.emplace_back(
                     curr().position(),

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -4434,7 +4434,8 @@ public:
         //-----------------------------------------------------------------------
         //  Else handle ordinary parameters
 
-        auto param_type = print_to_string(type_id);
+        assert(n.declaration->identifier);
+        auto param_type = print_to_string(type_id, source_position{}, print_to_string(*n.declaration->identifier));
 
         //  If there are template parameters on this function or its enclosing
         //  type, see if this parameter's name is an unqualified-id with a
@@ -4612,7 +4613,7 @@ public:
         if (is_returns) {
             printer.print_extra( " " + identifier );
         }
-        else {
+        else if (!n.declaration->is_object_with_function_typeid()) {
             printer.print_cpp2( " ", identifier_pos );
             if (n.declaration->is_variadic)
             {


### PR DESCRIPTION
Closes #1177 and closes #526 (previous efforts to implement this feature that I wasn't able to get working)

Closes #343 
Closes #711
Closes #718

The initial commit in this branch should generally support std::function<> style uses

Aside: I'm happy to find that C++ allows parameter names in function types, thank you WG21! I hadn't seen those used in examples so I had been expecting that cppfront would have to suppress those, but `std::function< int ( std::string& param_name ) >` is legal code. Sweet.

The first commit in this branch does not yet support pointer-to-function local variables...