### PR TITLE
as(): make as() cast to use type_safety.enforce

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -908,6 +908,7 @@ public:
 
     constexpr contract_group  (handler h = {}) : reporter{h} { }
     constexpr auto set_handler(handler h = {}) { reporter = h; }
+    constexpr auto get_handler() const -> handler { return reporter; }
     constexpr auto is_active  () const -> bool    { return reporter != handler{}; }
 
     constexpr auto enforce(bool b, CPP2_MESSAGE_PARAM msg = "" CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT)
@@ -2073,7 +2074,7 @@ auto as(X&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
         if constexpr (std::is_same_v< typename It::type, C >) { if (CPP2_FORWARD(x).index() ==  It::index) { ptr = &std::get<It::index>(x); return true; } }; 
         return false;
     });
-    if (!ptr) { Throw( std::bad_variant_access(), "'as' cast failed for 'variant'"); }
+    type_safety.enforce(ptr, "'as' cast failed for 'variant'");
     return cpp2::forward_like<decltype(x)>(*ptr);
 }
 
@@ -2115,7 +2116,7 @@ inline constexpr auto is( std::any const& x, auto&& value ) -> bool
 template<typename T, same_type_as<std::any> X>
 constexpr auto as( X && x ) -> decltype(auto) {
     constness_like_t<T, X>* ptr = std::any_cast<T>( &x );
-    if (!ptr) { Throw( std::bad_any_cast(), "'as' cast failed for 'std::any'"); }
+    type_safety.enforce(ptr, "'as' cast failed for 'std::any'");
     return cpp2::forward_like<X>(*ptr);
 }
 
@@ -2165,7 +2166,7 @@ constexpr auto as( X&& x ) -> decltype(auto) {
             ptr = &static_cast<constness_like_t<T, X>&>(*x);
         }
     }
-    if (!ptr) { Throw( std::bad_optional_access(), "'as' cast failed for 'std::optional'"); }
+    type_safety.enforce(ptr, "'as' cast failed for 'std::optional'");
     return cpp2::forward_like<X>(*ptr);
 }
 

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -2126,16 +2126,16 @@ constexpr auto as( X && x ) -> decltype(auto) {
 
 //  is Type
 //
-template<typename T, typename X>
-    requires std::is_same_v<X,std::optional<T>>
-constexpr auto is( X const& x ) -> bool
-    { return x.has_value(); }
-
-template<typename T, typename U>
-    requires std::is_same_v<T,empty>
-constexpr auto is( std::optional<U> const& x ) -> bool
-    { return !x.has_value(); }
-
+template<typename T, specialization_of_template<std::optional> X>
+constexpr auto is( X const& x ) -> bool { 
+    if (!x.has_value()) {
+        return std::same_as<T, empty>;
+    }
+    if constexpr (requires { static_cast<const T&>(*x);}) {
+        return true;
+    }
+    return false;
+}
 
 //  is Value
 //
@@ -2143,11 +2143,8 @@ template<typename T>
 constexpr auto is( std::optional<T> const& x, auto&& value ) -> bool
 {
     //  Predicate case
-    if constexpr (requires{ bool{ value(x) }; }) {
+    if constexpr (valid_predicate<decltype(value), decltype(x)>) {
         return value(x);
-    }
-    else if constexpr (std::is_function_v<decltype(value)> || requires{ &value.operator(); }) {
-        return false;
     }
 
     //  Value case
@@ -2160,10 +2157,17 @@ constexpr auto is( std::optional<T> const& x, auto&& value ) -> bool
 
 //  as
 //
-template<typename T, typename X>
-    requires std::is_same_v<X,std::optional<T>>
-constexpr auto as( X const& x ) -> decltype(auto)
-    { return x.value(); }
+template<typename T, specialization_of_template<std::optional> X>
+constexpr auto as( X&& x ) -> decltype(auto) { 
+    constness_like_t<T, X>* ptr = nullptr;
+    if constexpr (requires { static_cast<constness_like_t<T, X>&>(*x); }) {
+        if (x.has_value()) {
+            ptr = &static_cast<constness_like_t<T, X>&>(*x);
+        }
+    }
+    if (!ptr) { Throw( std::bad_optional_access(), "'as' cast failed for 'std::optional'"); }
+    return cpp2::forward_like<X>(*ptr);
+}
 
 
 } // impl

--- a/regression-tests/mixed-as-with-typesafety.cpp2
+++ b/regression-tests/mixed-as-with-typesafety.cpp2
@@ -1,0 +1,32 @@
+void throw_error(CPP2_MESSAGE_PARAM msg CPP2_SOURCE_LOCATION_PARAM) {
+    throw std::runtime_error(std::string("Type safety exception: ") + msg);
+}
+
+make_throwable: (inout cg : cpp2::contract_group) -> _ = {
+    h := cg.get_handler();
+    sh := :(pcg : *cpp2::contract_group) = {
+        pcg*.set_handler(h$);
+    };
+    cg.set_handler(throw_error);
+    return std::unique_ptr<cpp2::contract_group, decltype(sh)>(cg&, sh);
+}
+
+void expect_no_throw(auto&& fun) try {
+    fun();
+} catch(std::exception const& e) {
+    std::cout << e.what() << std::endl;
+} catch(...) {
+    std::cout << "Unknown exception!" << std::endl;
+}
+
+main: () = {
+    o : std::optional<int> = ();
+
+    (_ := make_throwable(cpp2::type_safety)) {
+        expect_no_throw( :() = {
+            std::cout << (o$ as int) << std::endl; // that will throw
+        });
+    }
+
+    std::cout << (o as int) << std::endl; // that will terminate
+}

--- a/regression-tests/test-results/apple-clang-14-c++2b/mixed-as-with-typesafety.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/mixed-as-with-typesafety.cpp.execution
@@ -1,0 +1,3 @@
+Type safety exception: 'as' cast failed for 'std::optional'
+Type safety violation: 'as' cast failed for 'std::optional'
+libc++abi: terminating

--- a/regression-tests/test-results/gcc-10-c++20/pure2-default-arguments.cpp.output
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-default-arguments.cpp.output
@@ -1,66 +1,66 @@
 In file included from pure2-default-arguments.cpp:7:
 ../../../include/cpp2util.h:2086:28: error: local variable ‘obj’ may not appear in this context
- 2086 | template<typename T, typename X>
+ 2086 | template<typename T, std::same_as<std::any> X>
       |                            ^~~
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
  2047 |             return false;
       |                                  ^          
 ../../../include/cpp2util.h:2086:15: note: in expansion of macro ‘CPP2_FORWARD’
- 2086 | template<typename T, typename X>
+ 2086 | template<typename T, std::same_as<std::any> X>
       |               ^~~~~~~~~~~~
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
  2107 |     }
       |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2086:92: error: local variable ‘params’ may not appear in this context
- 2086 | template<typename T, typename X>
+ 2086 | template<typename T, std::same_as<std::any> X>
       |                                                                                            ^     
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
  2047 |             return false;
       |                                  ^          
 ../../../include/cpp2util.h:2086:79: note: in expansion of macro ‘CPP2_FORWARD’
- 2086 | template<typename T, typename X>
+ 2086 | template<typename T, std::same_as<std::any> X>
       |                                                                               ^           
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
  2107 |     }
       |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2087:74: error: local variable ‘obj’ may not appear in this context
