### PR TITLE
Fix: `int` variable casted with as to `size_t` does not fail on compile time - closes #1257

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -741,6 +741,9 @@ concept valid_custom_is_operator = predicate_member_fun<X, F, &F::op_is>
                         || brace_initializable_to<X, argument_of_op_is_t<F>> 
                       );
 
+template <typename T>
+concept arithmetic = std::is_arithmetic_v<std::remove_cvref_t<T>>;
+
 //-----------------------------------------------------------------------
 //
 //  General helpers
@@ -1759,20 +1762,7 @@ inline constexpr auto is( X const& x, bool (*value)(X const&) ) -> bool {
 //  If it's confusing, we can switch this to <From, To>
 
 template< typename To, typename From >
-inline constexpr auto is_narrowing_v =
-    // [dcl.init.list] 7.1
-    (std::is_floating_point_v<From> && std::is_integral_v<To>) ||
-    // [dcl.init.list] 7.2
-    (std::is_floating_point_v<From> && std::is_floating_point_v<To> && sizeof(From) > sizeof(To)) ||
-    // [dcl.init.list] 7.3
-    (std::is_integral_v<From> && std::is_floating_point_v<To>) ||
-    (std::is_enum_v<From> && std::is_floating_point_v<To>) ||
-    // [dcl.init.list] 7.4
-    (std::is_integral_v<From> && std::is_integral_v<To> && sizeof(From) > sizeof(To)) ||
-    (std::is_enum_v<From> && std::is_integral_v<To> && sizeof(From) > sizeof(To)) ||
-    // [dcl.init.list] 7.5
-    (std::is_pointer_v<From> && std::is_same_v<To, bool>)
-    ;
+concept is_narrowing_v = arithmetic<To> && arithmetic<From> && !brace_initializable_to<From,To>;
 
 template< typename To, typename From >
 inline constexpr auto is_unsafe_pointer_conversion_v =

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-check.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-check.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1007) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]
+../../../include/cpp2util.h(1010) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-safety-with-assert.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-safety-with-assert.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(819) : Bounds safety violation
+../../../include/cpp2util.h(822) : Bounds safety violation

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-initialization-safety-3-contract-violation.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-initialization-safety-3-contract-violation.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(819) : Contract violation: fill: value must contain at least count elements
+../../../include/cpp2util.h(822) : Contract violation: fill: value must contain at least count elements

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-lifetime-safety-and-null-contracts.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-lifetime-safety-and-null-contracts.cpp.execution
@@ -1,2 +1,2 @@
 sending error to my framework... [dynamic null dereference attempt detected]
-from source location: ../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]
+from source location: ../../../include/cpp2util.h(901) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-expected-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-expected-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::expected<int, bool>]: Null safety violation: std::expected has an unexpected value
+../../../include/cpp2util.h(901) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::expected<int, bool>]: Null safety violation: std::expected has an unexpected value

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-optional-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-optional-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value
+../../../include/cpp2util.h(901) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-shared-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-shared-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty
+../../../include/cpp2util.h(901) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-unique-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-unique-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty
+../../../include/cpp2util.h(901) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-default-arguments.cpp.execution
@@ -1,2 +1,4 @@
 calling: 
-012an older compiler
+012
+an older compiler
+1, 1, 66

--- a/regression-tests/test-results/clang-15-c++20/mixed-bounds-check.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-bounds-check.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1007) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]
+../../../include/cpp2util.h(1010) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]

--- a/regression-tests/test-results/clang-15-c++20/mixed-bounds-safety-with-assert.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-bounds-safety-with-assert.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(819) : Bounds safety violation
+../../../include/cpp2util.h(822) : Bounds safety violation

--- a/regression-tests/test-results/clang-15-c++20/mixed-initialization-safety-3-contract-violation.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-initialization-safety-3-contract-violation.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(819) : Contract violation: fill: value must contain at least count elements
+../../../include/cpp2util.h(822) : Contract violation: fill: value must contain at least count elements

--- a/regression-tests/test-results/clang-15-c++20/mixed-lifetime-safety-and-null-contracts.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-lifetime-safety-and-null-contracts.cpp.execution
@@ -1,2 +1,2 @@
 sending error to my framework... [dynamic null dereference attempt detected]
-from source location: ../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]
+from source location: ../../../include/cpp2util.h(901) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-optional-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-optional-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value
+../../../include/cpp2util.h(901) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-shared-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-shared-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty
+../../../include/cpp2util.h(901) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-unique-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-unique-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(898) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty
+../../../include/cpp2util.h(901) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty

