### PR TITLE
is()/as(): refactor of is() and as() for variant to new design (part 2 of n)

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -784,9 +784,9 @@ auto pointer_eq(T const* a, T const* b) {
 //
 //  A type_find_if for iterating over types in parameter packs
 //
-//  Note: the current implementation is a workaround for clang-12 internal error.
-//  Original implementation does not need type_it and is implemented
-//  using lambda with explicit parameter type list in the following way:
+//  Note: This implementation works around limitations in gcc <12.1,
+//  Clang <13, and MSVC <19.29. Otherwise we could avoid type_it and use
+//  a lambda with an explicit parameter type list like this:
 //
 //    template <typename... Ts, typename F>
 //    constexpr auto type_find_if(F&& fun)
@@ -800,10 +800,8 @@ auto pointer_eq(T const* a, T const* b) {
 //        return found;
 //    }
 //
-//  The workaround is not needed in gcc-12.1+, clang-13+, msvc 19.29+
-//
-//  Note2: the internal if constexpr could have else with static_assert.
-//  Unfortunatelly I cannot make it work on MSVC.
+//  Note: The internal if constexpr could have else with static_assert.
+//  Unfortunately there doesn't seem to be a way to make it work on MSVC.
 //
 //-----------------------------------------------------------------------
 //

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1802,9 +1802,7 @@ constexpr auto is( X const& x ) -> auto {
             }
         }
         return type_find_if(x, [&]<typename It>(It const&) -> bool {
-            if constexpr (It::index < 20) {
-                if (x.index() == It::index) { return std::is_same_v<C, std::variant_alternative_t<It::index, X>>;}
-            }
+            if (x.index() == It::index) { return std::is_same_v<C, std::variant_alternative_t<It::index, X>>;}
             return false;
         }) != std::variant_npos;
     }