- 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
-      |                                                                          ^~~
+ 2087 | constexpr auto is( X const& x ) -> bool{
+      |                                                                          ^  
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
  2047 |             return false;
       |                                  ^          
 ../../../include/cpp2util.h:2087:61: note: in expansion of macro ‘CPP2_FORWARD’
- 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
-      |                                                             ^~~~~~~~~~~~
+ 2087 | constexpr auto is( X const& x ) -> bool{
+      |                                                             ^           
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
  2107 |     }
       |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 ../../../include/cpp2util.h:2087:93: error: local variable ‘params’ may not appear in this context
- 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
-      |                                                                                             ^~~~~~
+ 2087 | constexpr auto is( X const& x ) -> bool{
+      |                                                                                             ^     
 ../../../include/cpp2util.h:2047:34: note: in definition of macro ‘CPP2_UFCS_IDENTITY’
  2047 |             return false;
       |                                  ^          
 ../../../include/cpp2util.h:2087:80: note: in expansion of macro ‘CPP2_FORWARD’
- 2087 |     requires (std::is_same_v<X,std::any> && !std::is_same_v<T,std::any> && !std::is_same_v<T,empty>)
-      |                                                                                ^~~~~~~~~~~~
+ 2087 | constexpr auto is( X const& x ) -> bool{
+      |                                                                                ^           
 ../../../include/cpp2util.h:2107:22: note: in expansion of macro ‘CPP2_UFCS_CONSTRAINT_ARG’
  2107 |     }
       |                      ^                       
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 pure2-default-arguments.cpp2:6:22: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 pure2-default-arguments.cpp2:6:61: error: ‘std::source_location’ has not been declared

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
+++ b/regression-tests/test-results/gcc-14-c++2b/mixed-bugfix-for-ufcs-non-local.cpp.output
@@ -1,41 +1,41 @@
 In file included from mixed-bugfix-for-ufcs-non-local.cpp:6:
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:13:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:13:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:31:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:31:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:33:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:33:36: error: template argument 1 is invalid
 ../../../include/cpp2util.h:2100:1: error: lambda-expression in template parameter type
- 2100 | {
+ 2100 |         return value(x);
       | ^
 ../../../include/cpp2util.h:2137:59: note: in expansion of macro ‘CPP2_UFCS_’
- 2137 | 
+ 2137 |     return false;
       |                                                           ^         
 mixed-bugfix-for-ufcs-non-local.cpp2:21:12: note: in expansion of macro ‘CPP2_UFCS_NONLOCAL’
 mixed-bugfix-for-ufcs-non-local.cpp2:21:36: error: template argument 1 is invalid

--- a/regression-tests/test-results/mixed-as-with-typesafety.cpp
+++ b/regression-tests/test-results/mixed-as-with-typesafety.cpp
@@ -1,0 +1,63 @@
+
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "mixed-as-with-typesafety.cpp2"
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "mixed-as-with-typesafety.cpp2"
+void throw_error(CPP2_MESSAGE_PARAM msg CPP2_SOURCE_LOCATION_PARAM) {
+    throw std::runtime_error(std::string("Type safety exception: ") + msg);
+}
+
+#line 5 "mixed-as-with-typesafety.cpp2"
+[[nodiscard]] auto make_throwable(cpp2::contract_group& cg) -> auto;
+#line 13 "mixed-as-with-typesafety.cpp2"
+
+void expect_no_throw(auto&& fun) try {
+    fun();
+} catch(std::exception const& e) {
+    std::cout << e.what() << std::endl;
+} catch(...) {
+    std::cout << "Unknown exception!" << std::endl;
+}
+
+auto main() -> int;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "mixed-as-with-typesafety.cpp2"
+
+#line 5 "mixed-as-with-typesafety.cpp2"
+[[nodiscard]] auto make_throwable(cpp2::contract_group& cg) -> auto{
+    auto h {CPP2_UFCS(get_handler)(cg)}; 
+    auto sh {[_0 = cpp2::move(h)](cpp2::contract_group* pcg) mutable -> void{
+        CPP2_UFCS(set_handler)((*cpp2::impl::assert_not_null(pcg)), _0);
+    }}; 
+    CPP2_UFCS(set_handler)(cg, throw_error);
+    return std::unique_ptr<cpp2::contract_group,decltype(sh)>(&cg, cpp2::move(sh)); 
+}
+
+#line 22 "mixed-as-with-typesafety.cpp2"
+auto main() -> int{
+    std::optional<int> o {}; 
+{
+[[maybe_unused]] auto const& unnamed_param_1{make_throwable(cpp2::type_safety)};
+
+#line 25 "mixed-as-with-typesafety.cpp2"
+    {
+        expect_no_throw([_0 = o]() mutable -> void{
+            std::cout << (cpp2::impl::as_<int>(_0)) << std::endl;// that will throw
+        });
+    }
+}
+
+#line 31 "mixed-as-with-typesafety.cpp2"
+    std::cout << (cpp2::impl::as_<int>(cpp2::move(o))) << std::endl;// that will terminate
+}
+

--- a/regression-tests/test-results/mixed-as-with-typesafety.cpp2.output
+++ b/regression-tests/test-results/mixed-as-with-typesafety.cpp2.output
@@ -1,0 +1,2 @@
+mixed-as-with-typesafety.cpp2... ok (mixed Cpp1/Cpp2, Cpp2 code passes safety checks)
+


### PR DESCRIPTION
The current implementation of `as()` for `std::any`, `std::optional`, and `std::variant` throws exceptions in case of tunability to cast. This behavior is inconsistent with runtime checked `as()` for signed/unsigned integral cast where it calls `terminate()`.

This implementation switch runtime checked as() to use `type_safety`, which allows the setup of one approach for all `type_safety` issues.

The current behavior is to terminate, but it can be changed, e.g., to throw an exception. The following example is an excellent example of how it can be used.

```cpp
void throw_error(CPP2_MESSAGE_PARAM msg CPP2_SOURCE_LOCATION_PARAM) {
    throw std::runtime_error(std::string("Type safety exception: ") + msg);
}

make_throwable: (inout cg : cpp2::contract_group) -> _ = {
    h := cg.get_handler();
    sh := :(pcg : *cpp2::contract_group) = {
        pcg*.set_handler(h$);
    };
    cg.set_handler(throw_error);
    return std::unique_ptr<cpp2::contract_group, decltype(sh)>(cg&, sh);
}

void expect_no_throw(auto&& fun) try {
    fun();
} catch(std::exception const& e) {
    std::cout << e.what() << std::endl;
} catch(...) {
    std::cout << "Unknown exception!" << std::endl;
}

main: () = {
    o : std::optional<int> = ();

    (_ := make_throwable(cpp2::type_safety)) {
        expect_no_throw( :() = {
            std::cout << (o$ as int) << std::endl; // that will throw
        });
    }

    std::cout << (o as int) << std::endl; // that will terminate
}
```
and the result is the following:
```
Type safety exception: 'as' cast failed for 'std::optional'
Type safety violation: 'as' cast failed for 'std::optional'
libc++abi: terminating
```