--- a/regression-tests/test-results/clang-15-c++20/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-default-arguments.cpp.execution
@@ -1,2 +1,4 @@
 calling: 
-012an older compiler
+012
+an older compiler
+1, 1, 66

--- a/regression-tests/test-results/gcc-10-c++20/pure2-default-arguments.cpp.output
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-default-arguments.cpp.output
@@ -1,66 +1,66 @@
 In file included from pure2-default-arguments.cpp:7:
 ../../../include/cpp2util.h:2086:28: error: local variable ‘obj’ may not appear in this context
- 2086 | auto as( std::variant<Ts...> & x ) -> decltype(auto) {
+ 2086 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 9>(x)), T >) { if (x.index() ==  9) return operator_as<9>(x); }
       |                            ^~~
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
- 2047 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return true; }
-      |                                  ^~~~~~~~~~~
+ 2047 |     return false;
+      |                                  ^          
 ../../../include/cpp2util.h:2086:15: note: in expansion of macro ‘CPP2_FORWARD’
- 2086 | auto as( std::variant<Ts...> & x ) -> decltype(auto) {
+ 2086 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 9>(x)), T >) { if (x.index() ==  9) return operator_as<9>(x); }
       |               ^~~~~~~~~~~~
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
- 2107 |     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
+ 2107 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 5>(x)), T >) { if (x.index() ==  5) return operator_as<5>(x); }
       |                      ^~~~~~~~~~~~~~~~~~~~~~~~
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2086:92: error: local variable ‘params’ may not appear in this context
- 2086 | auto as( std::variant<Ts...> & x ) -> decltype(auto) {
-      |                                                                                            ^     
+ 2086 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 9>(x)), T >) { if (x.index() ==  9) return operator_as<9>(x); }
+      |                                                                                            ^~~~~~
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
- 2047 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return true; }
-      |                                  ^~~~~~~~~~~
+ 2047 |     return false;
+      |                                  ^          
 ../../../include/cpp2util.h:2086:79: note: in expansion of macro ‘CPP2_FORWARD’
- 2086 | auto as( std::variant<Ts...> & x ) -> decltype(auto) {
-      |                                                                               ^           
+ 2086 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 9>(x)), T >) { if (x.index() ==  9) return operator_as<9>(x); }
+      |                                                                               ^~~~~~~~~~~~
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
- 2107 |     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
+ 2107 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 5>(x)), T >) { if (x.index() ==  5) return operator_as<5>(x); }
       |                      ^~~~~~~~~~~~~~~~~~~~~~~~
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2087:74: error: local variable ‘obj’ may not appear in this context
- 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 0>(x)), T >) { if (x.index() ==  0) return operator_as<0>(x); }
+ 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<10>(x); }
       |                                                                          ^~~
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
- 2047 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return true; }
-      |                                  ^~~~~~~~~~~
+ 2047 |     return false;
+      |                                  ^          
 ../../../include/cpp2util.h:2087:61: note: in expansion of macro ‘CPP2_FORWARD’
- 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 0>(x)), T >) { if (x.index() ==  0) return operator_as<0>(x); }
+ 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<10>(x); }
       |                                                             ^~~~~~~~~~~~
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
- 2107 |     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
+ 2107 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 5>(x)), T >) { if (x.index() ==  5) return operator_as<5>(x); }
       |                      ^~~~~~~~~~~~~~~~~~~~~~~~
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2087:93: error: local variable ‘params’ may not appear in this context
- 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 0>(x)), T >) { if (x.index() ==  0) return operator_as<0>(x); }
+ 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<10>(x); }
       |                                                                                             ^~~~~~
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
- 2047 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<15>(x)), T >) { if (x.index() == 15) return true; }
-      |                                  ^~~~~~~~~~~
+ 2047 |     return false;
+      |                                  ^          
 ../../../include/cpp2util.h:2087:80: note: in expansion of macro ‘CPP2_FORWARD’
- 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 0>(x)), T >) { if (x.index() ==  0) return operator_as<0>(x); }
+ 2087 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<10>(x)), T >) { if (x.index() == 10) return operator_as<10>(x); }
       |                                                                                ^~~~~~~~~~~~
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
- 2107 |     Throw( std::bad_variant_access(), "'as' cast failed for 'variant'");
+ 2107 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as< 5>(x)), T >) { if (x.index() ==  5) return operator_as<5>(x); }
       |                      ^~~~~~~~~~~~~~~~~~~~~~~~
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 pure2-default-arguments.cpp2:6:61: error: ‘std::source_location’ has not been declared

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/gcc-13-c++2b/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/pure2-default-arguments.cpp.execution
@@ -1,2 +1,4 @@
 calling: int main(int, char**)
