### PR TITLE
feat: add _computed-type-id_ for qualified `type_of` and `decltype`

### DIFF
--- a/regression-tests/pure2-print.cpp2
+++ b/regression-tests/pure2-print.cpp2
@@ -101,6 +101,9 @@ outer: @print type = {
         (... && args);
 
     y: (_: type_of(0)) = { }
+    y: (_: decltype(1LL)) = { }
+    y: (_: type_of(2 is int)::value_type) = { }
+    y: (_: decltype(new<long>(3))::element_type) = { }
 
 }
 

--- a/regression-tests/pure2-variadics-indexing.cpp2
+++ b/regression-tests/pure2-variadics-indexing.cpp2
@@ -1,0 +1,11 @@
+f0: <T...> () == :T...[0] = 32;
+// f1: <T...> () == :T...[0]::value_type = 4; // Pending #533.
+// 'V...[0]' needs to be made an _id-expression_.
+// f2: <V...: _> () == V...[0];
+// f3: <V...: _> () == V...[0].front();
+main: () = {
+  static_assert(f0<i64>() == 32);
+  // static_assert(f1<std::integral_constant<i16, 8>>() == 4);
+  // static_assert(f2<2>() == 2);
+  // static_assert(f3<(:std::array = (1))>() == 1);
+}

--- a/regression-tests/pure2-variadics-indexing.cpp2
+++ b/regression-tests/pure2-variadics-indexing.cpp2
@@ -1,11 +1,10 @@
 f0: <T...> () == :T...[0] = 32;
 // f1: <T...> () == :T...[0]::value_type = 4; // Pending #533.
-// 'V...[0]' needs to be made an _id-expression_.
-// f2: <V...: _> () == V...[0];
-// f3: <V...: _> () == V...[0].front();
+f2: <V...: _> () == V...[0];
+f3: <V...: _> () == V...[0].front();
 main: () = {
   static_assert(f0<i64>() == 32);
   // static_assert(f1<std::integral_constant<i16, 8>>() == 4);
-  // static_assert(f2<2>() == 2);
-  // static_assert(f3<(:std::array = (1))>() == 1);
+  static_assert(f2<2>() == 2);
+  static_assert(f3<(:std::array = (1))>() == 1);
 }

