### PR TITLE
Fix some `int` to `size_t` conversion warnings in `cpp2regex.h2`

### DIFF
--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -2229,9 +2229,9 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
 #line 735 "cpp2regex.h2"
     [[nodiscard]] auto parse_context::grab_n(cpp2::impl::in<int> n, cpp2::impl::out<std::string> r) & -> bool
     {
-        if (cpp2::impl::cmp_less_eq(pos + n,regex.size())) {
-            r.construct(regex.substr(pos, n));
-            pos += n - 1;
+        if (cpp2::impl::cmp_less_eq(pos + cpp2::impl::as_<size_t>(n),regex.size())) {
+            r.construct(regex.substr(pos, cpp2::impl::as_<size_t>(n)));
+            pos += (cpp2::impl::as_<size_t>(n)) - 1;
             return true; 
         }
         else {
@@ -2412,7 +2412,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
 
 #line 920 "cpp2regex.h2"
     auto generation_function_context::remove_tabs(cpp2::impl::in<int> c) & -> void{
-        tabs = tabs.substr(0, c * 2);
+        tabs = tabs.substr(0, (cpp2::impl::as_<size_t>(c)) * 2);
     }
 
     generation_function_context::generation_function_context(auto const& code_, auto const& tabs_)

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -734,9 +734,9 @@ parse_context: type =
 
     grab_n: (inout this, in n: int, out r: std::string) -> bool = 
     {
-        if pos + n <= regex..size() {
-            r = regex..substr(pos, n);
-            pos += n - 1;
+        if pos + n as size_t <= regex..size() {
+            r = regex..substr(pos, n as size_t);
+            pos += (n as size_t) - 1;
             return true;
         }
         else {
@@ -918,7 +918,7 @@ generation_function_context: @struct type = {
     }
 
     remove_tabs: (inout this, c: int) = {
-        tabs = tabs..substr(0, c * 2);
+        tabs = tabs..substr(0, (c as size_t) * 2);
     }
 }
 


### PR DESCRIPTION
There are some conversion warnings emitted by clang when building the lowered C++ produced by cppfront that originate in the new `cpp2regex` header. See this [repro](https://cpp2.godbolt.org/z/ev1jrP7x9).

```
cpp2regex.h2:737:43: warning: implicit conversion changes signedness: 'cpp2::impl::in<int>' (aka 'const int') to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
  737 |         if (cpp2::impl::cmp_less_eq(pos + n,regex.size())) {
      |                                         ~ ^
cpp2regex.h2:738:43: warning: implicit conversion changes signedness: 'cpp2::impl::in<int>' (aka 'const int') to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
  738 |             r.construct(regex.substr(pos, n));
      |                               ~~~~~~      ^
cpp2regex.h2:739:22: warning: implicit conversion changes signedness: 'int' to 'size_t' (aka 'unsigned long') [-Wsign-conversion]
  739 |             pos += n - 1;
      |                 ~~ ~~^~~
cpp2regex.h2:921:33: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
  921 |         tabs = tabs.substr(0, c * 2);
      |                     ~~~~~~    ~~^~~
4 warnings generated.
```

This PR adds some `as` casts for those cases. An alternative would be to change the function signatures that currently take `int` to `size_t`, but I assumed it was better to cast to `size_t` only where necessary.

CC @MaxSagebaum 