-012an older compiler
+012
+an older compiler
+1, 1, 66

--- a/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 |     if constexpr (std::is_same_v< CPP2_TYPEOF(operator_as<13>(x)), T >) { if (x.index() == 13) return operator_as<13>(x); }
+ 2100 | template<typename T, typename... Ts>
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | //  std::any is and as
+ 2137 | template<typename T, typename X>
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-default-arguments.cpp.execution
@@ -1,4 +1,4 @@
 calling: int main(int, char**)
 012
-an older compiler
+a newer compiler
 1, 1, 66

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-default-arguments.cpp.execution
@@ -1,4 +1,4 @@
 calling: int main(int, char**)
 012
-a newer compiler
+an older compiler
 1, 1, 66

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-range-operators.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-range-operators.cpp.execution
@@ -34,3 +34,6 @@ true
 true
 false
 false
+
+Make sure views::take works:
+1 2 3 4 5 2 3 4 

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
@@ -6,7 +6,7 @@ pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' b
 pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(9): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(9): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-..\..\..\include\cpp2util.h(898): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
+..\..\..\include\cpp2util.h(901): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
 pure2-assert-expected-not-null.cpp2(14): error C2039: 'expected': is not a member of 'std'
 predefined C++ types (compiler internal)(347): note: see declaration of 'std'
 pure2-assert-expected-not-null.cpp2(14): error C2062: type 'int' unexpected
@@ -19,4 +19,4 @@ pure2-assert-expected-not-null.cpp2(14): note: while trying to match the argumen
 pure2-assert-expected-not-null.cpp2(14): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(15): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(15): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-..\..\..\include\cpp2util.h(898): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
+..\..\..\include\cpp2util.h(901): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-default-arguments.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-default-arguments.cpp.execution
@@ -1,2 +1,4 @@
 calling: int __cdecl main(const int,char **)
-012a newer compiler
+012
+a newer compiler
+1, 1, 66

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -3661,9 +3661,9 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
 #line 1993 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_n(cpp2::impl::in<int> n, cpp2::impl::out<std::string> r) & -> bool
     {
-        if (cpp2::impl::cmp_less_eq(pos + cpp2::impl::as_<size_t>(n),regex.size())) {
-            r.construct(regex.substr(pos, cpp2::impl::as_<size_t>(n)));
-            pos += (cpp2::impl::as_<size_t>(n)) - 1;
+        if (cpp2::impl::cmp_less_eq(pos + cpp2::unsafe_narrow<size_t>(n),regex.size())) {
+            r.construct(regex.substr(pos, cpp2::unsafe_narrow<size_t>(n)));
+            pos += (cpp2::unsafe_narrow<size_t>(n)) - 1;
             return true; 
         }
         else {
@@ -3844,7 +3844,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
 
 #line 2178 "reflect.h2"
     auto generation_function_context::remove_tabs(cpp2::impl::in<int> c) & -> void{
-        tabs = tabs.substr(0, (cpp2::impl::as_<size_t>(c)) * 2);
+        tabs = tabs.substr(0, (cpp2::unsafe_narrow<size_t>(c)) * 2);
     }
 
     generation_function_context::generation_function_context(auto const& code_, auto const& tabs_)

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -1992,9 +1992,9 @@ parse_context: type =
 
     grab_n: (inout this, in n: int, out r: std::string) -> bool = 
     {
-        if pos + n as size_t <= regex..size() {
-            r = regex..substr(pos, n as size_t);
-            pos += (n as size_t) - 1;
+        if pos + unsafe_narrow<size_t>(n) <= regex..size() {
+            r = regex..substr(pos, unsafe_narrow<size_t>(n));
+            pos += (unsafe_narrow<size_t>(n)) - 1;
             return true;
         }
         else {
@@ -2176,7 +2176,7 @@ generation_function_context: @struct type = {
     }
 
     remove_tabs: (inout this, c: int) = {
-        tabs = tabs..substr(0, (c as size_t) * 2);
+        tabs = tabs..substr(0, (unsafe_narrow<size_t>(c)) * 2);
     }
 }
 


### PR DESCRIPTION
The current implementation of `is_narrowing_v` does not handle type conversions correctly. For example, `cpp2::impl::is_narrowing_v<std::size_t, int>` returns `false`, indicating that it mistakenly perceives the conversion from a signed `int` to an unsigned `size_t` as potentially non-narrowing.

The new implementation is based on curly braces initialization on the cpp1 side which does all the required checking correctly. Examples here: https://godbolt.org/z/EdEK75E7z 

Closes #1257