### PR TITLE
[CI] Fix clang-18 C++23 build of cppfront

### DIFF
--- a/source/parse.h
+++ b/source/parse.h
@@ -2273,7 +2273,9 @@ struct parameter_declaration_node
 
     std::unique_ptr<declaration_node> declaration;
 
-    parameter_declaration_node(parameter_declaration_list_node const* my) : my_list{my} { }
+    // Out-of-line definition of the ctor is necessary due to the forward-declared
+    // type(s) used in a std::unique_ptr as a member
+    parameter_declaration_node(parameter_declaration_list_node const* my);
 
     //  API
     //
@@ -4512,7 +4514,11 @@ struct translation_unit_node
     }
 };
 
-// Definitions of out-of-line dtors for nodes with unique_ptr members of forward-declared types
+// Definitions of out-of-line ctors & dtors for nodes with unique_ptr members of forward-declared types
+
+parameter_declaration_node::parameter_declaration_node(parameter_declaration_list_node const* my)
+    : my_list{my}
+{ }
 
 type_id_node::~type_id_node() = default;
 

--- a/source/parse.h
+++ b/source/parse.h
@@ -2861,6 +2861,10 @@ struct declaration_node
         : parent_declaration{parent}
     { }
 
+    // Out-of-line definition of the dtor is necessary due to the forward-declared
+    // type(s) used in a std::unique_ptr as a member
+    ~declaration_node();
+
     //  API
     //
 
@@ -4541,6 +4545,8 @@ template_argument::~template_argument() = default;
 inspect_expression_node::~inspect_expression_node() = default;
 
 statement_node::~statement_node() = default;
+
+declaration_node::~declaration_node() = default;
 
 
 //-----------------------------------------------------------------------

--- a/source/parse.h
+++ b/source/parse.h
@@ -2277,6 +2277,10 @@ struct parameter_declaration_node
     // type(s) used in a std::unique_ptr as a member
     parameter_declaration_node(parameter_declaration_list_node const* my);
 
+    // Out-of-line definition of the dtor is necessary due to the forward-declared
+    // type(s) used in a std::unique_ptr as a member
+    ~parameter_declaration_node();
+
     //  API
     //
     auto has_name() const
@@ -4523,6 +4527,8 @@ struct translation_unit_node
 parameter_declaration_node::parameter_declaration_node(parameter_declaration_list_node const* my)
     : my_list{my}
 { }
+
+parameter_declaration_node::~parameter_declaration_node() = default;
 
 type_id_node::~type_id_node() = default;
 


### PR DESCRIPTION
Some constructors and destructors have to be defaulted/written out-of-line in order to compile successfully with clang 18 in C++23 mode, due to forward declaring types and using them with `unique_ptr`.

Fixes [this build error](https://github.com/hsutter/cppfront/actions/runs/10153992510/job/28078384021).

Similar issue as solved by this previous PR: https://github.com/hsutter/cppfront/pull/1088

EDIT: This only fixes the CI build of cppfront; I'll create a separate PR to update the regression tests.