### PR TITLE
Fix clang conversion warnings in `string_util::split_string_list`

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -389,16 +389,16 @@ auto split_string_list(std::string_view str)
         return std::isalnum(c) || c == '_';
     };
 
-    decltype(str)::size_type pos = 0;
-    while( pos < std::size(str) ) {
+    auto pos = decltype(std::ssize(str)){ 0 };
+    while( pos < std::ssize(str) ) {
         //  Skip non-alnum
-        while (pos < std::size(str) && !is_id_char(str[pos])) {
+        while (pos < std::ssize(str) && !is_id_char(str[pos])) {
             ++pos;
         }
         auto start = pos;
 
         //  Find the end of the current component
-        while (pos < std::size(str) && is_id_char(str[pos])) {
+        while (pos < std::ssize(str) && is_id_char(str[pos])) {
             ++pos;
         }
 

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -389,16 +389,16 @@ auto split_string_list(std::string_view str)
         return std::isalnum(c) || c == '_';
     };
 
-    auto pos = 0;
-    while( pos < std::ssize(str) ) {
+    decltype(str)::size_type pos = 0;
+    while( pos < std::size(str) ) {
         //  Skip non-alnum
-        while (pos < std::ssize(str) && !is_id_char(str[pos])) {
+        while (pos < std::size(str) && !is_id_char(str[pos])) {
             ++pos;
         }
         auto start = pos;
 
         //  Find the end of the current component
-        while (pos < std::ssize(str) && is_id_char(str[pos])) {
+        while (pos < std::size(str) && is_id_char(str[pos])) {
             ++pos;
         }
 


### PR DESCRIPTION
The `string_util::split_string_list` function in `cpp2util.h` causes clang to emit some conversion warnings:

```
warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
  395 |         while (pos < std::ssize(str) && !is_id_char(str[pos])) {
      |                                                     ~~~ ^~~
raw.githubusercontent.com/hsutter/cppfront/main/include/cpp2util.h:401:56: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
  401 |         while (pos < std::ssize(str) && is_id_char(str[pos])) {
      |                                                    ~~~ ^~~
raw.githubusercontent.com/hsutter/cppfront/main/include/cpp2util.h:407:52: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
  407 |             ret.emplace_back(str.substr(start, pos - start));
      |                                  ~~~~~~        ~~~~^~~~~~~
raw.githubusercontent.com/hsutter/cppfront/main/include/cpp2util.h:407:41: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
  407 |             ret.emplace_back(str.substr(start, pos - start));
      |                                  ~~~~~~ ^~~~~
```
[Repro here](https://cpp2.godbolt.org/z/ev1jrP7x9)

This PR fixes those warnings by changing the type of `start` and `pos`.
