### PR TITLE
CI Update the GitHub checkout action

### DIFF
--- a/.github/workflows/build-cppfront.yaml
+++ b/.github/workflows/build-cppfront.yaml
@@ -12,7 +12,7 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Compiler name & version
         run: cl.exe
@@ -61,7 +61,7 @@ jobs:
       CXX: ${{ matrix.compiler }}
       CXXFLAGS: -std=${{ matrix.cxx-std }} -Wall -Wextra -Wold-style-cast -Wunused-parameter -Wpedantic -Werror -pthread -Wno-unknown-warning -Wno-unknown-warning-option
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install compiler
       if: startsWith(matrix.runs-on, 'ubuntu')
       run: sudo apt-get install -y $CXX

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x


### PR DESCRIPTION
As stated in the title.
Some GitHub workflows use v3 of the checkout action that causes wirings. The PR updates the version to 4, as used e.g. for regression tests.