### PR TITLE
feat(parse): add _type-id_ production for `type_of`

### DIFF
--- a/regression-tests/pure2-print.cpp2
+++ b/regression-tests/pure2-print.cpp2
@@ -100,7 +100,7 @@ outer: @print type = {
     all: <Args...: type> (args...: Args) -> bool =
         (... && args);
 
-    y: (_: decltype(0)) = { }
+    y: (_: type_of(0)) = { }
 
 }
 

--- a/regression-tests/test-results/pure2-print.cpp
+++ b/regression-tests/test-results/pure2-print.cpp
@@ -72,7 +72,7 @@ CPP2_REQUIRES_ (cpp2::impl::cmp_greater_eq(sizeof...(Args),0u)) ;
     public: template<typename ...Args> [[nodiscard]] static auto all(Args const& ...args) -> bool;
 
 #line 103 "pure2-print.cpp2"
-    public: static auto y([[maybe_unused]] cpp2::impl::in<decltype(0)> unnamed_param_1) -> void;
+    public: static auto y([[maybe_unused]] cpp2::impl::in<CPP2_TYPEOF(0)> unnamed_param_1) -> void;
     public: outer() = default;
     public: outer(outer const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(outer const&) -> void = delete;
@@ -203,7 +203,7 @@ requires (cpp2::impl::cmp_greater_eq(sizeof...(Args),0u)) {
         return (... && args);  }
 
 #line 103 "pure2-print.cpp2"
-    auto outer::y([[maybe_unused]] cpp2::impl::in<decltype(0)> unnamed_param_1) -> void{}
+    auto outer::y([[maybe_unused]] cpp2::impl::in<CPP2_TYPEOF(0)> unnamed_param_1) -> void{}
 
 #line 107 "pure2-print.cpp2"
 auto main() -> int{

--- a/regression-tests/test-results/pure2-print.cpp2.output
+++ b/regression-tests/test-results/pure2-print.cpp2.output
@@ -147,7 +147,7 @@ outer:/* @print */ type =
 
     all: <Args...: type, >(in args...: Args, ) -> move bool = (... && args);
 
-    y:(in _: decltype(0), ) = 
+    y:(in _: type_of(0), ) = 
     {
     }
 }

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -1939,7 +1939,7 @@ public:
             printer.print_cpp2("auto", pos);
         }
         else {
-            try_emit<type_id_node::decltype_  >(n.id);
+            try_emit<type_id_node::postfix    >(n.id);
             try_emit<type_id_node::unqualified>(n.id, 0, false);
             try_emit<type_id_node::qualified  >(n.id);
             try_emit<type_id_node::keyword    >(n.id);


### PR DESCRIPTION
Updating some code didn't go as expected:
```Cpp2
export expect: (x: type_of(boost::ut::eq(i64(), i64()))) _ = boost::ut::expect(x);
export expect: (x: std::type_identity_t<CPP2_TYPEOF(boost::ut::eq(std::vector<int>(), std::vector<int>()))>) _ =
  boost::ut::expect(x);
```
This PR remedies that.