@@ -1860,13 +1858,11 @@ inline constexpr auto is( auto const& x, auto&& value ) -> bool
     }
     else if constexpr (specialization_of_template<decltype(x), std::variant> ) {        
         return type_find_if(x, [&]<typename It>(It const&) -> bool {
-            if constexpr (It::index < 20) { // TODO: remove after refactor
-                if (x.index() == It::index) {
-                    if constexpr (valid_predicate<decltype(value), decltype(std::get<It::index>(x))>) {
-                        return value(std::get<It::index>(x));
-                    } else if constexpr ( requires { bool{std::get<It::index>(x) == value}; }  ) {
-                        return std::get<It::index>(x) == value;
-                    }
+            if (x.index() == It::index) {
+                if constexpr (valid_predicate<decltype(value), decltype(std::get<It::index>(x))>) {
+                    return value(std::get<It::index>(x));
+                } else if constexpr ( requires { bool{std::get<It::index>(x) == value}; }  ) {
+                    return std::get<It::index>(x) == value;
                 }
             }
             return false;
@@ -2052,9 +2048,7 @@ auto as(auto&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
     else if constexpr (specialization_of_template<decltype(x), std::variant>) {
         constness_like_t<C, decltype(x)>* ptr = nullptr;
         type_find_if(CPP2_FORWARD(x), [&]<typename It>(It const&) -> bool {
-            if constexpr (It::index < 20) {
-                if constexpr (std::is_same_v< typename It::type, C >) { if (CPP2_FORWARD(x).index() ==  It::index) { ptr = &std::get<It::index>(x); return true; } }; 
-            }
+            if constexpr (std::is_same_v< typename It::type, C >) { if (CPP2_FORWARD(x).index() ==  It::index) { ptr = &std::get<It::index>(x); return true; } }; 
             return false;
         });
         if (!ptr) { Throw( std::bad_variant_access(), "'as' cast failed for 'variant'"); }

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -2050,7 +2050,8 @@ constexpr auto is( X const& x ) -> auto
 }
 
 
-inline constexpr auto is( specialization_of_template<std::variant> auto const& x, auto&& value ) -> bool
+template <specialization_of_template<std::variant> X>
+inline constexpr auto is( X const& x, auto&& value ) -> bool
 {
     return type_find_if(x, [&]<typename It>(It const&) -> bool {
         if (x.index() == It::index) {
@@ -2064,8 +2065,8 @@ inline constexpr auto is( specialization_of_template<std::variant> auto const& x
     }) != std::variant_npos;
 }
 
-template< typename C >
-auto as(specialization_of_template<std::variant> auto&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
+template< typename C, specialization_of_template<std::variant> X >
+auto as(X&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
 {
     constness_like_t<C, decltype(x)>* ptr = nullptr;
     type_find_if(CPP2_FORWARD(x), [&]<typename It>(It const&) -> bool {

--- a/regression-tests/mixed-is-as-value-with-variant.cpp2
+++ b/regression-tests/mixed-is-as-value-with-variant.cpp2
@@ -1,0 +1,112 @@
+auto in(int min, int max) {
+    return [=](int x){ return min <= x && x <= max; };
+}
+
+test: (forward v) = {
+    if v is (42) {
+        std::cout << " 42";
+    }
+    if v is (24) {
+        std::cout << " 24";
+    }
+    if v is (100) {
+        std::cout << " 100";
+    }
+    if v is (-100) {
+        std::cout << " -100";
+    }
+    if v is (314) {
+        std::cout << " 314";
+    }
+    if v is (std::optional<int>(100)) {
+        std::cout << " std::optional<int>(100)";
+    }
+    if v is (std::any(-100)) {
+        std::cout << " std::any(-100)";
+    }
+    if v is (new<int>(1000)) {
+        std::cout << " std::unique_ptr<int>(1000)";
+    }
+    i : int = 314;
+    if v is (i&) {
+        std::cout << " *int(314)";
+    }
+    if v is (in(0,100)) {
+        std::cout << " in(0,100)";
+    }
+    std::cout << "\n---" << std::endl;
+}
+
+my_variant: type == std::variant<std::monostate, int, int, std::optional<int>, std::any, *int, std::unique_ptr<int>>;
+
+main: () -> int = {
+
+    v: std::variant<std::monostate, int, int, std::optional<int>, std::any, *int, std::unique_ptr<int>, my_variant> = ();
+
+    header(1, "std::monostate");
+    v..emplace<0>();
+    test(v);
+
+    header(1, "int(42)");
+    v..emplace<1>(42);
+    test(v);
+
+    header(1, "int(24)");
+    v..emplace<2>(24);
+    test(v);
+
+    header(1, "std::optional<int>(100)");
+    v..emplace<3>(100);
+    test(v);
+
+    header(1, "std::any(-100)");
+    v..emplace<4>(-100);
+    test(v);
+
+    i : int = 314;
+    header(1, "*int(314)");
+    v..emplace<5>(i&);
+    test(v);
+
+    header(1, "std::unique_ptr<int>(1000)");
+    v..emplace<6>(new<int>(1000));
+    test(v);
+
+    header(1, "my_variant(std::monostate)");
+    v..emplace<7>();
+    test(v);
+
+    header(1, "my_variant(int(42))");
+    v..emplace<7>();
+    std::get<7>(v)..emplace<1>(42);
+    test(v);
+
+    header(1, "my_variant(int(24))");
+    v..emplace<7>();
+    std::get<7>(v)..emplace<2>(24);
+    test(v);
+
+    header(1, "my_variant(std::optional<int>(100))");
+    v..emplace<7>();
+    std::get<7>(v)..emplace<3>(100);
+    test(v);
+
+    header(1, "my_variant(std::any(-100))");
+    v..emplace<7>();
+    std::get<7>(v)..emplace<4>(-100);
+    test(v);
+
+    header(1, "my_variant(*int(314))");
+    v..emplace<7>();
+    std::get<7>(v)..emplace<5>(i&);
+    test(v);
+
+    header(1, "my_variant(std::unique_ptr<int>(1000))");
+    v..emplace<7>();
+    std::get<7>(v)..emplace<6>(new<int>(1000));
+    test(v);
+}
+
+header: (lvl : int, msg: std::string) = {
+    std::cout << std::string(lvl, '#') << " " << msg << std::endl;
+}

--- a/regression-tests/mixed-is-as-variant.cpp2
+++ b/regression-tests/mixed-is-as-variant.cpp2
@@ -1,0 +1,91 @@
+test: (forward v) = {
+    std::cout << "v is empty = (v is  void)$" << std::endl;
+    std::cout << "v is std::monostate = (v is std::monostate)$" << std::endl;
+    std::cout << "v is X< 0> = (v is X< 0>)$,\t(v as X< 1>) = " << expect_no_throw(forward v, :(forward v) v as X<0>) << std::endl;
+    std::cout << "v is X< 1> = (v is X< 1>)$,\t(v as X< 1>).to_string() = (expect_no_throw(forward v, :(forward v) -> std::string = { return (v as X< 1>).to_string();}))$" << std::endl;
+    std::cout << "v is X<19> = (v is X<19>)$,\t(v as X<19>).to_string() = (expect_no_throw(forward v, :(forward v) -> std::string = { return (v as X<19>).to_string();}))$" << std::endl;
+    std::cout << "v is X<20> = (v is X<20>)$,\t(v as X<20>) = " << expect_no_throw(forward v, :(forward v) v as X<20>) << std::endl;
+    std::cout << std::endl;
+}
+
+main: () -> int = {
+
+    v: std::variant<std::monostate,
+                    X< 1>, X< 2>, X< 3>, X< 4>, X< 5>, X< 6>, X< 7>, X< 8>, X< 9>, X<10>,
+                    X<11>, X<12>, X<13>, X<14>, X<15>, X<16>, X<17>, X<18>, X<19>, X<20> > = ();
+
+    header(1, "std::monostate");
+    v..emplace<0>();
+    run_tests(v);
+
+    header(1, "X<1>");
+    v..emplace<1>();
+    run_tests(v);
+
+    header(1, "X<19>");
+    v..emplace<19>();
+    run_tests(v);
+
+    header(1, "X<20>");
+    v..emplace<20>();
+    run_tests(v);
+
+    header(1, "X<10>(std::exception)");
+    set_to_valueless_by_exception<10>(v);
+    run_tests(v);
+
+}
+
+run_tests: (forward v) = {
+    header(2, "v as lvalue reference");
+    test(v);
+
+    header(2, "v as const lvalue reference");
+    test(std::as_const(v));
+
+    header(2, "v as rvalue reference");
+    test(move v);
+}
+
+header: (lvl : int, msg: std::string) = {
+    std::cout << std::string(lvl, '#') << " " << msg << "\n" << std::endl;
+}
+
+template<int I>
+struct X { 
+    operator int() const { return I; } 
+    X() = default;
+    X(std::exception const& e) { throw e; }
+    auto to_string() const { return "X<" + std::to_string(I) + ">"; }
+};
+
+template <std::size_t I>
+void set_to_valueless_by_exception(auto& v) try {
+    v.template emplace<I>(std::runtime_error("make valueless"));
+} catch (...) {}
+
+auto expect_no_throw(auto&& l) -> std::string try {
+    if constexpr ( requires { { l() } -> std::convertible_to<std::string>; }) {
+        return l();
+    } else {
+        l();
+        return "works!";
+    }
+} catch (std::exception const& e) {
+    return e.what();
+} catch (...) {
+    return "unknow exception!";
+}
+
+auto expect_no_throw(auto&& v, auto&& l) -> std::string try {
+    if constexpr ( requires { { l(v) } -> std::convertible_to<std::string>; }) {
+        return l(v);
+    } else {
+        l(v);
+        return "works!";
+    }
+} catch (std::exception const& e) {
+    return e.what();
+} catch (...) {
+    return "unknow exception!";
+}

--- a/regression-tests/mixed-is-as-variant.cpp2
+++ b/regression-tests/mixed-is-as-variant.cpp2
@@ -74,7 +74,7 @@ auto expect_no_throw(auto&& l) -> std::string try {
 } catch (std::exception const& e) {
     return e.what();
 } catch (...) {
-    return "unknow exception!";
+    return "unknown exception!";
 }
 
 auto expect_no_throw(auto&& v, auto&& l) -> std::string try {
@@ -87,5 +87,5 @@ auto expect_no_throw(auto&& v, auto&& l) -> std::string try {
 } catch (std::exception const& e) {
     return e.what();
 } catch (...) {
-    return "unknow exception!";
+    return "unknown exception!";
 }

--- a/regression-tests/test-results/apple-clang-14-c++2b/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/apple-clang-14-c++2b/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/mixed-is-as-variant.cpp.execution
@@ -94,7 +94,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
@@ -103,7 +103,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
@@ -112,7 +112,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 

--- a/regression-tests/test-results/apple-clang-14-c++2b/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-check.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-check.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1007) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]
+../../../include/cpp2util.h(1103) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-safety-with-assert.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-safety-with-assert.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(819) : Bounds safety violation
+../../../include/cpp2util.h(915) : Bounds safety violation

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-initialization-safety-3-contract-violation.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-initialization-safety-3-contract-violation.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(819) : Contract violation: fill: value must contain at least count elements
+../../../include/cpp2util.h(915) : Contract violation: fill: value must contain at least count elements

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-is-as-variant.cpp.execution
@@ -94,7 +94,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
@@ -103,7 +103,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
@@ -112,7 +112,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-lifetime-safety-and-null-contracts.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-lifetime-safety-and-null-contracts.cpp.execution
@@ -1,2 +1,2 @@
 sending error to my framework... [dynamic null dereference attempt detected]
-from source location: ../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]
+from source location: ../../../include/cpp2util.h(994) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-expected-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-expected-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::expected<int, bool>]: Null safety violation: std::expected has an unexpected value
+../../../include/cpp2util.h(994) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::expected<int, bool>]: Null safety violation: std::expected has an unexpected value

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-optional-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-optional-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value
+../../../include/cpp2util.h(994) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-shared-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-shared-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty
+../../../include/cpp2util.h(994) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-unique-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-unique-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty
+../../../include/cpp2util.h(994) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-default-arguments.cpp.execution
@@ -1,2 +1,4 @@
 calling: 
-012an older compiler
+012
+an older compiler
+1, 1, 66

--- a/regression-tests/test-results/clang-12-c++20/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/clang-12-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/mixed-is-as-variant.cpp.execution
@@ -4,28 +4,28 @@
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<1>
 
@@ -33,28 +33,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<19>
 
@@ -62,28 +62,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<20>
 
@@ -91,55 +91,55 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 
 ## v as lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 

--- a/regression-tests/test-results/clang-12-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/clang-15-c++20-libcpp/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/clang-15-c++20-libcpp/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/mixed-is-as-variant.cpp.execution
@@ -94,7 +94,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
@@ -103,7 +103,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
@@ -112,7 +112,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 

--- a/regression-tests/test-results/clang-15-c++20-libcpp/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/clang-15-c++20/mixed-bounds-check.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-bounds-check.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1007) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]
+../../../include/cpp2util.h(1103) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]

--- a/regression-tests/test-results/clang-15-c++20/mixed-bounds-safety-with-assert.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-bounds-safety-with-assert.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(819) : Bounds safety violation
+../../../include/cpp2util.h(915) : Bounds safety violation

--- a/regression-tests/test-results/clang-15-c++20/mixed-initialization-safety-3-contract-violation.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-initialization-safety-3-contract-violation.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(819) : Contract violation: fill: value must contain at least count elements
+../../../include/cpp2util.h(915) : Contract violation: fill: value must contain at least count elements

--- a/regression-tests/test-results/clang-15-c++20/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/clang-15-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-is-as-variant.cpp.execution
@@ -4,28 +4,28 @@
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<1>
 
@@ -33,28 +33,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<19>
 
@@ -62,28 +62,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<20>
 
@@ -91,55 +91,55 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 
 ## v as lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 

--- a/regression-tests/test-results/clang-15-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/clang-15-c++20/mixed-lifetime-safety-and-null-contracts.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-lifetime-safety-and-null-contracts.cpp.execution
@@ -1,2 +1,2 @@
 sending error to my framework... [dynamic null dereference attempt detected]
-from source location: ../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]
+from source location: ../../../include/cpp2util.h(994) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-optional-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-optional-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value
+../../../include/cpp2util.h(994) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-shared-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-shared-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty
+../../../include/cpp2util.h(994) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-unique-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-unique-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty
+../../../include/cpp2util.h(994) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty

--- a/regression-tests/test-results/clang-15-c++20/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-default-arguments.cpp.execution
@@ -1,2 +1,4 @@
 calling: 
-012an older compiler
+012
+an older compiler
+1, 1, 66

--- a/regression-tests/test-results/clang-18-c++20/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++20/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/clang-18-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++20/mixed-is-as-variant.cpp.execution
@@ -4,28 +4,28 @@
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<1>
 
@@ -33,28 +33,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<19>
 
@@ -62,28 +62,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<20>
 
@@ -91,55 +91,55 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 
 ## v as lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 

--- a/regression-tests/test-results/clang-18-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++20/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/clang-18-c++23-libcpp/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++23-libcpp/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/clang-18-c++23-libcpp/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++23-libcpp/mixed-is-as-variant.cpp.execution
@@ -94,7 +94,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
@@ -103,7 +103,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
@@ -112,7 +112,7 @@ v is std::monostate = false
 v is X< 0> = false,	(v as X< 1>) = bad_variant_access
 v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
 v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 

--- a/regression-tests/test-results/clang-18-c++23-libcpp/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++23-libcpp/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/gcc-10-c++20/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/gcc-10-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/mixed-is-as-variant.cpp.execution
@@ -4,28 +4,28 @@
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<1>
 
@@ -33,28 +33,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<19>
 
@@ -62,28 +62,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<20>
 
@@ -91,55 +91,55 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 
 ## v as lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 

--- a/regression-tests/test-results/gcc-10-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/gcc-10-c++20/pure2-default-arguments.cpp.output
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-default-arguments.cpp.output
@@ -1,66 +1,66 @@
 In file included from pure2-default-arguments.cpp:7:
 ../../../include/cpp2util.h:2086:28: error: local variable ‘obj’ may not appear in this context
- 2086 | auto as( std::variant<Ts...> & x ) -> decltype(auto) {
+ 2086 | template<typename T, typename X>
       |                            ^~~
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
- 2047 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return true; }
-      |                                  ^~~~~~~~~~~
+ 2047 |             return false;
+      |                                  ^          
 ../../../include/cpp2util.h:2086:15: note: in expansion of macro ‘CPP2_FORWARD’
- 2086 | auto as( std::variant<Ts...> & x ) -> decltype(auto) {
+ 2086 | template<typename T, typename X>
       |               ^~~~~~~~~~~~
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
- 2107 |     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
-      |                      ^~~~~~~~~~~~~~~~~~~~~~~~
+ 2107 |     }
+      |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2086:92: error: local variable ‘params’ may not appear in this context
- 2086 | auto as( std::variant<Ts...> & x ) -> decltype(auto) {
+ 2086 | template<typename T, typename X>
       |                                                                                            ^     
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
- 2047 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return true; }
-      |                                  ^~~~~~~~~~~
+ 2047 |             return false;
+      |                                  ^          
 ../../../include/cpp2util.h:2086:79: note: in expansion of macro ‘CPP2_FORWARD’
- 2086 | auto as( std::variant<Ts...> & x ) -> decltype(auto) {
+ 2086 | template<typename T, typename X>
       |                                                                               ^           
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
- 2107 |     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
-      |                      ^~~~~~~~~~~~~~~~~~~~~~~~
+ 2107 |     }
+      |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2087:74: error: local variable ‘obj’ may not appear in this context
- 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 0>(x)), T >) { if (x.index() ==  0) return operator_as<0>(x); }
+ 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
       |                                                                          ^~~
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
- 2047 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return true; }
-      |                                  ^~~~~~~~~~~
+ 2047 |             return false;
+      |                                  ^          
 ../../../include/cpp2util.h:2087:61: note: in expansion of macro ‘CPP2_FORWARD’
- 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 0>(x)), T >) { if (x.index() ==  0) return operator_as<0>(x); }
+ 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
       |                                                             ^~~~~~~~~~~~
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
- 2107 |     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
-      |                      ^~~~~~~~~~~~~~~~~~~~~~~~
+ 2107 |     }
+      |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2087:93: error: local variable ‘params’ may not appear in this context
- 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 0>(x)), T >) { if (x.index() ==  0) return operator_as<0>(x); }
+ 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
       |                                                                                             ^~~~~~
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
- 2047 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return true; }
-      |                                  ^~~~~~~~~~~
+ 2047 |             return false;
+      |                                  ^          
 ../../../include/cpp2util.h:2087:80: note: in expansion of macro ‘CPP2_FORWARD’
