### PR TITLE
Exclude MSVC workaround on clang and gcc

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -368,7 +368,7 @@ constexpr auto gcc_clang_msvc_min_versions(
 }
 
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang_major__) && !defined(__GNUC__)
    // MSVC can't handle 'inline constexpr' variables yet in all cases
     #define CPP2_CONSTEXPR const
 #else

--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -368,7 +368,7 @@ constexpr auto gcc_clang_msvc_min_versions(
 }
 
 
-#if defined(_MSC_VER) && !defined(__clang_major__) && !defined(__GNUC__)
+#if defined(_MSC_VER) && !defined(__clang_major__)
    // MSVC can't handle 'inline constexpr' variables yet in all cases
     #define CPP2_CONSTEXPR const
 #else


### PR DESCRIPTION
Resolves #1304 
On Windows, clang defines `_MSC_VER`, so the MSVC workaround needs to not happen when the clang define is set.