### PR TITLE
test: avoid unnamed parameter in function type template argument

### DIFF
--- a/regression-tests/pure2-last-use.cpp2
+++ b/regression-tests/pure2-last-use.cpp2
@@ -270,9 +270,9 @@ issue_857_6: @struct type = {
 
 issue_857_4: @struct type = {
    f: std::add_pointer_t<()->int>;
-   g: std::add_pointer_t<(_:int)->int>;
+   g: std::add_pointer_t<(x:int)->int>;
   mf: std::move_only_function<()->int>;
-  mg: std::move_only_function<(_:int)->int>;
+  mg: std::move_only_function<(x:int)->int>;
 //   h0: (move this) = _ = mf();
 //   h1: (move this) = _ = this.mf();
 //   h2: (move this, that) = _ = that.mf();
@@ -770,7 +770,7 @@ issue_884: () = {
 issue_888_0: (copy r: std::string, copy size: int) = {
   _ = r.size();
 }
-issue_888_1: (copy _: std::string, copy size: std::move_only_function<(_:int)->int>) = {
+issue_888_1: (copy _: std::string, copy size: std::move_only_function<(x:int)->int>) = {
   _ = 0.size();
 }
 
@@ -787,7 +787,7 @@ issue_962: (s: ::std::string) = {
 
 draw: () = {
   pos := 0;
-  vertex: std::move_only_function<(_:int)->int> = ();
+  vertex: std::move_only_function<(x:int)->int> = ();
   _ = (pos).vertex();
 }
 

--- a/regression-tests/test-results/clang-12-c++20/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/clang-12-c++20/pure2-last-use.cpp.output
@@ -1,12 +1,21 @@
-pure2-last-use.cpp2:273:36: error: expected variable name or 'this' in lambda capture list
-   public: std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> g; 
-                                   ^
-pure2-last-use.cpp2:329:2: error: expected '>'
-};
- ^
-pure2-last-use.cpp2:273:30: note: to match this '<'
-   public: std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> g; 
-                             ^
+pure2-last-use.cpp2:274:16: error: no template named 'move_only_function' in namespace 'std'
+  public: std::move_only_function<int()> mf; 
+          ~~~~~^
+pure2-last-use.cpp2:275:16: error: no template named 'move_only_function' in namespace 'std'
+  public: std::move_only_function<int(cpp2::impl::in<int> x)> mg; 
+          ~~~~~^
+pure2-last-use.cpp2:277:278: error: no member named 'move_only_function' in namespace 'std'
+CPP2_REQUIRES_ (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> inx)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> inx)>>&>) ;
+                                                                                                                                                                                                                                                                                ~~~~~^
+../../../include/cpp2util.h:10008:43: note: expanded from macro 'CPP2_REQUIRES_'
+    #define CPP2_REQUIRES_(...) requires (__VA_ARGS__)
+                                          ^~~~~~~~~~~
+pure2-last-use.cpp2:277:305: error: expected expression
+CPP2_REQUIRES_ (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> inx)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> inx)>>&>) ;
+                                                                                                                                                                                                                                                                                                                ^
+pure2-last-use.cpp2:277:310: error: use of address-of-label extension outside of a function body
+CPP2_REQUIRES_ (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> inx)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> inx)>>&>) ;
+                                                                                                                                                                                                                                                                                                                     ^
 pure2-last-use.cpp2:344:16: error: no template named 'move_only_function' in namespace 'std'
   public: std::move_only_function<int()> b; 
           ~~~~~^
@@ -23,52 +32,33 @@ pure2-last-use.cpp2:348:193: error: use of address-of-label extension outside of
 CPP2_REQUIRES_ (std::is_convertible_v<CPP2_TYPEOF(a_), std::add_const_t<std::unique_ptr<int>>&> && std::is_convertible_v<CPP2_TYPEOF(b_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(c_), std::add_const_t<std::add_lvalue_reference_t<int>>&>) ;
                                                                                                                                                                                                 ^
 pure2-last-use.cpp2:773:69: error: no template named 'move_only_function' in namespace 'std'
-auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> size) -> void;
+auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int(cpp2::impl::in<int> x)> size) -> void;
                                                                ~~~~~^
-pure2-last-use.cpp2:773:93: error: expected variable name or 'this' in lambda capture list
-auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> size) -> void;
-                                                                                            ^
-pure2-last-use.cpp2:773:156: error: expected unqualified-id
-auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> size) -> void;
-                                                                                                                                                           ^
-pure2-last-use.cpp2:773:160: error: expected '>'
-auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> size) -> void;
-                                                                                                                                                               ^
-pure2-last-use.cpp2:773:87: note: to match this '<'
-auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> size) -> void;
-                                                                                      ^
-pure2-last-use.cpp2:773:160: error: expected ')'
-auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> size) -> void;
-                                                                                                                                                               ^
-pure2-last-use.cpp2:773:17: note: to match this '('
-auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> size) -> void;
-                ^
-pure2-last-use.cpp2:271:7: error: missing '}' at end of definition of 'issue_857_4'
-class issue_857_4 {
-      ^
-pure2-last-use.cpp2:905:1: note: still within definition of 'issue_857_4' here
-namespace captures {
-^
 pure2-last-use.cpp2:279:272: error: no member named 'move_only_function' in namespace 'std'
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> inx)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> inx)>>&>) 
                                                                                                                                                                                                                                                                           ~~~~~^
 pure2-last-use.cpp2:279:299: error: expected expression
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> inx)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> inx)>>&>) 
                                                                                                                                                                                                                                                                                                           ^
 pure2-last-use.cpp2:279:304: error: use of address-of-label extension outside of a function body
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> inx)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> inx)>>&>) 
                                                                                                                                                                                                                                                                                                                ^