--- a/regression-tests/test-results/pure2-last-use.cpp
+++ b/regression-tests/test-results/pure2-last-use.cpp
@@ -606,7 +606,7 @@ auto issue_313() -> void{
     static_cast<void>(cpp2::impl::is(e, (e)));
 
     auto f {cpp2_new<int>(0)}; 
-    static_cast<void>(cpp2::impl::is<decltype(f)>(f));// OK?
+    static_cast<void>(cpp2::impl::is<decltype(f)>(cpp2::move(f)));// OK?
 
     auto g {cpp2_new<int>(0)}; 
     for ( 

--- a/regression-tests/test-results/pure2-print.cpp
+++ b/regression-tests/test-results/pure2-print.cpp
@@ -73,12 +73,15 @@ CPP2_REQUIRES_ (cpp2::impl::cmp_greater_eq(sizeof...(Args),0u)) ;
 
 #line 103 "pure2-print.cpp2"
     public: static auto y([[maybe_unused]] cpp2::impl::in<CPP2_TYPEOF(0)> unnamed_param_1) -> void;
+    public: static auto y([[maybe_unused]] cpp2::impl::in<decltype(1LL)> unnamed_param_1) -> void;
+    public: static auto y([[maybe_unused]] cpp2::impl::in<CPP2_TYPEOF(cpp2::impl::is<int>(2))::value_type> unnamed_param_1) -> void;
+    public: static auto y([[maybe_unused]] cpp2::impl::in<decltype(cpp2_new<long>(3))::element_type> unnamed_param_1) -> void;
     public: outer() = default;
     public: outer(outer const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(outer const&) -> void = delete;
 
 
-#line 105 "pure2-print.cpp2"
+#line 108 "pure2-print.cpp2"
 };
 
 auto main() -> int;
@@ -204,8 +207,14 @@ requires (cpp2::impl::cmp_greater_eq(sizeof...(Args),0u)) {
 
 #line 103 "pure2-print.cpp2"
     auto outer::y([[maybe_unused]] cpp2::impl::in<CPP2_TYPEOF(0)> unnamed_param_1) -> void{}
+#line 104 "pure2-print.cpp2"
+    auto outer::y([[maybe_unused]] cpp2::impl::in<decltype(1LL)> unnamed_param_1) -> void{}
+#line 105 "pure2-print.cpp2"
+    auto outer::y([[maybe_unused]] cpp2::impl::in<CPP2_TYPEOF(cpp2::impl::is<int>(2))::value_type> unnamed_param_1) -> void{}
+#line 106 "pure2-print.cpp2"
+    auto outer::y([[maybe_unused]] cpp2::impl::in<decltype(cpp2_new<long>(3))::element_type> unnamed_param_1) -> void{}
 
-#line 107 "pure2-print.cpp2"
+#line 110 "pure2-print.cpp2"
 auto main() -> int{
     outer::test();
 }

--- a/regression-tests/test-results/pure2-print.cpp2.output
+++ b/regression-tests/test-results/pure2-print.cpp2.output
@@ -150,6 +150,18 @@ outer:/* @print */ type =
     y:(in _: type_of(0), ) = 
     {
     }
+
+    y:(in _: decltype(1LL), ) = 
+    {
+    }
+
+    y:(in _: type_of(2 is int)::value_type, ) = 
+    {
+    }
+
+    y:(in _: decltype(new<long>(3))::element_type, ) = 
+    {
+    }
 }
  ok (all Cpp2, passes safety checks)
 

--- a/regression-tests/test-results/pure2-variadics-indexing.cpp
+++ b/regression-tests/test-results/pure2-variadics-indexing.cpp
@@ -1,0 +1,35 @@
+
+#define CPP2_IMPORT_STD          Yes
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "pure2-variadics-indexing.cpp2"
+
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-variadics-indexing.cpp2"
+template<typename ...T> [[nodiscard]] constexpr auto f0() -> decltype(auto);
+// f1: <T...> () == :T...[0]::value_type = 4; // Pending #533.
+// 'V...[0]' needs to be made an _id-expression_.
+// f2: <V...: _> () == V...[0];
+// f3: <V...: _> () == V...[0].front();
+#line 6 "pure2-variadics-indexing.cpp2"
+auto main() -> int;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-variadics-indexing.cpp2"
+template<typename ...T> [[nodiscard]] constexpr auto f0() -> decltype(auto) { return T...[0]{32};  }
+
+#line 6 "pure2-variadics-indexing.cpp2"
+auto main() -> int{
+  static_assert(f0<cpp2::i64>() == 32);
+  // static_assert(f1<std::integral_constant<i16, 8>>() == 4);
+  // static_assert(f2<2>() == 2);
+  // static_assert(f3<(:std::array = (1))>() == 1);
+}
+

--- a/regression-tests/test-results/pure2-variadics-indexing.cpp
+++ b/regression-tests/test-results/pure2-variadics-indexing.cpp
@@ -14,10 +14,9 @@
 #line 1 "pure2-variadics-indexing.cpp2"
 template<typename ...T> [[nodiscard]] constexpr auto f0() -> decltype(auto);
 // f1: <T...> () == :T...[0]::value_type = 4; // Pending #533.
-// 'V...[0]' needs to be made an _id-expression_.
-// f2: <V...: _> () == V...[0];
-// f3: <V...: _> () == V...[0].front();
-#line 6 "pure2-variadics-indexing.cpp2"
+#line 3 "pure2-variadics-indexing.cpp2"
+template<auto ...V> [[nodiscard]] constexpr auto f2() -> decltype(auto);
+template<auto ...V> [[nodiscard]] constexpr auto f3() -> decltype(auto);
 auto main() -> int;
 
 //=== Cpp2 function definitions =================================================
@@ -25,11 +24,15 @@ auto main() -> int;
 #line 1 "pure2-variadics-indexing.cpp2"
 template<typename ...T> [[nodiscard]] constexpr auto f0() -> decltype(auto) { return T...[0]{32};  }
 
-#line 6 "pure2-variadics-indexing.cpp2"
+#line 3 "pure2-variadics-indexing.cpp2"
+template<auto ...V> [[nodiscard]] constexpr auto f2() -> decltype(auto) { return V...[0];  }
+#line 4 "pure2-variadics-indexing.cpp2"
+template<auto ...V> [[nodiscard]] constexpr auto f3() -> decltype(auto) { return CPP2_UFCS(front)(V...[0]);  }
+#line 5 "pure2-variadics-indexing.cpp2"
 auto main() -> int{
   static_assert(f0<cpp2::i64>() == 32);
   // static_assert(f1<std::integral_constant<i16, 8>>() == 4);
-  // static_assert(f2<2>() == 2);
-  // static_assert(f3<(:std::array = (1))>() == 1);
+  static_assert(f2<2>() == 2);
+  static_assert(f3<(std::array{1})>() == 1);
 }
 

--- a/regression-tests/test-results/pure2-variadics-indexing.cpp2.output
+++ b/regression-tests/test-results/pure2-variadics-indexing.cpp2.output
@@ -1,0 +1,2 @@
+pure2-variadics-indexing.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/source/parse.h
+++ b/source/parse.h
@@ -7495,7 +7495,6 @@ private:
     //G id-expression:
     //G     qualified-id
     //G     unqualified-id
-    //GTODO identifier '...' '[' expression ']'  // C++26 pack indexing
     //G
     auto id_expression()
         -> std::unique_ptr<id_expression_node>

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -3516,11 +3516,15 @@ public:
                 last_was_prefixed = false;
 
                 //  Enable subscript bounds checks
-                if (
+                auto checked_subscript =
                     flag_safe_subscripts
                     && i->op->type() == lexeme::LeftBracket
                     && std::ssize(i->expr_list->expressions) == 1
-                    )
+                    && (
+                        i+1 == n.ops.rend()
+                        || (i+1)->op->type() != lexeme::Ellipsis
+                        );
+                if (checked_subscript)
                 {
                     suffix.emplace_back( ")", i->op->position() );
                 }
@@ -3570,11 +3574,7 @@ public:
                 }
 
                 //  Enable subscript bounds checks
-                if (
-                    flag_safe_subscripts
-                    && i->op->type() == lexeme::LeftBracket
-                    && std::ssize(i->expr_list->expressions) == 1
-                    )
+                if (checked_subscript)
                 {
                     if (auto lit = i->expr_list->expressions.front().expr->get_literal();
                         lit


### PR DESCRIPTION
My next code which I couldn't update:
```Cpp2
      magnitude2d: <Number> type ==
        decltype(_cartesian_magnitude2d(std::type_identity<std::tuple<Unit, Number>>()))::type;
      vector2d: <Number> type ==
        std::type_identity_t<decltype(_cartesian_vector2d(std::type_identity<std::tuple<Unit, Number>>()))>::type;
```

The Cpp1 syntax uses [_computed-type-specifier_](https://eel.is/c++draft/gram),
which I modeled with _computed-type-id_.
Supporting C++26's pack indexing (in *type-id*s) was a low-hanging fruit.