### PR TITLE
[CI] Update regression tests after recent changes

### DIFF
--- a/regression-tests/test-results/apple-clang-14-c++2b/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/pure2-function-typeids.cpp.execution
@@ -1,0 +1,17 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in, Sam
+Come in awhile, but take some biscuits on your way out, Frodo!
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
+I hear you've moving, Frodo?
+I hear you've moving, Sam?
+Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/clang-15-c++20-libcpp/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/pure2-function-typeids.cpp.execution
@@ -1,0 +1,17 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in, Sam
+Come in awhile, but take some biscuits on your way out, Frodo!
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
+I hear you've moving, Frodo?
+I hear you've moving, Sam?
+Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/clang-15-c++20/mixed-bounds-check.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-bounds-check.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(883) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]
+../../../include/cpp2util.h(937) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]

--- a/regression-tests/test-results/clang-15-c++20/mixed-bounds-safety-with-assert.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-bounds-safety-with-assert.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(744) : Bounds safety violation
+../../../include/cpp2util.h(749) : Bounds safety violation

--- a/regression-tests/test-results/clang-15-c++20/mixed-initialization-safety-3-contract-violation.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-initialization-safety-3-contract-violation.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(744) : Contract violation: fill: value must contain at least count elements
+../../../include/cpp2util.h(749) : Contract violation: fill: value must contain at least count elements

--- a/regression-tests/test-results/clang-15-c++20/mixed-lifetime-safety-and-null-contracts.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-lifetime-safety-and-null-contracts.cpp.execution
@@ -1,2 +1,2 @@
 sending error to my framework... [dynamic null dereference attempt detected]
-from source location: ../../../include/cpp2util.h(823) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]
+from source location: ../../../include/cpp2util.h(828) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-optional-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-optional-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(823) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value
+../../../include/cpp2util.h(828) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-shared-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-shared-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(823) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty
+../../../include/cpp2util.h(828) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-unique-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-unique-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(823) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int> &]: Null safety violation: std::unique_ptr is empty
+../../../include/cpp2util.h(828) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int> &]: Null safety violation: std::unique_ptr is empty

--- a/regression-tests/test-results/clang-15-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-function-typeids.cpp.execution
@@ -1,0 +1,17 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in, Sam
+Come in awhile, but take some biscuits on your way out, Frodo!
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
+I hear you've moving, Frodo?
+I hear you've moving, Sam?
+Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/clang-18-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++20/pure2-function-typeids.cpp.execution
@@ -1,0 +1,17 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in, Sam
+Come in awhile, but take some biscuits on your way out, Frodo!
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
+I hear you've moving, Frodo?
+I hear you've moving, Sam?
+Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-bounds-safety-with-assert.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-bounds-safety-with-assert.cpp.execution
@@ -1,1 +1,1 @@
-mixed-bounds-safety-with-assert.cpp2(11) void print_subrange(const auto:261&, cpp2::impl::in<int>, cpp2::impl::in<int>) [with auto:261 = std::vector<int>; cpp2::impl::in<int> = const int]: Bounds safety violation
+mixed-bounds-safety-with-assert.cpp2(11) void print_subrange(const auto:263&, cpp2::impl::in<int>, cpp2::impl::in<int>) [with auto:263 = std::vector<int>; cpp2::impl::in<int> = const int]: Bounds safety violation

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | constexpr auto is( std::optional<U> const& x ) -> bool
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 | //
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | constexpr auto is( std::optional<U> const& x ) -> bool
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 | //
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | constexpr auto is( std::optional<U> const& x ) -> bool
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 | //
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | constexpr auto is( std::optional<U> const& x ) -> bool
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 | //
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | class finally_success
+ 2100 | constexpr auto is( std::optional<U> const& x ) -> bool
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 |     finally(finally&& that) noexcept
+ 2137 | //
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/gcc-13-c++2b/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/pure2-function-typeids.cpp.execution
@@ -1,0 +1,17 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in, Sam
+Come in awhile, but take some biscuits on your way out, Frodo!
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
+I hear you've moving, Frodo?
+I hear you've moving, Sam?
+Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
@@ -6,7 +6,7 @@ pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' b
 pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(9): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(9): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-D:\a\cppfront\cppfront\include\cpp2util.h(823): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
+D:\a\cppfront\cppfront\include\cpp2util.h(828): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
 pure2-assert-expected-not-null.cpp2(14): error C2039: 'expected': is not a member of 'std'
 predefined C++ types (compiler internal)(347): note: see declaration of 'std'
 pure2-assert-expected-not-null.cpp2(14): error C2062: type 'int' unexpected
@@ -19,4 +19,4 @@ pure2-assert-expected-not-null.cpp2(14): note: while trying to match the argumen
 pure2-assert-expected-not-null.cpp2(14): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(15): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(15): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-D:\a\cppfront\cppfront\include\cpp2util.h(823): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
+D:\a\cppfront\cppfront\include\cpp2util.h(828): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-function-typeids.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-function-typeids.cpp.execution
@@ -1,0 +1,17 @@
+hello world!
+hello world!
+Come in, Frodo
+Come in, Sam
+Come in awhile, but take some biscuits on your way out, Frodo!
+Come in awhile, but take some biscuits on your way out, Sam!
+fg_out initialized gandalf to: A Powerful Mage
+pg_out initialized galadriel to: A Powerful Mage
+I hear you've moving, Frodo?
+I hear you've moving, Sam?
+Inout Gandalf ... fh_forward returned: Gandalf
+Inout Galadriel ... ph_forward returned: Galadriel
+Inout Galadriel ... ph_forward2 returned: Galadriel
+In Gandalf ... fh_out returned: yohoho
+In Galadriel ... ph_out returned: yohoho
+43
+44

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-function-typeids.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-function-typeids.cpp.output
@@ -1,0 +1,1 @@
+pure2-function-typeids.cpp


### PR DESCRIPTION
Update regression tests for various platforms.

The remaining errors will be fixed by PR https://github.com/hsutter/cppfront/pull/1187 so it's probably best to merge that first.