### PR TITLE
Make cpp2::args usable as a std::ranges::bidirectional_range

### DIFF
--- a/docs/cpp2/common.md
+++ b/docs/cpp2/common.md
@@ -10,7 +10,7 @@ As always, `main` is the entry point of the program. For example:
 
 - One parameter of implicit type named `args`: &emsp; **`#!cpp main: (args) /*etc.*/`**
 
-    - The type of `args` cannot be explicitly specified. It is always `cpp2::args_t`, which behaves similarly to a `#!cpp const std::array<std::string_view>`.
+    - The type of `args` cannot be explicitly specified. It is always `cpp2::args`, which behaves similarly to a `#!cpp const std::array<std::string_view>`.
 
     - Using `args` performs zero heap allocations. Every `string_view` is directly bound to the string storage provided by host environment.
 

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -2327,8 +2327,11 @@ struct args
         using difference_type = std::ptrdiff_t;
         using value_type      = std::string_view;
 
-        constexpr iterator() : argc(0), argv(nullptr), curr(0) {}
-        constexpr iterator(const iterator& o) : argc(o.argc), argv(o.argv), curr(o.curr) {}
+        constexpr iterator() = default;
+        constexpr iterator(const iterator& o) = default;
+        constexpr iterator(iterator&& o) = default;
+        constexpr iterator& operator=(const iterator& o) = default;
+        constexpr iterator& operator=(iterator&& o) = default;
 
         constexpr auto operator*() const {
             if (curr < argc) { return std::string_view{ argv[curr] }; }
@@ -2348,9 +2351,9 @@ struct args
         constexpr auto operator<=>(iterator const&) const = default;
 
     private:
-        int    argc;
-        char** argv;
-        int    curr;
+        int    argc = 0;
+        char** argv = nullptr;
+        int    curr = 0;
     };
 
     constexpr auto begin()  const -> iterator       { return iterator{ argc, argv, 0    }; }

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -2324,6 +2324,12 @@ struct args
     public:
         constexpr iterator(int c, char** v, int start) : argc{c}, argv{v}, curr{start} {}
 
+        using difference_type = std::ptrdiff_t;
+        using value_type      = std::string_view;
+
+        iterator() : argc(0), argv(nullptr), curr(0) {}
+        iterator(const iterator& o) : argc(o.argc), argv(o.argv), curr(o.curr) {}
+
         constexpr auto operator*() const {
             if (curr < argc) { return std::string_view{ argv[curr] }; }
             else             { return std::string_view{}; }

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -2323,15 +2323,10 @@ struct args
     class iterator {
     public:
         constexpr iterator(int c, char** v, int start) : argc{c}, argv{v}, curr{start} {}
+        constexpr iterator() = default;
 
         using difference_type = std::ptrdiff_t;
         using value_type      = std::string_view;
-
-        constexpr iterator() = default;
-        constexpr iterator(const iterator& o) = default;
-        constexpr iterator(iterator&& o) = default;
-        constexpr iterator& operator=(const iterator& o) = default;
-        constexpr iterator& operator=(iterator&& o) = default;
 
         constexpr auto operator*() const {
             if (curr < argc) { return std::string_view{ argv[curr] }; }

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -2327,8 +2327,8 @@ struct args
         using difference_type = std::ptrdiff_t;
         using value_type      = std::string_view;
 
-        iterator() : argc(0), argv(nullptr), curr(0) {}
-        iterator(const iterator& o) : argc(o.argc), argv(o.argv), curr(o.curr) {}
+        constexpr iterator() : argc(0), argv(nullptr), curr(0) {}
+        constexpr iterator(const iterator& o) : argc(o.argc), argv(o.argv), curr(o.curr) {}
 
         constexpr auto operator*() const {
             if (curr < argc) { return std::string_view{ argv[curr] }; }

--- a/regression-tests/pure2-main-args-range.cpp2
+++ b/regression-tests/pure2-main-args-range.cpp2
@@ -1,0 +1,12 @@
+main: (args) = {
+    static_assert(std::bidirectional_iterator<cpp2::args::iterator>);
+    static_assert(std::ranges::bidirectional_range<cpp2::args>);
+    static_assert(std::ranges::viewable_range<cpp2::args>);
+
+    // Output command line arguments, dropping the program name argc[0].
+    for args | std::ranges::views::drop(1) do (arg)
+    {
+        std::cout
+            << arg << std::endl;
+    }
+}

--- a/regression-tests/test-results/pure2-main-args-range.cpp
+++ b/regression-tests/test-results/pure2-main-args-range.cpp
@@ -1,0 +1,34 @@
+
+#define CPP2_IMPORT_STD          Yes
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "pure2-main-args-range.cpp2"
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-main-args-range.cpp2"
+auto main(int const argc_, char** argv_) -> int;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-main-args-range.cpp2"
+auto main(int const argc_, char** argv_) -> int{
+    auto const args = cpp2::make_args(argc_, argv_); 
+#line 2 "pure2-main-args-range.cpp2"
+    static_assert(std::bidirectional_iterator<cpp2::args::iterator>);
+    static_assert(std::ranges::bidirectional_range<cpp2::args>);
+    static_assert(std::ranges::viewable_range<cpp2::args>);
+
+    // Output command line arguments, dropping the program name argc[0].
+    for ( auto const& arg : args | std::ranges::views::drop(1) ) 
+    {
+        std::cout 
+            << arg << std::endl;
+    }
+}
+

--- a/regression-tests/test-results/pure2-main-args-range.cpp2.output
+++ b/regression-tests/test-results/pure2-main-args-range.cpp2.output
@@ -1,0 +1,2 @@
+pure2-main-args-range.cpp2... ok (all Cpp2, passes safety checks)
+


### PR DESCRIPTION
Satisfy the `std::ranges::bidirectional_range` constraint, so that `cpp2::args` can be used with `std::ranges` adapters, etc.

See #1280.