### PR TITLE
Fix Clang with MSVC standard library

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -368,7 +368,7 @@ constexpr auto gcc_clang_msvc_min_versions(
 }
 
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang_major__)
    // MSVC can't handle 'inline constexpr' variables yet in all cases
     #define CPP2_CONSTEXPR const
 #else


### PR DESCRIPTION
When compiling with Clang and MSVC as the standard library, clang defines the _MSC_VER and _MSC_FULL_VER macros.
Use the __clang_major__ macro to ensure that the code is compiled with MSVC.