### PR TITLE
CI Update test after recent mods

### DIFF
--- a/regression-tests/test-results/apple-clang-14-c++2b/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/apple-clang-14-c++2b/pure2-last-use.cpp.output
@@ -49,26 +49,31 @@ class issue_857_4 {
 pure2-last-use.cpp2:905:1: note: still within definition of 'issue_857_4' here
 namespace captures {
 ^
-pure2-last-use.cpp2:279:272: error: no member named 'move_only_function' in namespace 'std'
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                          ~~~~~^
-pure2-last-use.cpp2:279:299: error: expected expression
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                          ^
-pure2-last-use.cpp2:279:304: error: use of address-of-label extension outside of a function body
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                               ^
-pure2-last-use.cpp2:278:14: error: out-of-line definition of 'issue_857_4' does not match any declaration in 'issue_857_4'
-issue_857_4::issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-             ^~~~~~~~~~~
-pure2-last-use.cpp2:281:272: error: member initializer 'g' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , g{ CPP2_FORWARD(g_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:282:272: error: member initializer 'mf' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mf{ CPP2_FORWARD(mf_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:283:272: error: member initializer 'mg' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mg{ CPP2_FORWARD(mg_) }{}
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-fatal error: too many errors emitted, stopping now [-ferror-limit=]
-20 errors generated.
+pure2-last-use.cpp2:279:179: error: expected variable name or 'this' in lambda capture list
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                                  ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:173: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                            ^
+pure2-last-use.cpp2:1045:1: error: expected a type
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:154: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                         ^
+pure2-last-use.cpp2:1045:1: error: expected a type
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:120: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                       ^
+pure2-last-use.cpp2:1045:1: error: expected function body after function declarator
+^
+19 errors generated.

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-last-use.cpp.output
@@ -49,26 +49,31 @@ class issue_857_4 {
 pure2-last-use.cpp2:905:1: note: still within definition of 'issue_857_4' here
 namespace captures {
 ^
-pure2-last-use.cpp2:279:272: error: no member named 'move_only_function' in namespace 'std'
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                          ~~~~~^
-pure2-last-use.cpp2:279:299: error: expected expression
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                          ^
-pure2-last-use.cpp2:279:304: error: use of address-of-label extension outside of a function body
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                               ^
-pure2-last-use.cpp2:278:14: error: out-of-line definition of 'issue_857_4' does not match any declaration in 'issue_857_4'
-issue_857_4::issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-             ^~~~~~~~~~~
-pure2-last-use.cpp2:281:272: error: member initializer 'g' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , g{ CPP2_FORWARD(g_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:282:272: error: member initializer 'mf' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mf{ CPP2_FORWARD(mf_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:283:272: error: member initializer 'mg' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mg{ CPP2_FORWARD(mg_) }{}
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-fatal error: too many errors emitted, stopping now [-ferror-limit=]
-20 errors generated.
+pure2-last-use.cpp2:279:179: error: expected variable name or 'this' in lambda capture list
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                                  ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:173: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                            ^
+pure2-last-use.cpp2:1045:1: error: type name requires a specifier or qualifier
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:154: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                         ^
+pure2-last-use.cpp2:1045:1: error: type name requires a specifier or qualifier
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:120: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                       ^
+pure2-last-use.cpp2:1045:1: error: expected function body after function declarator
+^
+19 errors generated.

--- a/regression-tests/test-results/clang-12-c++20/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/clang-12-c++20/pure2-last-use.cpp.output
@@ -49,26 +49,31 @@ class issue_857_4 {
 pure2-last-use.cpp2:905:1: note: still within definition of 'issue_857_4' here
 namespace captures {
 ^
-pure2-last-use.cpp2:279:272: error: no member named 'move_only_function' in namespace 'std'
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                          ~~~~~^
-pure2-last-use.cpp2:279:299: error: expected expression
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                          ^
-pure2-last-use.cpp2:279:304: error: use of address-of-label extension outside of a function body
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                               ^
-pure2-last-use.cpp2:278:14: error: out-of-line definition of 'issue_857_4' does not match any declaration in 'issue_857_4'
-issue_857_4::issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-             ^~~~~~~~~~~
-pure2-last-use.cpp2:281:272: error: member initializer 'g' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , g{ CPP2_FORWARD(g_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:282:272: error: member initializer 'mf' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mf{ CPP2_FORWARD(mf_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:283:272: error: member initializer 'mg' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mg{ CPP2_FORWARD(mg_) }{}
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-fatal error: too many errors emitted, stopping now [-ferror-limit=]
-20 errors generated.
+pure2-last-use.cpp2:279:179: error: expected variable name or 'this' in lambda capture list
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                                  ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:173: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                            ^
+pure2-last-use.cpp2:1045:1: error: expected a type
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:154: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                         ^
+pure2-last-use.cpp2:1045:1: error: expected a type
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:120: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                       ^
+pure2-last-use.cpp2:1045:1: error: expected function body after function declarator
+^
+19 errors generated.

--- a/regression-tests/test-results/clang-15-c++20-libcpp/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/pure2-last-use.cpp.output
@@ -49,26 +49,31 @@ class issue_857_4 {
 pure2-last-use.cpp2:905:1: note: still within definition of 'issue_857_4' here
 namespace captures {
 ^
-pure2-last-use.cpp2:279:272: error: no member named 'move_only_function' in namespace 'std'
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                          ~~~~~^
-pure2-last-use.cpp2:279:299: error: expected expression
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                          ^
-pure2-last-use.cpp2:279:304: error: use of address-of-label extension outside of a function body
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                               ^
-pure2-last-use.cpp2:278:14: error: out-of-line definition of 'issue_857_4' does not match any declaration in 'issue_857_4'
-issue_857_4::issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-             ^~~~~~~~~~~
-pure2-last-use.cpp2:281:272: error: member initializer 'g' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , g{ CPP2_FORWARD(g_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:282:272: error: member initializer 'mf' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mf{ CPP2_FORWARD(mf_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:283:272: error: member initializer 'mg' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mg{ CPP2_FORWARD(mg_) }{}
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-fatal error: too many errors emitted, stopping now [-ferror-limit=]
-20 errors generated.
+pure2-last-use.cpp2:279:179: error: expected variable name or 'this' in lambda capture list
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                                  ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:173: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                            ^
+pure2-last-use.cpp2:1045:1: error: expected a type
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:154: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                         ^
+pure2-last-use.cpp2:1045:1: error: expected a type
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:120: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                       ^
+pure2-last-use.cpp2:1045:1: error: expected function body after function declarator
+^
+19 errors generated.

--- a/regression-tests/test-results/clang-15-c++20/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/clang-15-c++20/pure2-last-use.cpp.output
@@ -49,26 +49,31 @@ class issue_857_4 {
 pure2-last-use.cpp2:905:1: note: still within definition of 'issue_857_4' here
 namespace captures {
 ^
-pure2-last-use.cpp2:279:272: error: no member named 'move_only_function' in namespace 'std'
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                          ~~~~~^
-pure2-last-use.cpp2:279:299: error: expected expression
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                          ^
-pure2-last-use.cpp2:279:304: error: use of address-of-label extension outside of a function body
-requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-                                                                                                                                                                                                                                                                                                               ^
-pure2-last-use.cpp2:278:14: error: out-of-line definition of 'issue_857_4' does not match any declaration in 'issue_857_4'
-issue_857_4::issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-             ^~~~~~~~~~~
-pure2-last-use.cpp2:281:272: error: member initializer 'g' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , g{ CPP2_FORWARD(g_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:282:272: error: member initializer 'mf' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mf{ CPP2_FORWARD(mf_) }
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:283:272: error: member initializer 'mg' does not name a non-static data member or base class
-                                                                                                                                                                                                                                                                             , mg{ CPP2_FORWARD(mg_) }{}
-                                                                                                                                                                                                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
-fatal error: too many errors emitted, stopping now [-ferror-limit=]
-20 errors generated.
+pure2-last-use.cpp2:279:179: error: expected variable name or 'this' in lambda capture list
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                                  ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:173: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                                            ^
+pure2-last-use.cpp2:1045:1: error: expected a type
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:154: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                                                         ^
+pure2-last-use.cpp2:1045:1: error: expected a type
+^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+}
+ ^
+pure2-last-use.cpp2:279:120: note: to match this '<'
+requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+                                                                                                                       ^
+pure2-last-use.cpp2:1045:1: error: expected function body after function declarator
+^
+19 errors generated.

--- a/regression-tests/test-results/clang-18-c++20/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/clang-18-c++20/pure2-last-use.cpp.output
@@ -49,26 +49,34 @@ pure2-last-use.cpp2:271:7: error: missing '}' at end of definition of 'issue_857
 pure2-last-use.cpp2:905:1: note: still within definition of 'issue_857_4' here
   905 | namespace captures {
       | ^
-pure2-last-use.cpp2:279:272: error: no member named 'move_only_function' in namespace 'std'
-  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-      |                                                                                                                                                                                                                                                                           ~~~~~^
-pure2-last-use.cpp2:279:299: error: expected expression
-  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-      |                                                                                                                                                                                                                                                                                                           ^
-pure2-last-use.cpp2:279:304: error: use of address-of-label extension outside of a function body
-  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-      |                                                                                                                                                                                                                                                                                                                ^
-pure2-last-use.cpp2:278:14: error: out-of-line definition of 'issue_857_4' does not match any declaration in 'issue_857_4'
-  278 | issue_857_4::issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-      |              ^~~~~~~~~~~
-pure2-last-use.cpp2:281:272: error: member initializer 'g' does not name a non-static data member or base class
-  281 |                                                                                                                                                                                                                                                                              , g{ CPP2_FORWARD(g_) }
-      |                                                                                                                                                                                                                                                                                ^~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:282:272: error: member initializer 'mf' does not name a non-static data member or base class
-  282 |                                                                                                                                                                                                                                                                              , mf{ CPP2_FORWARD(mf_) }
-      |                                                                                                                                                                                                                                                                                ^~~~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:283:272: error: member initializer 'mg' does not name a non-static data member or base class
-  283 |                                                                                                                                                                                                                                                                              , mg{ CPP2_FORWARD(mg_) }{}
-      |                                                                                                                                                                                                                                                                                ^~~~~~~~~~~~~~~~~~~~~~~
-fatal error: too many errors emitted, stopping now [-ferror-limit=]
-20 errors generated.
+pure2-last-use.cpp2:279:179: error: expected variable name or 'this' in lambda capture list
+  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+      |                                                                                                                                                                                   ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+ 1044 | }
+      |  ^
+pure2-last-use.cpp2:279:173: note: to match this '<'
+  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+      |                                                                                                                                                                             ^
+pure2-last-use.cpp2:1045:1: error: type name requires a specifier or qualifier
+ 1045 | 
+      | ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+ 1044 | }
+      |  ^
+pure2-last-use.cpp2:279:154: note: to match this '<'
+  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+      |                                                                                                                                                          ^
+pure2-last-use.cpp2:1045:1: error: type name requires a specifier or qualifier
+ 1045 | 
+      | ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+ 1044 | }
+      |  ^
+pure2-last-use.cpp2:279:120: note: to match this '<'
+  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+      |                                                                                                                        ^
+pure2-last-use.cpp2:1045:1: error: expected function body after function declarator
+ 1045 | 
+      | ^
+19 errors generated.

--- a/regression-tests/test-results/clang-18-c++23-libcpp/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/clang-18-c++23-libcpp/pure2-last-use.cpp.output
@@ -49,26 +49,34 @@ pure2-last-use.cpp2:271:7: error: missing '}' at end of definition of 'issue_857
 pure2-last-use.cpp2:905:1: note: still within definition of 'issue_857_4' here
   905 | namespace captures {
       | ^
-pure2-last-use.cpp2:279:272: error: no member named 'move_only_function' in namespace 'std'
-  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-      |                                                                                                                                                                                                                                                                           ~~~~~^
-pure2-last-use.cpp2:279:299: error: expected expression
-  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-      |                                                                                                                                                                                                                                                                                                           ^
-pure2-last-use.cpp2:279:304: error: use of address-of-label extension outside of a function body
-  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int(cpp2::impl::in<int> in_)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int(cpp2::impl::in<int> in_)>>&>) 
-      |                                                                                                                                                                                                                                                                                                                ^
-pure2-last-use.cpp2:278:14: error: out-of-line definition of 'issue_857_4' does not match any declaration in 'issue_857_4'
-  278 | issue_857_4::issue_857_4(auto&& f_, auto&& g_, auto&& mf_, auto&& mg_)
-      |              ^~~~~~~~~~~
-pure2-last-use.cpp2:281:272: error: member initializer 'g' does not name a non-static data member or base class
-  281 |                                                                                                                                                                                                                                                                              , g{ CPP2_FORWARD(g_) }
-      |                                                                                                                                                                                                                                                                                ^~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:282:272: error: member initializer 'mf' does not name a non-static data member or base class
-  282 |                                                                                                                                                                                                                                                                              , mf{ CPP2_FORWARD(mf_) }
-      |                                                                                                                                                                                                                                                                                ^~~~~~~~~~~~~~~~~~~~~~~
-pure2-last-use.cpp2:283:272: error: member initializer 'mg' does not name a non-static data member or base class
-  283 |                                                                                                                                                                                                                                                                              , mg{ CPP2_FORWARD(mg_) }{}
-      |                                                                                                                                                                                                                                                                                ^~~~~~~~~~~~~~~~~~~~~~~
-fatal error: too many errors emitted, stopping now [-ferror-limit=]
-20 errors generated.
+pure2-last-use.cpp2:279:179: error: expected variable name or 'this' in lambda capture list
+  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+      |                                                                                                                                                                                   ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+ 1044 | }
+      |  ^
+pure2-last-use.cpp2:279:173: note: to match this '<'
+  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+      |                                                                                                                                                                             ^
+pure2-last-use.cpp2:1045:1: error: type name requires a specifier or qualifier
+ 1045 | 
+      | ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+ 1044 | }
+      |  ^
+pure2-last-use.cpp2:279:154: note: to match this '<'
+  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+      |                                                                                                                                                          ^
+pure2-last-use.cpp2:1045:1: error: type name requires a specifier or qualifier
+ 1045 | 
+      | ^
+pure2-last-use.cpp2:1044:2: error: expected '>'
+ 1044 | }
+      |  ^
+pure2-last-use.cpp2:279:120: note: to match this '<'
+  279 | requires (std::is_convertible_v<CPP2_TYPEOF(f_), std::add_const_t<std::add_pointer_t<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(g_), std::add_const_t<std::add_pointer_t<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&> && std::is_convertible_v<CPP2_TYPEOF(mf_), std::add_const_t<std::move_only_function<int()>>&> && std::is_convertible_v<CPP2_TYPEOF(mg_), std::add_const_t<std::move_only_function<int([[maybe_unused]] cpp2::impl::in<int> unnamed_param_1)>>&>) 
+      |                                                                                                                        ^
+pure2-last-use.cpp2:1045:1: error: expected function body after function declarator
+ 1045 | 
+      | ^
+19 errors generated.

--- a/regression-tests/test-results/gcc-10-c++20/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-last-use.cpp.output
@@ -102,9 +102,9 @@ pure2-last-use.cpp2:266:7: note: candidates are: ‘issue_857_6& issue_857_6::op
 pure2-last-use.cpp2:266:7: note:                 ‘issue_857_6& issue_857_6::operator=(const issue_857_6&)’
 pure2-last-use.cpp2:272:14: note:                 ‘template<class auto:125> issue_857_6& issue_857_6::operator=(auto:125&&)’
 pure2-last-use.cpp2:266:7: note: ‘class issue_857_6’ defined here
-pure2-last-use.cpp2:279:272: error: ‘move_only_function’ is not a member of ‘std’
-pure2-last-use.cpp2:279:295: error: template argument 1 is invalid
-pure2-last-use.cpp2:279:299: error: expected primary-expression before ‘>’ token
-pure2-last-use.cpp2:279:304: error: label ‘std’ referenced outside of any function
-pure2-last-use.cpp2:279:307: error: expected ‘)’ before ‘::’ token
+pure2-last-use.cpp2:279:301: error: ‘move_only_function’ is not a member of ‘std’
+pure2-last-use.cpp2:279:324: error: template argument 1 is invalid
+pure2-last-use.cpp2:279:328: error: expected primary-expression before ‘>’ token
+pure2-last-use.cpp2:279:333: error: label ‘std’ referenced outside of any function
+pure2-last-use.cpp2:279:336: error: expected ‘)’ before ‘::’ token
 pure2-last-use.cpp2:280: confused by earlier errors, bailing out

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
@@ -1,6 +1,6 @@
 pure2-assert-expected-not-null.cpp
 pure2-assert-expected-not-null.cpp2(7): error C2039: 'expected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-assert-expected-not-null.cpp2(7): error C2062: type 'int' unexpected
 pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' before '{'
 pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' before '}'
@@ -8,13 +8,13 @@ pure2-assert-expected-not-null.cpp2(9): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(9): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
 ..\..\..\include\cpp2util.h(1047): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
 pure2-assert-expected-not-null.cpp2(14): error C2039: 'expected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-assert-expected-not-null.cpp2(14): error C2062: type 'int' unexpected
 pure2-assert-expected-not-null.cpp2(14): error C2143: syntax error: missing ';' before '{'
 pure2-assert-expected-not-null.cpp2(14): error C2039: 'unexpected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-assert-expected-not-null.cpp2(14): error C2660: 'unexpected': function does not take 1 arguments
-C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\eh.h(33): note: see declaration of 'unexpected'
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\eh.h(33): note: see declaration of 'unexpected'
 pure2-assert-expected-not-null.cpp2(14): note: while trying to match the argument list '(bool)'
 pure2-assert-expected-not-null.cpp2(14): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(15): error C2065: 'ex': undeclared identifier

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-last-use.cpp.output
@@ -1,13 +1,94 @@
 pure2-last-use.cpp
 pure2-last-use.cpp2(274): error C2039: 'move_only_function': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-last-use.cpp2(274): error C7568: argument list missing after assumed function template 'move_only_function'
 pure2-last-use.cpp2(274): error C2062: type 'unknown-type' unexpected
 pure2-last-use.cpp2(274): error C2238: unexpected token(s) preceding ';'
 pure2-last-use.cpp2(275): error C2039: 'move_only_function': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-last-use.cpp2(275): error C7568: argument list missing after assumed function template 'move_only_function'
 pure2-last-use.cpp2(275): error C2062: type 'unknown-type' unexpected
 pure2-last-use.cpp2(275): error C2238: unexpected token(s) preceding ';'
 pure2-last-use.cpp2(277): error C2760: syntax error: '>' was unexpected here; expected 'expression'
-pure2-last-use.cpp2(276): fatal error C1907: unable to recover from previous error(s); stopping compilation
+pure2-last-use.cpp2(277): error C2760: syntax error: '>' was unexpected here; expected ';'
+pure2-last-use.cpp2(277): error C2059: syntax error: '>'
+pure2-last-use.cpp2(344): error C2039: 'move_only_function': is not a member of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
+pure2-last-use.cpp2(344): error C7568: argument list missing after assumed function template 'move_only_function'
+pure2-last-use.cpp2(344): error C2062: type 'unknown-type' unexpected
+pure2-last-use.cpp2(344): error C2238: unexpected token(s) preceding ';'
+pure2-last-use.cpp2(348): error C2760: syntax error: '>' was unexpected here; expected 'expression'
+pure2-last-use.cpp2(348): error C2760: syntax error: '>' was unexpected here; expected ';'
+pure2-last-use.cpp2(348): error C2059: syntax error: '>'
+pure2-last-use.cpp2(773): error C2039: 'move_only_function': is not a member of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
+pure2-last-use.cpp2(773): error C2061: syntax error: identifier 'move_only_function'
+pure2-last-use.cpp2(279): error C2760: syntax error: '>' was unexpected here; expected 'expression'
+pure2-last-use.cpp2(278): error C2244: 'issue_857_4::{ctor}': unable to match function definition to an existing declaration
+pure2-last-use.cpp2(278): note: see declaration of 'issue_857_4::{ctor}'
+pure2-last-use.cpp2(278): note: definition
+pure2-last-use.cpp2(278): note: 'void issue_857_4::{ctor}(_T0 &&,_T1 &&,_T2 &&,_T3 &&)'
+pure2-last-use.cpp2(278): note: existing declarations
+pure2-last-use.cpp2(329): note: 'issue_857_4::issue_857_4(issue_857_4 &&)'
+pure2-last-use.cpp2(329): note: 'issue_857_4::issue_857_4(const issue_857_4 &)'
+pure2-last-use.cpp2(276): note: 'issue_857_4::issue_857_4(_T0 &&,_T1 &&,_T2 &&,_T3 &&)'
+pure2-last-use.cpp2(279): error C2760: syntax error: '>' was unexpected here; expected ';'
+pure2-last-use.cpp2(279): error C2059: syntax error: '>'
+pure2-last-use.cpp2(279): error C2065: 'mg_': undeclared identifier
+pure2-last-use.cpp2(279): error C3553: decltype expects an expression not a type
+pure2-last-use.cpp2(279): error C2039: 'move_only_function': is not a member of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
+pure2-last-use.cpp2(279): error C2143: syntax error: missing ')' before 'attribute specifier'
+pure2-last-use.cpp2(279): error C2065: 'move_only_function': undeclared identifier
+pure2-last-use.cpp2(279): error C2059: syntax error: 'attribute specifier'
+pure2-last-use.cpp2(279): error C2947: expecting '>' to terminate template-argument-list, found '>>'
+pure2-last-use.cpp2(279): error C2059: syntax error: ')'
+pure2-last-use.cpp2(280): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
+pure2-last-use.cpp2(280): error C2065: 'f_': undeclared identifier
+pure2-last-use.cpp2(280): error C3553: decltype expects an expression not a type
+pure2-last-use.cpp2(281): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
+pure2-last-use.cpp2(281): error C2065: 'g_': undeclared identifier
+pure2-last-use.cpp2(281): error C3553: decltype expects an expression not a type
+pure2-last-use.cpp2(282): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
+pure2-last-use.cpp2(282): error C2065: 'mf_': undeclared identifier
+pure2-last-use.cpp2(282): error C3553: decltype expects an expression not a type
+pure2-last-use.cpp2(283): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
+pure2-last-use.cpp2(283): error C2065: 'mg_': undeclared identifier
+pure2-last-use.cpp2(283): error C3553: decltype expects an expression not a type
+pure2-last-use.cpp2(283): error C2059: syntax error: '{'
+pure2-last-use.cpp2(283): error C2143: syntax error: missing ';' before '{'
+pure2-last-use.cpp2(283): error C2447: '{': missing function header (old-style formal list?)
+pure2-last-use.cpp2(349): error C2760: syntax error: '>' was unexpected here; expected 'expression'
+pure2-last-use.cpp2(348): error C2244: 'issue_857_8::{ctor}': unable to match function definition to an existing declaration
+pure2-last-use.cpp2(348): note: see declaration of 'issue_857_8::{ctor}'
+pure2-last-use.cpp2(348): note: definition
+pure2-last-use.cpp2(348): note: 'void issue_857_8::{ctor}(_T0 &&,_T1 &&,_T2 &&)'
+pure2-last-use.cpp2(348): note: existing declarations
+pure2-last-use.cpp2(347): note: 'issue_857_8::issue_857_8(issue_857_8 &&)'
+pure2-last-use.cpp2(347): note: 'issue_857_8::issue_857_8(const issue_857_8 &)'
+pure2-last-use.cpp2(347): note: 'issue_857_8::issue_857_8(_T0 &&,_T1 &&,_T2 &&)'
+pure2-last-use.cpp2(349): error C2760: syntax error: '>' was unexpected here; expected ';'
+pure2-last-use.cpp2(349): error C2059: syntax error: '>'
+pure2-last-use.cpp2(349): error C2065: 'c_': undeclared identifier
+pure2-last-use.cpp2(349): error C3553: decltype expects an expression not a type
+pure2-last-use.cpp2(349): error C2059: syntax error: ')'
+pure2-last-use.cpp2(350): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
+pure2-last-use.cpp2(350): error C2065: 'a_': undeclared identifier
+pure2-last-use.cpp2(350): error C3553: decltype expects an expression not a type
+pure2-last-use.cpp2(351): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
+pure2-last-use.cpp2(351): error C2065: 'b_': undeclared identifier
+pure2-last-use.cpp2(351): error C3553: decltype expects an expression not a type
+pure2-last-use.cpp2(352): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
+pure2-last-use.cpp2(352): error C2065: 'c_': undeclared identifier
+pure2-last-use.cpp2(352): error C3553: decltype expects an expression not a type
+pure2-last-use.cpp2(352): error C2059: syntax error: '{'
+pure2-last-use.cpp2(352): error C2143: syntax error: missing ';' before '{'
+pure2-last-use.cpp2(352): error C2447: '{': missing function header (old-style formal list?)
+pure2-last-use.cpp2(773): error C2039: 'move_only_function': is not a member of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
+pure2-last-use.cpp2(773): error C2061: syntax error: identifier 'move_only_function'
+pure2-last-use.cpp2(774): error C3861: 'size': identifier not found
+pure2-last-use.cpp2(774): note: This diagnostic occurred in the compiler generated function 'decltype(auto) issue_888_1::<lambda_1>::operator ()(Obj &&,Params ...) noexcept(<expr>) const'
+pure2-last-use.cpp2(774): error C2065: 'size': undeclared identifier
+pure2-last-use.cpp2(774): note: This diagnostic occurred in the compiler generated function 'decltype(auto) issue_888_1::<lambda_1>::operator ()(Obj &&,Params ...) noexcept(<expr>) const'
+pure2-last-use.cpp2(773): fatal error C1075: '{': no matching token found


### PR DESCRIPTION
Updates results of `pure2-last-use.cpp2` for a number of compilers, including clang-18.
The results for clang-18 were generated with the fix from #1335 applied.
Together with #1335 this PR makes all the tests pass on CI.