-pure2-last-use.cpp2:278:14: error: out-of-line definition of 'issue_857_4' does not match any declaration in 'issue_857_4'
-issue_857_4::issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-             ^~~~~~~~~~~
-pure2-last-use.cpp2:281:272: error: member initializer 'g' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , g{ CPP2_FORWARD(g_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:282:272: error: member initializer 'mf' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mf{ CPP2_FORWARD(mf_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:283:272: error: member initializer 'mg' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mg{ CPP2_FORWARD(mg_) }{}
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
+pure2-last-use.cpp2:349:155: error: no member named 'move_only_function' in namespace 'std'
+requires (std::is_convertible_v<CPP2_TYPEOF(a_), std::add_const_t<std::unique_ptr<int>>&> && std::is_convertible_v<CPP2_TYPEOF(b_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(c_), std::add_const_t<std::add_lvalue_reference_t<int>>&>) 
+                                                                                                                                                     ~~~~~^
+pure2-last-use.cpp2:349:182: error: expected expression
+requires (std::is_convertible_v<CPP2_TYPEOF(a_), std::add_const_t<std::unique_ptr<int>>&> && std::is_convertible_v<CPP2_TYPEOF(b_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(c_), std::add_const_t<std::add_lvalue_reference_t<int>>&>) 
+                                                                                                                                                                                     ^
+pure2-last-use.cpp2:349:187: error: use of address-of-label extension outside of a function body
+requires (std::is_convertible_v<CPP2_TYPEOF(a_), std::add_const_t<std::unique_ptr<int>>&> && std::is_convertible_v<CPP2_TYPEOF(b_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(c_), std::add_const_t<std::add_lvalue_reference_t<int>>&>) 
+                                                                                                                                                                                          ^
+pure2-last-use.cpp2:773:69: error: no template named 'move_only_function' in namespace 'std'
+auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int(cpp2::impl::in<int> x)> size) -> void{
+                                                               ~~~~~^
+error: constexpr if condition is not a constant expression
+pure2-last-use.cpp2:774:41: note: in instantiation of function template specialization 'issue_888_1(std::string, int)::(anonymous class)::operator()<int>' requested here
+  static_cast<void>(CPP2_UFCS_MOVE(size)(0));
+                                        ^
+error: constexpr if condition is not a constant expression
 fatal error: too many errors emitted, stopping now [-ferror-limit=]
 20 errors generated.

--- a/regression-tests/test-results/gcc-14-c++2b/gcc-version.output
+++ b/regression-tests/test-results/gcc-14-c++2b/gcc-version.output
@@ -1,4 +1,4 @@
-g++ (GCC) 14.2.1 20240801 (Red Hat 14.2.1-1)
+g++ (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3)
 Copyright (C) 2024 Free Software Foundation, Inc.
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/regression-tests/test-results/pure2-last-use.cpp
+++ b/regression-tests/test-results/pure2-last-use.cpp
@@ -283,11 +283,11 @@ public: issue_857_6();
 
 class issue_857_4 {
    public: std::add_pointer_t<int()> f; 
-   public: std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> g; 
+   public: std::add_pointer_t<int(cpp2::impl::in<int> x)> g; 
   public: std::move_only_function<int()> mf; 
-  public: std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> mg; 
+  public: std::move_only_function<int(cpp2::impl::in<int> x)> mg; 
   public: issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-CPP2_REQUIRES_ (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) ;
+CPP2_REQUIRES_ (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> inx)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> inx)>>&>) ;
 
 //   h0: (move this) = _ = mf();
 //   h1: (move this) = _ = this.mf();
@@ -438,7 +438,7 @@ auto issue_884() -> void;
 auto issue_888_0(std::string r, int size) -> void;
 
 #line 773 "pure2-last-use.cpp2"
-auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> size) -> void;
+auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int(cpp2::impl::in<int> x)> size) -> void;
 
 #line 777 "pure2-last-use.cpp2"
 auto issue_890() -> void;
@@ -772,7 +772,7 @@ requires (std::is_convertible_v<CPP2_TYPEOF(i_), std::add_const_t<std::add_lvalu
                                                                                         return *this;}
 issue_857_6::issue_857_6(){}
 issue_857_4::issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> inx)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> inx)>>&>) 
                                                                                                                                                                                                                                                                              : f{ CPP2_FORWARD(f_) }
                                                                                                                                                                                                                                                                              , g{ CPP2_FORWARD(g_) }
                                                                                                                                                                                                                                                                              , mf{ CPP2_FORWARD(mf_) }
@@ -1272,7 +1272,7 @@ auto issue_888_0(std::string r, int size) -> void{
   static_cast<void>(CPP2_UFCS_MOVE(size)(cpp2::move(r)));
 }
 #line 773 "pure2-last-use.cpp2"
-auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> size) -> void{
+auto issue_888_1([[maybe_unused]] std::string unnamed_param_1, std::move_only_function<int(cpp2::impl::in<int> x)> size) -> void{
   static_cast<void>(CPP2_UFCS_MOVE(size)(0));
 }
 
@@ -1297,7 +1297,7 @@ auto issue_962(cpp2::impl::in<::std::string> s) -> void{
 #line 788 "pure2-last-use.cpp2"
 auto draw() -> void{
   auto pos {0}; 
-  std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)> vertex {}; 
+  std::move_only_function<int(cpp2::impl::in<int> x)> vertex {}; 
   static_cast<void>(CPP2_UFCS_MOVE(vertex)((cpp2::move(pos))));
 }
 


### PR DESCRIPTION
Resolves <https://github.com/hsutter/cppfront/commit/212eb15e77bba222c7fda3ff50f1e5f479a627ee#commitcomment-147400224>
by avoiding the unnamed parameters,
rather than changing the lowering to Cpp1.