### PR TITLE
Feat: Add ability to compile from stdin

### DIFF
--- a/source/common.h
+++ b/source/common.h
@@ -799,7 +799,9 @@ public:
             [](auto& a, auto& b){ return a.group < b.group || (a.group == b.group && a.name < b.name); }
         );
 
-        print("\nUsage: cppfront [options] file ...\n\nOptions:\n");
+        print("\nUsage: cppfront [options] file ...\n");
+        print("\nfile - The source file(s) to compile (can be 'stdin' to read text directly) \n");
+        print("\nOptions: \n");
         int last_group = -1;
         for (auto& flag : flags) {
             //  Skip hidden flags

--- a/source/common.h
+++ b/source/common.h
@@ -800,7 +800,7 @@ public:
         );
 
         print("\nUsage: cppfront [options] file ...\n");
-        print("\nfile - The source file(s) to compile (can be 'stdin' to read text directly) \n");
+        print("\n  file                    source file(s) (can be 'stdin')\n");
         print("\nOptions: \n");
         int last_group = -1;
         for (auto& flag : flags) {

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -84,7 +84,12 @@ auto main(
         }
 
         //  Load + lex + parse + sema
-        cppfront c(arg.text);
+        cppfront c = [&]() -> cppfront {
+            if (arg.text == "stdin") 
+                return cppfront(std::cin);
+            else
+                return cppfront(arg.text);
+        }();
 
         //  Generate Cpp1 (this may catch additional late errors)
         auto count = c.lower_to_cpp1();

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -79,7 +79,12 @@ auto main(
 
         auto& out = flag_cpp1_filename != "stdout" ? std::cout : std::cerr;
 
-        if (!flag_quiet) {
+        if (
+            !flag_quiet
+            && arg.text != "stdin"
+            && flag_cpp1_filename != "stdout"
+            ) 
+        {
             out << arg.text << "...";
         }
 
@@ -92,7 +97,10 @@ auto main(
         //  If there were no errors, say so and generate Cpp1
         if (c.had_no_errors())
         {
-            if (!flag_quiet)
+            if (
+                !flag_quiet
+                && flag_cpp1_filename != "stdout"
+                )
             {
                 if (!c.has_cpp1()) {
                     out << " ok (all Cpp2, passes safety checks)\n";

--- a/source/cppfront.cpp
+++ b/source/cppfront.cpp
@@ -84,12 +84,7 @@ auto main(
         }
 
         //  Load + lex + parse + sema
-        cppfront c = [&]() -> cppfront {
-            if (arg.text == "stdin") 
-                return cppfront(std::cin);
-            else
-                return cppfront(arg.text);
-        }();
+        cppfront c(arg.text);
 
         //  Generate Cpp1 (this may catch additional late errors)
         auto count = c.lower_to_cpp1();

--- a/source/io.h
+++ b/source/io.h
@@ -884,10 +884,14 @@ public:
     {
         //  If filename is stdin, we read from stdin, otherwise we try to read the file
         //
-        std::ifstream fss{ filename };
-        std::istream& in = filename == "stdin" ? std::cin : fss;
-        if (filename != "stdin" && !fss.is_open())
-            return false;
+        auto is_stdin = filename == "stdin";
+        std::ifstream fss;
+        if (is_stdin) 
+        {
+            fss.open(filename);
+            if( !fss.is_open()) { return false; }
+        }
+        std::istream& in = is_stdin ? std::cin : fss;
     
         auto in_comment            = false;
         auto in_string_literal     = false;

--- a/source/io.h
+++ b/source/io.h
@@ -882,25 +882,11 @@ public:
     )
         -> bool
     {
-        std::ifstream in{ filename };
-        if (!in.is_open()) {
+        std::ifstream fss{ filename };
+        std::istream& in = filename == "stdin" ? std::cin : fss;
+        if (filename != "stdin" && !fss.is_open())
             return false;
-        }
-
-        return load(in);
-    }
-
-    //-----------------------------------------------------------------------
-    //  load: Read a line-by-line view of a source file, preserving line breaks
-    //
-    //  in                      the loaded source file
-    //  source                  program textual representation
-    //
-    auto load(
-        std::istream&  in
-    )
-        -> bool
-    {
+    
         auto in_comment            = false;
         auto in_string_literal     = false;
         auto in_raw_string_literal = false;

--- a/source/io.h
+++ b/source/io.h
@@ -882,6 +882,8 @@ public:
     )
         -> bool
     {
+        //  If filename is stdin, we read from stdin, otherwise we try to read the file
+        //
         std::ifstream fss{ filename };
         std::istream& in = filename == "stdin" ? std::cin : fss;
         if (filename != "stdin" && !fss.is_open())

--- a/source/io.h
+++ b/source/io.h
@@ -886,7 +886,7 @@ public:
         //
         auto is_stdin = filename == "stdin";
         std::ifstream fss;
-        if (is_stdin) 
+        if (!is_stdin) 
         {
             fss.open(filename);
             if( !fss.is_open()) { return false; }

--- a/source/io.h
+++ b/source/io.h
@@ -887,6 +887,20 @@ public:
             return false;
         }
 
+        return load(in);
+    }
+
+    //-----------------------------------------------------------------------
+    //  load: Read a line-by-line view of a source file, preserving line breaks
+    //
+    //  in                      the loaded source file
+    //  source                  program textual representation
+    //
+    auto load(
+        std::istream&  in
+    )
+        -> bool
+    {
         auto in_comment            = false;
         auto in_string_literal     = false;
         auto in_raw_string_literal = false;

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -1258,14 +1258,18 @@ public:
         }
 
         //  Now we'll open the Cpp1 file
-        auto cpp1_filename = sourcefile.substr(0, std::ssize(sourcefile) - 1);
+        //  Default to stdout if input is stdin
+        auto cpp1_filename = std::string{"stdout"};
+        if (sourcefile != "stdin") {
+            assert(sourcefile.ends_with("2"));
+            cpp1_filename = sourcefile.substr(0, std::ssize(sourcefile) - 1);
+        }
         
-        //  Use explicit filename override if present,
-        //  otherwise strip leading path
+        //  Use explicit filename override if present, otherwise strip leading path
         if (!flag_cpp1_filename.empty()) {
             cpp1_filename = flag_cpp1_filename;
         }
-        else {
+        else if (cpp1_filename != "stdout") {
             cpp1_filename = std::filesystem::path(cpp1_filename).filename().string();
         }
 

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -1179,6 +1179,7 @@ public:
         if (
             !sourcefile.ends_with(".cpp2")
             && !sourcefile.ends_with(".h2")
+            && sourcefile != "stdin"
             )
         {
             errors.emplace_back(
@@ -1202,78 +1203,37 @@ public:
 
         else
         {
-            process_cpp2();
-        }
-    }
+            //  Tokenize
+            //
+            tokens.lex(source.get_lines());
 
-    //-----------------------------------------------------------------------
-    //  Constructor
-    //
-    //  source_stream    the contents of a source file to be processed
-    //
-    cppfront(std::istream& source_stream)
-        : sourcefile{ "stdin.cpp2" }
-        , source    { errors }
-        , tokens    { errors }
-        , parser    { errors, includes }
-        , sema      { errors }
-    {
-        //  Load the program file into memory
-        //
-        if (!source.load(source_stream))
-        {
-            if (errors.empty()) {
-                errors.emplace_back(
-                    source_position(-1, -1),
-                    "error reading source content from stdin"
-                );
-            }
-            source_loaded = false;
-        }
+            //  Parse
+            //
+            try
+            {
+                for (auto const& [line, entry] : tokens.get_map()) {
+                    if (!parser.parse(entry, tokens.get_generated())) {
+                        errors.emplace_back(
+                            source_position(line, 0),
+                            "parse failed for section starting here",
+                            false,
+                            true    // a noisy fallback error message
+                        );
+                    }
+                }
 
-        else
-        {
-            process_cpp2();
-        }
-    }
-
-    //-----------------------------------------------------------------------
-    //  process_cpp2
-    //
-    //  Runs the lexer and parser on the loaded source code
-    //
-    auto process_cpp2() -> void
-    {
-        //  Tokenize
-        //
-        tokens.lex(source.get_lines());
-
-        //  Parse
-        //
-        try
-        {
-            for (auto const& [line, entry] : tokens.get_map()) {
-                if (!parser.parse(entry, tokens.get_generated())) {
-                    errors.emplace_back(
-                        source_position(line, 0),
-                        "parse failed for section starting here",
-                        false,
-                        true    // a noisy fallback error message
-                    );
+                //  Sema
+                parser.visit(sema);
+                if (!sema.apply_local_rules()) {
+                    violates_initialization_safety = true;
                 }
             }
-
-            //  Sema
-            parser.visit(sema);
-            if (!sema.apply_local_rules()) {
-                violates_initialization_safety = true;
+            catch (std::runtime_error& e) {
+                errors.emplace_back(
+                    source_position(-1, -1),
+                    e.what()
+                );
             }
-        }
-        catch (std::runtime_error& e) {
-            errors.emplace_back(
-                source_position(-1, -1),
-                e.what()
-            );
         }
     }
 

--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -1237,6 +1237,11 @@ public:
         }
     }
 
+    //-----------------------------------------------------------------------
+    //  process_cpp2
+    //
+    //  Runs the lexer and parser on the loaded source code
+    //
     auto process_cpp2() -> void
     {
         //  Tokenize


### PR DESCRIPTION
This PR adds the ability to compile from `stdin`. 

This is useful so that cppfront can compile source code that's been piped in from another program. 
For my use-case specifically: when working on the LSP server, we already have access to source code within a `TextDocument` variable. 

Prior to this PR, we have to either save the edited content to a temporary file, or save the source file itself prior to invoking cppfront, otherwise we end up with stale diagnostics data.

Happy to fix any issues anyone finds!

Thanks! 