- 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 0>(x)), T >) { if (x.index() ==  0) return operator_as<0>(x); }
+ 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
       |                                                                                ^~~~~~~~~~~~
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
- 2107 |     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
-      |                      ^~~~~~~~~~~~~~~~~~~~~~~~
+ 2107 |     }
+      |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 pure2-default-arguments.cpp2:6:61: error: ‘std::source_location’ has not been declared

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-is-as-variant.cpp.execution
@@ -4,28 +4,28 @@
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<1>
 
@@ -33,28 +33,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<19>
 
@@ -62,28 +62,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<20>
 
@@ -91,55 +91,55 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 
 ## v as lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/gcc-13-c++2b/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/pure2-default-arguments.cpp.execution
@@ -1,2 +1,4 @@
 calling: int main(int, char**)
-012an older compiler
+012
+an older compiler
+1, 1, 66

--- a/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | {
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | 
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/gcc-14-c++2b/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/gcc-14-c++2b/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/mixed-is-as-variant.cpp.execution
@@ -4,28 +4,28 @@
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<1>
 
@@ -33,28 +33,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<19>
 
@@ -62,28 +62,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<20>
 
@@ -91,55 +91,55 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 
 ## v as lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
-v is empty = true
+v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 

--- a/regression-tests/test-results/gcc-14-c++2b/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-default-arguments.cpp.execution
@@ -1,4 +1,4 @@
 calling: int main(int, char**)
 012
-a newer compiler
+an older compiler
 1, 1, 66

--- a/regression-tests/test-results/mixed-is-as-value-with-variant.cpp
+++ b/regression-tests/test-results/mixed-is-as-value-with-variant.cpp
@@ -1,0 +1,142 @@
+
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "mixed-is-as-value-with-variant.cpp2"
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "mixed-is-as-value-with-variant.cpp2"
+auto in(int min, int max) {
+    return [=](int x){ return min <= x && x <= max; };
+}
+
+#line 5 "mixed-is-as-value-with-variant.cpp2"
+auto test(auto&& v) -> void;
+
+#line 40 "mixed-is-as-value-with-variant.cpp2"
+using my_variant = std::variant<std::monostate,int,int,std::optional<int>,std::any,int*,std::unique_ptr<int>>;
+
+[[nodiscard]] auto main() -> int;
+
+#line 110 "mixed-is-as-value-with-variant.cpp2"
+auto header(cpp2::impl::in<int> lvl, cpp2::impl::in<std::string> msg) -> void;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "mixed-is-as-value-with-variant.cpp2"
+
+#line 5 "mixed-is-as-value-with-variant.cpp2"
+auto test(auto&& v) -> void{
+    if (cpp2::impl::is(v, (42))) {
+        std::cout << " 42";
+    }
+    if (cpp2::impl::is(v, (24))) {
+        std::cout << " 24";
+    }
+    if (cpp2::impl::is(v, (100))) {
+        std::cout << " 100";
+    }
+    if (cpp2::impl::is(v, (-100))) {
+        std::cout << " -100";
+    }
+    if (cpp2::impl::is(v, (314))) {
+        std::cout << " 314";
+    }
+    if (cpp2::impl::is(v, (std::optional<int>(100)))) {
+        std::cout << " std::optional<int>(100)";
+    }
+    if (cpp2::impl::is(v, (std::any(-100)))) {
+        std::cout << " std::any(-100)";
+    }
+    if (cpp2::impl::is(v, (cpp2_new<int>(1000)))) {
+        std::cout << " std::unique_ptr<int>(1000)";
+    }
+    int i {314}; 
+    if (cpp2::impl::is(v, (&i))) {
+        std::cout << " *int(314)";
+    }
+    if (cpp2::impl::is(CPP2_FORWARD(v), (in(0, 100)))) {
+        std::cout << " in(0,100)";
+    }
+    std::cout << "\n---" << std::endl;
+}
+
+#line 42 "mixed-is-as-value-with-variant.cpp2"
+[[nodiscard]] auto main() -> int{
+
+    std::variant<std::monostate,int,int,std::optional<int>,std::any,int*,std::unique_ptr<int>,my_variant> v {}; 
+
+    header(1, "std::monostate");
+    v.emplace<0>();
+    test(v);
+
+    header(1, "int(42)");
+    v.emplace<1>(42);
+    test(v);
+
+    header(1, "int(24)");
+    v.emplace<2>(24);
+    test(v);
+
+    header(1, "std::optional<int>(100)");
+    v.emplace<3>(100);
+    test(v);
+
+    header(1, "std::any(-100)");
+    v.emplace<4>(-100);
+    test(v);
+
+    int i {314}; 
+    header(1, "*int(314)");
+    v.emplace<5>(&i);
+    test(v);
+
+    header(1, "std::unique_ptr<int>(1000)");
+    v.emplace<6>(cpp2_new<int>(1000));
+    test(v);
+
+    header(1, "my_variant(std::monostate)");
+    v.emplace<7>();
+    test(v);
+
+    header(1, "my_variant(int(42))");
+    v.emplace<7>();
+    std::get<7>(v).emplace<1>(42);
+    test(v);
+
+    header(1, "my_variant(int(24))");
+    v.emplace<7>();
+    std::get<7>(v).emplace<2>(24);
+    test(v);
+
+    header(1, "my_variant(std::optional<int>(100))");
+    v.emplace<7>();
+    std::get<7>(v).emplace<3>(100);
+    test(v);
+
+    header(1, "my_variant(std::any(-100))");
+    v.emplace<7>();
+    std::get<7>(v).emplace<4>(-100);
+    test(v);
+
+    header(1, "my_variant(*int(314))");
+    v.emplace<7>();
+    std::get<7>(v).emplace<5>(&i);
+    test(v);
+
+    header(1, "my_variant(std::unique_ptr<int>(1000))");
+    v.emplace<7>();
+    std::get<7>(v).emplace<6>(cpp2_new<int>(1000));
+    test(cpp2::move(v));
+}
+
+#line 110 "mixed-is-as-value-with-variant.cpp2"
+auto header(cpp2::impl::in<int> lvl, cpp2::impl::in<std::string> msg) -> void{
+    std::cout << std::string(lvl, '#') << " " << msg << std::endl;
+}
+

--- a/regression-tests/test-results/mixed-is-as-value-with-variant.cpp2.output
+++ b/regression-tests/test-results/mixed-is-as-value-with-variant.cpp2.output
@@ -1,0 +1,2 @@
+mixed-is-as-value-with-variant.cpp2... ok (mixed Cpp1/Cpp2, Cpp2 code passes safety checks)
+

--- a/regression-tests/test-results/mixed-is-as-variant.cpp
+++ b/regression-tests/test-results/mixed-is-as-variant.cpp
@@ -46,7 +46,7 @@ auto expect_no_throw(auto&& l) -> std::string try {
 } catch (std::exception const& e) {
     return e.what();
 } catch (...) {
-    return "unknow exception!";
+    return "unknown exception!";
 }
 
 auto expect_no_throw(auto&& v, auto&& l) -> std::string try {
@@ -59,7 +59,7 @@ auto expect_no_throw(auto&& v, auto&& l) -> std::string try {
 } catch (std::exception const& e) {
     return e.what();
 } catch (...) {
-    return "unknow exception!";
+    return "unknown exception!";
 }
 
 

--- a/regression-tests/test-results/mixed-is-as-variant.cpp
+++ b/regression-tests/test-results/mixed-is-as-variant.cpp
@@ -1,0 +1,125 @@
+
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "mixed-is-as-variant.cpp2"
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "mixed-is-as-variant.cpp2"
+auto test(auto&& v) -> void;
+
+#line 11 "mixed-is-as-variant.cpp2"
+[[nodiscard]] auto main() -> int;
+
+#line 39 "mixed-is-as-variant.cpp2"
+auto run_tests(auto&& v) -> void;
+
+#line 50 "mixed-is-as-variant.cpp2"
+auto header(cpp2::impl::in<int> lvl, cpp2::impl::in<std::string> msg) -> void;
+#line 53 "mixed-is-as-variant.cpp2"
+
+template<int I>
+struct X { 
+    operator int() const { return I; } 
+    X() = default;
+    X(std::exception const& e) { throw e; }
+    auto to_string() const { return "X<" + std::to_string(I) + ">"; }
+};
+
+template <std::size_t I>
+void set_to_valueless_by_exception(auto& v) try {
+    v.template emplace<I>(std::runtime_error("make valueless"));
+} catch (...) {}
+
+auto expect_no_throw(auto&& l) -> std::string try {
+    if constexpr ( requires { { l() } -> std::convertible_to<std::string>; }) {
+        return l();
+    } else {
+        l();
+        return "works!";
+    }
+} catch (std::exception const& e) {
+    return e.what();
+} catch (...) {
+    return "unknow exception!";
+}
+
+auto expect_no_throw(auto&& v, auto&& l) -> std::string try {
+    if constexpr ( requires { { l(v) } -> std::convertible_to<std::string>; }) {
+        return l(v);
+    } else {
+        l(v);
+        return "works!";
+    }
+} catch (std::exception const& e) {
+    return e.what();
+} catch (...) {
+    return "unknow exception!";
+}
+
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "mixed-is-as-variant.cpp2"
+auto test(auto&& v) -> void{
+#line 2 "mixed-is-as-variant.cpp2"
+    std::cout << "v is empty = " + cpp2::to_string(cpp2::impl::is<void>(v)) + "" << std::endl;
+    std::cout << "v is std::monostate = " + cpp2::to_string(cpp2::impl::is<std::monostate>(v)) + "" << std::endl;
+    std::cout << "v is X< 0> = " + cpp2::to_string(cpp2::impl::is<X<0>>(v)) + ",\t(v as X< 1>) = " << expect_no_throw(CPP2_FORWARD(v), [](auto&& v) mutable -> auto { return cpp2::impl::as_<X<0>>(CPP2_FORWARD(v));  }) << std::endl;
+    std::cout << "v is X< 1> = " + cpp2::to_string(cpp2::impl::is<X<1>>(v)) + ",\t(v as X< 1>).to_string() = " + cpp2::to_string(expect_no_throw(CPP2_FORWARD(v), [](auto&& v) mutable -> std::string{return CPP2_UFCS(to_string)((cpp2::impl::as_<X<1>>(CPP2_FORWARD(v)))); })) + "" << std::endl;
+    std::cout << "v is X<19> = " + cpp2::to_string(cpp2::impl::is<X<19>>(v)) + ",\t(v as X<19>).to_string() = " + cpp2::to_string(expect_no_throw(CPP2_FORWARD(v), [](auto&& v) mutable -> std::string{return CPP2_UFCS(to_string)((cpp2::impl::as_<X<19>>(CPP2_FORWARD(v)))); })) + "" << std::endl;
+    std::cout << "v is X<20> = " + cpp2::to_string(cpp2::impl::is<X<20>>(v)) + ",\t(v as X<20>) = " << expect_no_throw(CPP2_FORWARD(v), [](auto&& v) mutable -> auto { return cpp2::impl::as_<X<20>>(CPP2_FORWARD(v));  }) << std::endl;
+    std::cout << std::endl;
+}
+
+#line 11 "mixed-is-as-variant.cpp2"
+[[nodiscard]] auto main() -> int{
+
+    std::variant<std::monostate,X<1>,X<2>,X<3>,X<4>,X<5>,X<6>,X<7>,X<8>,X<9>,X<10>,X<11>,X<12>,X<13>,X<14>,X<15>,X<16>,X<17>,X<18>,X<19>,X<20>> v {
+
+                    }; 
+
+    header(1, "std::monostate");
+    CPP2_UFCS_TEMPLATE(emplace<0>)(v);
+    run_tests(v);
+
+    header(1, "X<1>");
+    CPP2_UFCS_TEMPLATE(emplace<1>)(v);
+    run_tests(v);
+
+    header(1, "X<19>");
+    CPP2_UFCS_TEMPLATE(emplace<19>)(v);
+    run_tests(v);
+
+    header(1, "X<20>");
+    CPP2_UFCS_TEMPLATE(emplace<20>)(v);
+    run_tests(v);
+
+    header(1, "X<10>(std::exception)");
+    set_to_valueless_by_exception<10>(v);
+    run_tests(cpp2::move(v));
+
+}
+
+#line 39 "mixed-is-as-variant.cpp2"
+auto run_tests(auto&& v) -> void{
+    header(2, "v as lvalue reference");
+    test(v);
+
+    header(2, "v as const lvalue reference");
+    test(std::as_const(v));
+
+    header(2, "v as rvalue reference");
+    test(std::move(CPP2_FORWARD(v)));
+}
+
+#line 50 "mixed-is-as-variant.cpp2"
+auto header(cpp2::impl::in<int> lvl, cpp2::impl::in<std::string> msg) -> void{
+    std::cout << std::string(lvl, '#') << " " << msg << "\n" << std::endl;
+}
+

--- a/regression-tests/test-results/mixed-is-as-variant.cpp
+++ b/regression-tests/test-results/mixed-is-as-variant.cpp
@@ -70,10 +70,10 @@ auto test(auto&& v) -> void{
 #line 2 "mixed-is-as-variant.cpp2"
     std::cout << "v is empty = " + cpp2::to_string(cpp2::impl::is<void>(v)) + "" << std::endl;
     std::cout << "v is std::monostate = " + cpp2::to_string(cpp2::impl::is<std::monostate>(v)) + "" << std::endl;
-    std::cout << "v is X< 0> = " + cpp2::to_string(cpp2::impl::is<X<0>>(v)) + ",\t(v as X< 1>) = " << expect_no_throw(CPP2_FORWARD(v), [](auto&& v) mutable -> auto { return cpp2::impl::as_<X<0>>(CPP2_FORWARD(v));  }) << std::endl;
-    std::cout << "v is X< 1> = " + cpp2::to_string(cpp2::impl::is<X<1>>(v)) + ",\t(v as X< 1>).to_string() = " + cpp2::to_string(expect_no_throw(CPP2_FORWARD(v), [](auto&& v) mutable -> std::string{return CPP2_UFCS(to_string)((cpp2::impl::as_<X<1>>(CPP2_FORWARD(v)))); })) + "" << std::endl;
-    std::cout << "v is X<19> = " + cpp2::to_string(cpp2::impl::is<X<19>>(v)) + ",\t(v as X<19>).to_string() = " + cpp2::to_string(expect_no_throw(CPP2_FORWARD(v), [](auto&& v) mutable -> std::string{return CPP2_UFCS(to_string)((cpp2::impl::as_<X<19>>(CPP2_FORWARD(v)))); })) + "" << std::endl;
-    std::cout << "v is X<20> = " + cpp2::to_string(cpp2::impl::is<X<20>>(v)) + ",\t(v as X<20>) = " << expect_no_throw(CPP2_FORWARD(v), [](auto&& v) mutable -> auto { return cpp2::impl::as_<X<20>>(CPP2_FORWARD(v));  }) << std::endl;
+    std::cout << "v is X< 0> = " + cpp2::to_string(cpp2::impl::is<X<0>>(v)) + ",\t(v as X< 1>) = " << expect_no_throw(CPP2_FORWARD(v), [](auto&& v) -> auto { return cpp2::impl::as_<X<0>>(CPP2_FORWARD(v));  }) << std::endl;
+    std::cout << "v is X< 1> = " + cpp2::to_string(cpp2::impl::is<X<1>>(v)) + ",\t(v as X< 1>).to_string() = " + cpp2::to_string(expect_no_throw(CPP2_FORWARD(v), [](auto&& v) -> std::string{return CPP2_UFCS(to_string)((cpp2::impl::as_<X<1>>(CPP2_FORWARD(v)))); })) + "" << std::endl;
+    std::cout << "v is X<19> = " + cpp2::to_string(cpp2::impl::is<X<19>>(v)) + ",\t(v as X<19>).to_string() = " + cpp2::to_string(expect_no_throw(CPP2_FORWARD(v), [](auto&& v) -> std::string{return CPP2_UFCS(to_string)((cpp2::impl::as_<X<19>>(CPP2_FORWARD(v)))); })) + "" << std::endl;
+    std::cout << "v is X<20> = " + cpp2::to_string(cpp2::impl::is<X<20>>(v)) + ",\t(v as X<20>) = " << expect_no_throw(CPP2_FORWARD(v), [](auto&& v) -> auto { return cpp2::impl::as_<X<20>>(CPP2_FORWARD(v));  }) << std::endl;
     std::cout << std::endl;
 }
 

--- a/regression-tests/test-results/mixed-is-as-variant.cpp
+++ b/regression-tests/test-results/mixed-is-as-variant.cpp
@@ -85,19 +85,19 @@ auto test(auto&& v) -> void{
                     }; 
 
     header(1, "std::monostate");
-    CPP2_UFCS_TEMPLATE(emplace<0>)(v);
+    v.emplace<0>();
     run_tests(v);
 
     header(1, "X<1>");
-    CPP2_UFCS_TEMPLATE(emplace<1>)(v);
+    v.emplace<1>();
     run_tests(v);
 
     header(1, "X<19>");
-    CPP2_UFCS_TEMPLATE(emplace<19>)(v);
+    v.emplace<19>();
     run_tests(v);
 
     header(1, "X<20>");
-    CPP2_UFCS_TEMPLATE(emplace<20>)(v);
+    v.emplace<20>();
     run_tests(v);
 
     header(1, "X<10>(std::exception)");

--- a/regression-tests/test-results/mixed-is-as-variant.cpp2.output
+++ b/regression-tests/test-results/mixed-is-as-variant.cpp2.output
@@ -1,0 +1,2 @@
+mixed-is-as-variant.cpp2... ok (mixed Cpp1/Cpp2, Cpp2 code passes safety checks)
+

--- a/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-value-with-variant.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-value-with-variant.cpp.output
@@ -1,0 +1,1 @@
+mixed-is-as-value-with-variant.cpp

--- a/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-variant.cpp.execution
@@ -4,28 +4,28 @@
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<1>
 
@@ -33,28 +33,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<19>
 
@@ -62,28 +62,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<20>
 
@@ -91,28 +91,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 
@@ -120,26 +120,26 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = true
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 

--- a/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-variant.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/mixed-is-as-variant.cpp.output
@@ -1,0 +1,1 @@
+mixed-is-as-variant.cpp

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
@@ -6,7 +6,7 @@ pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' b
 pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(9): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(9): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-..\..\..\include\cpp2util.h(898): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
+..\..\..\include\cpp2util.h(994): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
 pure2-assert-expected-not-null.cpp2(14): error C2039: 'expected': is not a member of 'std'
 predefined C++ types (compiler internal)(347): note: see declaration of 'std'
 pure2-assert-expected-not-null.cpp2(14): error C2062: type 'int' unexpected
@@ -19,4 +19,4 @@ pure2-assert-expected-not-null.cpp2(14): note: while trying to match the argumen
 pure2-assert-expected-not-null.cpp2(14): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(15): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(15): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-..\..\..\include\cpp2util.h(898): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
+..\..\..\include\cpp2util.h(994): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-default-arguments.cpp.execution
@@ -1,2 +1,4 @@
 calling: int __cdecl main(const int,char **)
-012a newer compiler
+012
+a newer compiler
+1, 1, 66

--- a/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-value-with-variant.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-value-with-variant.cpp.execution
@@ -1,0 +1,42 @@
+# std::monostate
+
+---
+# int(42)
+ 42 in(0,100)
+---
+# int(24)
+ 24 in(0,100)
+---
+# std::optional<int>(100)
+ 100 std::optional<int>(100)
+---
+# std::any(-100)
+
+---
+# *int(314)
+
+---
+# std::unique_ptr<int>(1000)
+
+---
+# my_variant(std::monostate)
+
+---
+# my_variant(int(42))
+
+---
+# my_variant(int(24))
+
+---
+# my_variant(std::optional<int>(100))
+
+---
+# my_variant(std::any(-100))
+
+---
+# my_variant(*int(314))
+
+---
+# my_variant(std::unique_ptr<int>(1000))
+
+---

--- a/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-value-with-variant.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-value-with-variant.cpp.output
@@ -1,0 +1,1 @@
+mixed-is-as-value-with-variant.cpp

--- a/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-variant.cpp.execution
@@ -4,28 +4,28 @@
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = true
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<1>
 
@@ -33,28 +33,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
 v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<19>
 
@@ -62,28 +62,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
 v is X<19> = true,	(v as X<19>).to_string() = X<19>
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 # X<20>
 
@@ -91,28 +91,28 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as const lvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 ## v as rvalue reference
 
 v is empty = false
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = true,	(v as X<20>) = works!
 
 # X<10>(std::exception)
 
@@ -120,26 +120,26 @@ v is X<20> = false,	(v as X<20>) = bad_variant_access
 
 v is empty = true
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as const lvalue reference
 
 v is empty = true
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 
 ## v as rvalue reference
 
 v is empty = true
 v is std::monostate = false
-v is X< 0> = false,	(v as X< 1>) = bad_variant_access
-v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
-v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
-v is X<20> = false,	(v as X<20>) = bad_variant_access
+v is X< 0> = false,	(v as X< 1>) = bad variant access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad variant access
+v is X<19> = false,	(v as X<19>).to_string() = bad variant access
+v is X<20> = false,	(v as X<20>) = bad variant access
 

--- a/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-variant.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-variant.cpp.execution
@@ -1,0 +1,145 @@
+# std::monostate
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = true
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<1>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = true,	(v as X< 1>).to_string() = X<1>
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<19>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = true,	(v as X<19>).to_string() = X<19>
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<20>
+
+## v as lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = false
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+# X<10>(std::exception)
+
+## v as lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as const lvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+
+## v as rvalue reference
+
+v is empty = true
+v is std::monostate = false
+v is X< 0> = false,	(v as X< 1>) = bad_variant_access
+v is X< 1> = false,	(v as X< 1>).to_string() = bad_variant_access
+v is X<19> = false,	(v as X<19>).to_string() = bad_variant_access
+v is X<20> = false,	(v as X<20>) = bad_variant_access
+

--- a/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-variant.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++latest/mixed-is-as-variant.cpp.output
@@ -1,0 +1,1 @@
+mixed-is-as-variant.cpp


### PR DESCRIPTION
Currently, `is()` and `as()` implementations are done using two redundant approaches - using concepts subsumption rules and using `constexpr if`s.

Thanks to the discussions with @JohelEGP, we moved some of them to the `constexpr if`s. This PR is meant to move all implementations to one version, which will simplify the implementation and make modification of them more manageable.

My intention is not to introduce any functional change - only refactoring.

Unfortunately, I have already found a couple of bugs that were accidentally fixed in a new version. 

Example:
```cpp
v : std::variant<int, int> = (42);
if v is (in(0,100)) {
    std::cout << " in(0,100)"; // this works
}
v.emplace<1>(42);
if v is (in(0,100)) {
    std::cout << " in(0,100)"; // that will not work
}
```

I will minimize these changes and introduce workarounds to keep the old behavior. To ensure there is no functional change introduced. These workarounds will be removed in the upcoming PRs.

This PR introduces extensive tests that will ensure no functional change is introduced, and that will track future changes of `is()` or `as()` implementations.