### PR TITLE
is()/as(): refactor of is() and as() for std::any and std::optional to new design (part 3 of n)

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -2126,16 +2126,16 @@ constexpr auto as( X && x ) -> decltype(auto) {
 
 //  is Type
 //
-template<typename T, typename X>
-    requires std::is_same_v<X,std::optional<T>>
-constexpr auto is( X const& x ) -> bool
-    { return x.has_value(); }
-
-template<typename T, typename U>
-    requires std::is_same_v<T,empty>
-constexpr auto is( std::optional<U> const& x ) -> bool
-    { return !x.has_value(); }
-
+template<typename T, specialization_of_template<std::optional> X>
+constexpr auto is( X const& x ) -> bool { 
+    if (!x.has_value()) {
+        return std::same_as<T, empty>;
+    }
+    if constexpr (requires { static_cast<const T&>(*x);}) {
+        return true;
+    }
+    return false;
+}
 
 //  is Value
 //
@@ -2143,11 +2143,8 @@ template<typename T>
 constexpr auto is( std::optional<T> const& x, auto&& value ) -> bool
 {
     //  Predicate case
-    if constexpr (requires{ bool{ value(x) }; }) {
+    if constexpr (valid_predicate<decltype(value), decltype(x)>) {
         return value(x);
-    }
-    else if constexpr (std::is_function_v<decltype(value)> || requires{ &value.operator(); }) {
-        return false;
     }
 
     //  Value case
@@ -2160,10 +2157,17 @@ constexpr auto is( std::optional<T> const& x, auto&& value ) -> bool
 
 //  as
 //
-template<typename T, typename X>
-    requires std::is_same_v<X,std::optional<T>>
-constexpr auto as( X const& x ) -> decltype(auto)
-    { return x.value(); }
+template<typename T, specialization_of_template<std::optional> X>
+constexpr auto as( X&& x ) -> decltype(auto) { 
+    constness_like_t<T, X>* ptr = nullptr;
+    if constexpr (requires { static_cast<constness_like_t<T, X>&>(*x); }) {
+        if (x.has_value()) {
+            ptr = &static_cast<constness_like_t<T, X>&>(*x);
+        }
+    }
+    if (!ptr) { Throw( std::bad_optional_access(), "'as' cast failed for 'std::optional'"); }
+    return cpp2::forward_like<X>(*ptr);
+}
 
 
 } // impl

--- a/regression-tests/test-results/gcc-10-c++20/pure2-default-arguments.cpp.output
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-default-arguments.cpp.output
@@ -1,66 +1,66 @@
 In file included from pure2-default-arguments.cpp:7:
 ../../../include/cpp2util.h:2086:28: error: local variable ‘obj’ may not appear in this context
- 2086 | template<typename T, typename X>
+ 2086 | template<typename T, std::same_as<std::any> X>
       |                            ^~~
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
  2047 |             return false;
       |                                  ^          
 ../../../include/cpp2util.h:2086:15: note: in expansion of macro ‘CPP2_FORWARD’
- 2086 | template<typename T, typename X>
+ 2086 | template<typename T, std::same_as<std::any> X>
       |               ^~~~~~~~~~~~
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
  2107 |     }
       |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2086:92: error: local variable ‘params’ may not appear in this context
- 2086 | template<typename T, typename X>
+ 2086 | template<typename T, std::same_as<std::any> X>
       |                                                                                            ^     
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
  2047 |             return false;
       |                                  ^          
 ../../../include/cpp2util.h:2086:79: note: in expansion of macro ‘CPP2_FORWARD’
- 2086 | template<typename T, typename X>
+ 2086 | template<typename T, std::same_as<std::any> X>
       |                                                                               ^           
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
  2107 |     }
       |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2087:74: error: local variable ‘obj’ may not appear in this context
- 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
-      |                                                                          ^~~
+ 2087 | constexpr auto is( X const& x ) -> bool{
+      |                                                                          ^  
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
  2047 |             return false;
       |                                  ^          
 ../../../include/cpp2util.h:2087:61: note: in expansion of macro ‘CPP2_FORWARD’
- 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
-      |                                                             ^~~~~~~~~~~~
+ 2087 | constexpr auto is( X const& x ) -> bool{
+      |                                                             ^           
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
  2107 |     }
       |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2087:93: error: local variable ‘params’ may not appear in this context
- 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
-      |                                                                                             ^~~~~~
+ 2087 | constexpr auto is( X const& x ) -> bool{
+      |                                                                                             ^     
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
  2047 |             return false;
       |                                  ^          
 ../../../include/cpp2util.h:2087:80: note: in expansion of macro ‘CPP2_FORWARD’
- 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
-      |                                                                                ^~~~~~~~~~~~
+ 2087 | constexpr auto is( X const& x ) -> bool{
+      |                                                                                ^           
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
  2107 |     }
       |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 pure2-default-arguments.cpp2:6:61: error: ‘std::source_location’ has not been declared

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid


### PR DESCRIPTION
Aligning implementation of `is()` and `as()` to the rest of the functions.

Keep them as separate functions to make them examples of how to extend `is()`/`as()` with custom-made functions.

This PR is based on #1203