### PR TITLE
Updates for missing features in regular expressions.

### DIFF
--- a/docs/notes/regex_status.md
+++ b/docs/notes/regex_status.md
@@ -15,7 +15,7 @@ The listings are taken from the [Perl regex docs](https://perldoc.perl.org/perlr
 | **`s`** | Treat the string as single line. That is, change `.` to match any character whatsoever, even a newline, which normally it would not match. | <span style="color:green">Supported</span> |
 | ***`x` and `xx`** | Extend your pattern's legibility by permitting whitespace and comments. For details see: [Perl regex docs: `/x` and `/xx`](https://perldoc.perl.org/perlre#/x-and-/xx). | <span style="color:green">Supported</span> |
 | **`n`** | Prevent the grouping metacharacters `(` and `)` from capturing. This modifier will stop `$1`, `$2`, etc. from being filled in. | <span style="color:green">Supported</span> |
-| **`c`** | Keep the current position during repeated matching. | <span style="color:gray">Planned</span> |
+| **`c`** | Keep the current position during repeated matching. | <span style="color:green">Supported</span> |
 
 
 ### Escape sequences __(Complete)__
@@ -96,7 +96,7 @@ The listings are taken from the [Perl regex docs](https://perldoc.perl.org/perlr
 | **`\A`** |     Match only at beginning of string | <span style="color:green">Supported</span> | 
 | **`\Z`** |     Match only at end of string, or before newline at the end | <span style="color:green">Supported</span> | 
 | **`\z`** |     Match only at end of string | <span style="color:green">Supported</span> | 
-| **`\G`** |     Match only at pos() (e.g. at the end-of-match position of prior m//g) | <span style="color:gray">Planned</span> | 
+| **`\G`** |     Match only at pos() (e.g. at the end-of-match position of prior m//g) | <span style="color:green">Supported</span> |
 
 
 ### Capture groups __(Complete)__
@@ -142,12 +142,12 @@ The listings are taken from the [Perl regex docs](https://perldoc.perl.org/perlr
 | **`(?!pattern)`**                     | Negative look ahead. | <span style="color:green">Supported</span> | 
 | **`(*nla:pattern)`**                  | Negative look ahead. | <span style="color:green">Supported</span> | 
 | **`(*negative_lookahead:pattern)`**   | Negative look ahead. | <span style="color:green">Supported</span> | 
-| **`(?<=pattern)`**                    | Positive look behind. | <span style="color:gray">Planned</span> | 
-| **`(*plb:pattern)`**                  | Positive look behind. | <span style="color:gray">Planned</span> | 
-| **`(*positive_lookbehind:pattern)`**  | Positive look behind. | <span style="color:gray">Planned</span> | 
-| **`(?<!pattern)`**                    | Negative look behind. | <span style="color:gray">Planned</span> | 
-| **`(*nlb:pattern)`**                  | Negative look behind. | <span style="color:gray">Planned</span> | 
-| **`(*negative_lookbehind:pattern)`**  | Negative look behind. | <span style="color:gray">Planned</span> | 
+| **`(?<=pattern)`**                    | Positive look behind. | <span style="color:green">Supported</span> |
+| **`(*plb:pattern)`**                  | Positive look behind. | <span style="color:green">Supported</span> |
+| **`(*positive_lookbehind:pattern)`**  | Positive look behind. | <span style="color:green">Supported</span> |
+| **`(?<!pattern)`**                    | Negative look behind. | <span style="color:green">Supported</span> |
+| **`(*nlb:pattern)`**                  | Negative look behind. | <span style="color:green">Supported</span> |
+| **`(*negative_lookbehind:pattern)`**  | Negative look behind. | <span style="color:green">Supported</span> |
 
 
 ### Special Backtracking Control Verbs

--- a/docs/notes/regex_status.md
+++ b/docs/notes/regex_status.md
@@ -128,8 +128,8 @@ The listings are taken from the [Perl regex docs](https://perldoc.perl.org/perlr
 | **`(?'NAME'pattern)`** |            Named capture group | <span style="color:green">Supported</span> | 
 | **`(?(condition)yes-pattern`<code>&#124;</code>`no-pattern)`** |  Conditional patterns. | <span style="color:gray">Planned</span> | 
 | **`(?(condition)yes-pattern)`** |             Conditional patterns. | <span style="color:gray">Planned</span> | 
-| **`(?>pattern)`** |                 Atomic patterns. (Disable backtrack.) | <span style="color:gray">Planned</span> | 
-| **`(*atomic:pattern)`** |           Atomic patterns. (Disable backtrack.) | <span style="color:gray">Planned</span> | 
+| **`(?>pattern)`** |                 Atomic patterns. (Disable backtrack.) | <span style="color:green">Supported</span> |
+| **`(*atomic:pattern)`** |           Atomic patterns. (Disable backtrack.) | <span style="color:green">Supported</span> |
 
 
 ### Lookaround Assertions

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -150,7 +150,7 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 
     private: std::array<match_group<Iter>,max_groups> groups {}; 
 
-    public: explicit match_context(Iter const& begin_, Iter const& end_);
+    public: match_context(Iter const& begin_, Iter const& end_);
 
 #line 66 "cpp2regex.h2"
     public: match_context(match_context const& that);
@@ -210,7 +210,7 @@ template<typename CharT, typename Iter, int max_groups> class reverse_match_cont
             public: ReverseIter begin; 
             public: ReverseIter end; 
 
-    public: explicit reverse_match_context(auto const& forward_context_);
+    public: reverse_match_context(auto const& forward_context_);
 #line 133 "cpp2regex.h2"
     public: auto operator=(auto const& forward_context_) -> reverse_match_context& ;
 
@@ -288,7 +288,7 @@ template<typename Func> class on_return
  {
     private: Func func; 
 
-    public: explicit on_return(Func const& f);
+    public: on_return(Func const& f);
 #line 213 "cpp2regex.h2"
     public: auto operator=(Func const& f) -> on_return& ;
 
@@ -664,10 +664,10 @@ template<typename CharT, typename matcher> class regular_expression
         public: context<Iter> ctx; 
         public: int pos; 
 
-        public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
+        public: search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
 #line 801 "cpp2regex.h2"
-        public: explicit search_return(Iter const& begin, Iter const& end);
+        public: search_return(Iter const& begin, Iter const& end);
 
 #line 807 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -24,53 +24,53 @@ template<typename Iter> class match_return;
 #line 56 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> class match_context;
 
-#line 117 "cpp2regex.h2"
+#line 123 "cpp2regex.h2"
 class true_end_func;
 
-#line 125 "cpp2regex.h2"
+#line 131 "cpp2regex.h2"
 class no_reset;
 
-#line 132 "cpp2regex.h2"
+#line 138 "cpp2regex.h2"
 template<typename Func> class on_return;
 
-#line 159 "cpp2regex.h2"
+#line 165 "cpp2regex.h2"
 template<typename CharT, CharT C> class single_class_entry;
 
-#line 168 "cpp2regex.h2"
+#line 174 "cpp2regex.h2"
 template<typename CharT, CharT Start, CharT End> class range_class_entry;
 
-#line 177 "cpp2regex.h2"
+#line 183 "cpp2regex.h2"
 template<typename CharT, typename ...List> class combined_class_entry;
 
-#line 186 "cpp2regex.h2"
+#line 192 "cpp2regex.h2"
 template<typename CharT, CharT ...List> class list_class_entry;
 
-#line 195 "cpp2regex.h2"
+#line 201 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry;
 
-#line 202 "cpp2regex.h2"
+#line 208 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry;
 
-#line 211 "cpp2regex.h2"
+#line 217 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry;
 
-#line 259 "cpp2regex.h2"
+#line 265 "cpp2regex.h2"
 template<typename CharT> class alternative_token_matcher;
 
-#line 337 "cpp2regex.h2"
+#line 343 "cpp2regex.h2"
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher;
 
-#line 492 "cpp2regex.h2"
+#line 498 "cpp2regex.h2"
 class range_flags;
     
 
-#line 501 "cpp2regex.h2"
+#line 507 "cpp2regex.h2"
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher;
 
-#line 673 "cpp2regex.h2"
+#line 679 "cpp2regex.h2"
 template<typename CharT, typename matcher_wrapper> class regular_expression;
 
-#line 760 "cpp2regex.h2"
+#line 815 "cpp2regex.h2"
 }
 }
 
@@ -188,9 +188,13 @@ template<typename CharT, typename Iter, int max_groups> class match_context
     //
     public: [[nodiscard]] auto fail() const& -> decltype(auto);
     public: [[nodiscard]] auto pass(cpp2::impl::in<Iter> cur) const& -> decltype(auto);
+
+    public: auto reset() & -> void;
+
+#line 118 "cpp2regex.h2"
 };
 
-#line 115 "cpp2regex.h2"
+#line 121 "cpp2regex.h2"
 //  End function that returns a valid match.
 //
 class true_end_func
@@ -198,7 +202,7 @@ class true_end_func
     public: [[nodiscard]] auto operator()(auto const& cur, auto& ctx) const& -> decltype(auto);
 };
 
-#line 123 "cpp2regex.h2"
+#line 129 "cpp2regex.h2"
 //  Empty group reset function.
 //
 class no_reset
@@ -206,30 +210,30 @@ class no_reset
     public: auto operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void;
 };
 
-#line 131 "cpp2regex.h2"
+#line 137 "cpp2regex.h2"
 //  Evaluate func on destruction of the handle.
 template<typename Func> class on_return
  {
     private: Func func; 
 
     public: explicit on_return(Func const& f);
-#line 136 "cpp2regex.h2"
+#line 142 "cpp2regex.h2"
     public: auto operator=(Func const& f) -> on_return& ;
 
-#line 140 "cpp2regex.h2"
+#line 146 "cpp2regex.h2"
     public: ~on_return() noexcept;
     public: on_return(on_return const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(on_return const&) -> void = delete;
 
 
-#line 143 "cpp2regex.h2"
+#line 149 "cpp2regex.h2"
 };
 
-#line 146 "cpp2regex.h2"
+#line 152 "cpp2regex.h2"
 //  Helper for auto deduction of the Func type.
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto);
 
-#line 150 "cpp2regex.h2"
+#line 156 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Character classes for regular expressions.
@@ -247,10 +251,10 @@ template<typename CharT, CharT C> class single_class_entry
     public: single_class_entry(single_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(single_class_entry const&) -> void = delete;
 
-#line 163 "cpp2regex.h2"
+#line 169 "cpp2regex.h2"
 };
 
-#line 166 "cpp2regex.h2"
+#line 172 "cpp2regex.h2"
 //  Class syntax: - Example: a-c
 //
 template<typename CharT, CharT Start, CharT End> class range_class_entry
@@ -261,10 +265,10 @@ template<typename CharT, CharT Start, CharT End> class range_class_entry
     public: range_class_entry(range_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_class_entry const&) -> void = delete;
 
-#line 172 "cpp2regex.h2"
+#line 178 "cpp2regex.h2"
 };
 
-#line 175 "cpp2regex.h2"
+#line 181 "cpp2regex.h2"
 //  Helper for combining two character classes
 //
 template<typename CharT, typename ...List> class combined_class_entry
@@ -275,10 +279,10 @@ template<typename CharT, typename ...List> class combined_class_entry
     public: combined_class_entry(combined_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(combined_class_entry const&) -> void = delete;
 
-#line 181 "cpp2regex.h2"
+#line 187 "cpp2regex.h2"
 };
 
-#line 184 "cpp2regex.h2"
+#line 190 "cpp2regex.h2"
 //  Class syntax: <list of characters>  Example: abcd
 //
 template<typename CharT, CharT ...List> class list_class_entry
@@ -289,10 +293,10 @@ template<typename CharT, CharT ...List> class list_class_entry
     public: list_class_entry(list_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(list_class_entry const&) -> void = delete;
 
-#line 190 "cpp2regex.h2"
+#line 196 "cpp2regex.h2"
 };
 
-#line 193 "cpp2regex.h2"
+#line 199 "cpp2regex.h2"
 //  Class syntax: [:<class name:]  Example: [:alnum:]
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry
@@ -303,10 +307,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class n
     public: named_class_entry(named_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(named_class_entry const&) -> void = delete;
 
-#line 199 "cpp2regex.h2"
+#line 205 "cpp2regex.h2"
 };
 
-#line 202 "cpp2regex.h2"
+#line 208 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry
 : public Inner {
 
@@ -315,10 +319,10 @@ template<typename CharT, typename Inner> class negated_class_entry
     public: negated_class_entry(negated_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(negated_class_entry const&) -> void = delete;
 
-#line 206 "cpp2regex.h2"
+#line 212 "cpp2regex.h2"
 };
 
-#line 209 "cpp2regex.h2"
+#line 215 "cpp2regex.h2"
 //  Short class syntax: \<character>  Example: \w
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry
@@ -329,10 +333,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class s
     public: shorthand_class_entry(shorthand_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(shorthand_class_entry const&) -> void = delete;
 
-#line 215 "cpp2regex.h2"
+#line 221 "cpp2regex.h2"
 };
 
-#line 218 "cpp2regex.h2"
+#line 224 "cpp2regex.h2"
 //  Named basic character classes
 //
 template        <typename CharT> using digits_class = named_class_entry<CharT,"digits",range_class_entry<CharT,'0','9'>>;
@@ -369,7 +373,7 @@ template                     <typename CharT> using short_not_space_class = nega
 template<typename CharT> using short_not_vert_space_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\V",ver_space_class<CharT>>>;
 template                     <typename CharT> using short_not_word_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\W",word_class<CharT>>>;
 
-#line 255 "cpp2regex.h2"
+#line 261 "cpp2regex.h2"
 //  Regex syntax: |  Example: ab|ba
 //
 //  Non greedy implementation. First alternative that matches is chosen.
@@ -378,22 +382,22 @@ template<typename CharT> class alternative_token_matcher
  {
     public: [[nodiscard]] static auto match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto;
 
-#line 265 "cpp2regex.h2"
+#line 271 "cpp2regex.h2"
     private: template<typename ...Other> [[nodiscard]] static auto match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto;
     public: alternative_token_matcher() = default;
     public: alternative_token_matcher(alternative_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(alternative_token_matcher const&) -> void = delete;
 
 
-#line 283 "cpp2regex.h2"
+#line 289 "cpp2regex.h2"
 };
 
-#line 286 "cpp2regex.h2"
+#line 292 "cpp2regex.h2"
 //  Regex syntax: .
 //
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 301 "cpp2regex.h2"
+#line 307 "cpp2regex.h2"
 // TODO: Check if vectorization works at some point with this implementation.
 // char_token_matcher: <tokens: string_util::fixed_string> (inout cur, inout ctx) -> bool = {
 //     if !(std::distance(cur, ctx.end) < tokens..size()) {
@@ -427,21 +431,21 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
 //     return matched;
 // }
 
-#line 335 "cpp2regex.h2"
+#line 341 "cpp2regex.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher
  {
     public: [[nodiscard]] static auto match(auto& cur, auto& ctx) -> bool;
 
-#line 368 "cpp2regex.h2"
+#line 374 "cpp2regex.h2"
     private: template<typename First, typename ...Other> [[nodiscard]] static auto match_any(cpp2::impl::in<CharT> c) -> bool;
     public: class_token_matcher() = default;
     public: class_token_matcher(class_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(class_token_matcher const&) -> void = delete;
 
 
-#line 381 "cpp2regex.h2"
+#line 387 "cpp2regex.h2"
     // TODO: Implement proper to string
     // to_string: () -> bstring<CharT> = {
     //     r: bstring<CharT> = "[";
@@ -453,10 +457,10 @@ template<typename CharT, bool negate, bool case_insensitive, typename ...List> c
 
     //     return r;
     // }
-#line 392 "cpp2regex.h2"
+#line 398 "cpp2regex.h2"
 };
 
-#line 395 "cpp2regex.h2"
+#line 401 "cpp2regex.h2"
 // Named short classes
 //
 template                    <typename CharT,          bool case_insensitive> using named_class_no_new_line = class_token_matcher<CharT,true,case_insensitive,single_class_entry<CharT,'\n'>>;
@@ -472,7 +476,7 @@ template                    <typename CharT,          bool case_insensitive> usi
 template                    <typename CharT,          bool case_insensitive> using named_class_not_ver_space = class_token_matcher<CharT,true,case_insensitive,ver_space_class<CharT>>;
 template                    <typename CharT,          bool case_insensitive> using named_class_not_word = class_token_matcher<CharT,true,case_insensitive,word_class<CharT>>;
 
-#line 411 "cpp2regex.h2"
+#line 417 "cpp2regex.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -481,27 +485,27 @@ template                    <typename CharT,          bool case_insensitive> usi
 //
 template<typename CharT, int group, bool case_insensitive> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 448 "cpp2regex.h2"
+#line 454 "cpp2regex.h2"
 //  Regex syntax: $  Example: aa$
 //
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 464 "cpp2regex.h2"
+#line 470 "cpp2regex.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 473 "cpp2regex.h2"
+#line 479 "cpp2regex.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 488 "cpp2regex.h2"
+#line 494 "cpp2regex.h2"
 // TODO: @enum as template parameter currently not working. See issue https://github.com/hsutter/cppfront/issues/1147
 
-#line 491 "cpp2regex.h2"
+#line 497 "cpp2regex.h2"
 //  Options for range matching.
 class range_flags {
     public: static const int not_greedy;// Try to take as few as possible.
@@ -512,9 +516,9 @@ class range_flags {
     public: range_flags(range_flags const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_flags const&) -> void = delete;
 };
-#line 497 "cpp2regex.h2"
+#line 503 "cpp2regex.h2"
 
-#line 499 "cpp2regex.h2"
+#line 505 "cpp2regex.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher
@@ -522,42 +526,42 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 
     public: template<typename Iter> [[nodiscard]] static auto match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto;
 
-#line 517 "cpp2regex.h2"
+#line 523 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_upper_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 522 "cpp2regex.h2"
+#line 528 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_lower_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 527 "cpp2regex.h2"
+#line 533 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_in_range(cpp2::impl::in<int> count) -> bool;
 
-#line 533 "cpp2regex.h2"
+#line 539 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto;
 
-#line 549 "cpp2regex.h2"
+#line 555 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 579 "cpp2regex.h2"
+#line 585 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 607 "cpp2regex.h2"
+#line 613 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
     public: range_token_matcher() = default;
     public: range_token_matcher(range_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_token_matcher const&) -> void = delete;
 
 
-#line 633 "cpp2regex.h2"
+#line 639 "cpp2regex.h2"
 };
 
-#line 636 "cpp2regex.h2"
+#line 642 "cpp2regex.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 665 "cpp2regex.h2"
+#line 671 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Regular expression implementation.
@@ -579,7 +583,10 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
         public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
-#line 690 "cpp2regex.h2"
+#line 696 "cpp2regex.h2"
+        public: explicit search_return(Iter const& begin, Iter const& end);
+
+#line 702 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
         public: [[nodiscard]] auto group(cpp2::impl::in<int> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_start(cpp2::impl::in<int> g) const& -> decltype(auto);
@@ -589,26 +596,38 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
         public: [[nodiscard]] auto group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto);
 
+        public: auto update(cpp2::impl::in<match_return<Iter>> r) & -> void;
+
+#line 716 "cpp2regex.h2"
         private: [[nodiscard]] auto get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto;
         public: search_return(search_return const&) = delete; /* No 'that' constructor, suppress copy */
         public: auto operator=(search_return const&) -> void = delete;
 
 
-#line 706 "cpp2regex.h2"
+#line 723 "cpp2regex.h2"
     };
 
+    public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
+    public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto);
+    public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto);
+    public: template<typename Iter> auto find_all(auto const& func, Iter const& start, Iter const& end) const& -> void;
+
+#line 756 "cpp2regex.h2"
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto match(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 719 "cpp2regex.h2"
+#line 767 "cpp2regex.h2"
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 746 "cpp2regex.h2"
+#line 776 "cpp2regex.h2"
+    private: template<typename Iter> [[nodiscard]] auto search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>;
+
+#line 801 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -619,7 +638,7 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 758 "cpp2regex.h2"
+#line 813 "cpp2regex.h2"
 };
 
 }
@@ -726,73 +745,80 @@ template <typename Iter> match_return<Iter>::match_return(){}
 #line 111 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<Iter> cur) const& -> decltype(auto) { return match_return<Iter>(true, cur);  }
 
-#line 119 "cpp2regex.h2"
+#line 113 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::reset() & -> void{
+        for ( auto& g : groups ) {
+            g.matched = false;
+        }
+    }
+
+#line 125 "cpp2regex.h2"
     [[nodiscard]] auto true_end_func::operator()(auto const& cur, auto& ctx) const& -> decltype(auto) { return ctx.pass(cur);  }
 
-#line 127 "cpp2regex.h2"
+#line 133 "cpp2regex.h2"
     auto no_reset::operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void{}
 
-#line 136 "cpp2regex.h2"
+#line 142 "cpp2regex.h2"
     template <typename Func> on_return<Func>::on_return(Func const& f)
         : func{ f }{
 
-#line 138 "cpp2regex.h2"
+#line 144 "cpp2regex.h2"
     }
-#line 136 "cpp2regex.h2"
+#line 142 "cpp2regex.h2"
     template <typename Func> auto on_return<Func>::operator=(Func const& f) -> on_return& {
         func = f;
         return *this;
 
-#line 138 "cpp2regex.h2"
+#line 144 "cpp2regex.h2"
     }
 
-#line 140 "cpp2regex.h2"
+#line 146 "cpp2regex.h2"
     template <typename Func> on_return<Func>::~on_return() noexcept{
         cpp2::move(*this).func();
     }
 
-#line 147 "cpp2regex.h2"
+#line 153 "cpp2regex.h2"
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto) { return on_return<Func>(func);  }
 
-#line 161 "cpp2regex.h2"
+#line 167 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return c == C;  }
-#line 162 "cpp2regex.h2"
+#line 168 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::to_string() -> decltype(auto) { return bstring<CharT>(1, C); }
 
-#line 170 "cpp2regex.h2"
+#line 176 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return [_0 = Start, _1 = c, _2 = End]{ return cpp2::impl::cmp_less_eq(_0,_1) && cpp2::impl::cmp_less_eq(_1,_2); }();  }
-#line 171 "cpp2regex.h2"
+#line 177 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::to_string() -> decltype(auto) { return "" + cpp2::to_string(Start) + "-" + cpp2::to_string(End) + ""; }
 
-#line 179 "cpp2regex.h2"
+#line 185 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || List::includes(c));  }
-#line 180 "cpp2regex.h2"
+#line 186 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List::to_string()); }
 
-#line 188 "cpp2regex.h2"
+#line 194 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || (List == c));  }
-#line 189 "cpp2regex.h2"
+#line 195 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List); }
 
-#line 197 "cpp2regex.h2"
+#line 203 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 198 "cpp2regex.h2"
+#line 204 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return "[:" + cpp2::to_string(Name.data()) + ":]"; }
 
-#line 205 "cpp2regex.h2"
+#line 211 "cpp2regex.h2"
     template <typename CharT, typename Inner> [[nodiscard]] auto negated_class_entry<CharT,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return !(Inner::includes(c));  }
 
-#line 213 "cpp2regex.h2"
+#line 219 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 214 "cpp2regex.h2"
+#line 220 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return Name.str(); }
 
-#line 261 "cpp2regex.h2"
+#line 267 "cpp2regex.h2"
     template <typename CharT> [[nodiscard]] auto alternative_token_matcher<CharT>::match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto{
         return match_first(cur, ctx, end_func, tail, functions...); 
     }
 
-#line 265 "cpp2regex.h2"
+#line 271 "cpp2regex.h2"
     template <typename CharT> template<typename ...Other> [[nodiscard]] auto alternative_token_matcher<CharT>::match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto
     {
         auto inner_call {[_0 = (tail), _1 = (end_func)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -812,7 +838,7 @@ template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> d
         }
     }
 
-#line 288 "cpp2regex.h2"
+#line 294 "cpp2regex.h2"
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool
 {
     if ( cur != ctx.end                     // any char except the end
@@ -825,7 +851,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
     return false; 
 }
 
-#line 339 "cpp2regex.h2"
+#line 345 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match(auto& cur, auto& ctx) -> bool
     {
         if constexpr (case_insensitive) 
@@ -855,7 +881,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         }
     }
 
-#line 368 "cpp2regex.h2"
+#line 374 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> template<typename First, typename ...Other> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match_any(cpp2::impl::in<CharT> c) -> bool
     {
         bool r {First::includes(c)}; 
@@ -869,7 +895,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         return r; 
     }
 
-#line 417 "cpp2regex.h2"
+#line 423 "cpp2regex.h2"
 template<typename CharT, int group, bool case_insensitive> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
 {
     auto g {ctx.get_group(group)}; 
@@ -900,7 +926,7 @@ template<typename CharT, int group, bool case_insensitive> [[nodiscard]] auto gr
     }
 }
 
-#line 450 "cpp2regex.h2"
+#line 456 "cpp2regex.h2"
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     if (cur == ctx.end || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
@@ -914,14 +940,14 @@ template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[
     }}
 }
 
-#line 466 "cpp2regex.h2"
+#line 472 "cpp2regex.h2"
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     return cur == ctx.begin || // Start of string
            (match_new_line && *cpp2::impl::assert_not_null((cur - 1)) == '\n'); // Start of new line
 }
 
-#line 477 "cpp2regex.h2"
+#line 483 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(cur, ctx, true_end_func())}; 
@@ -932,12 +958,12 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
     return cpp2::move(r).matched; 
 }
 
-#line 493 "cpp2regex.h2"
+#line 499 "cpp2regex.h2"
     inline CPP2_CONSTEXPR int range_flags::not_greedy{ 1 };
     inline CPP2_CONSTEXPR int range_flags::greedy{ 2 };
     inline CPP2_CONSTEXPR int range_flags::possessive{ 3 };
 
-#line 504 "cpp2regex.h2"
+#line 510 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto
     {
         if (range_flags::possessive == kind) {
@@ -951,26 +977,26 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         }}
     }
 
-#line 517 "cpp2regex.h2"
+#line 523 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_upper_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == max_count) {return true; }
         else {return cpp2::impl::cmp_less(count,max_count); }
     }
 
-#line 522 "cpp2regex.h2"
+#line 528 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_lower_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == min_count) {return false; }
         else {return cpp2::impl::cmp_less(count,min_count); }
     }
 
-#line 527 "cpp2regex.h2"
+#line 533 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_in_range(cpp2::impl::in<int> count) -> bool{
         if (-1 != min_count && cpp2::impl::cmp_less(count,min_count)) {return false; }
         if (-1 != max_count && cpp2::impl::cmp_greater(count,max_count)) {return false; }
         return true; 
     }
 
-#line 533 "cpp2regex.h2"
+#line 539 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto
     {   // TODO: count_r as out parameter introduces a performance loss.
         auto res {ctx.pass(cur)}; 
@@ -987,7 +1013,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return res; 
     }
 
-#line 549 "cpp2regex.h2"
+#line 555 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto inner_call {[_0 = (count + 1), _1 = (cur), _2 = (inner), _3 = (reset_func), _4 = (end_func), _5 = (other)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1018,7 +1044,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return r; 
     }
 
-#line 579 "cpp2regex.h2"
+#line 585 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1047,7 +1073,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return other(cpp2::move(pos), ctx, end_func); 
     }
 
-#line 607 "cpp2regex.h2"
+#line 613 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1075,7 +1101,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return other(cpp2::move(pos), ctx, end_func); // Upper bound reached.
     }
 
-#line 640 "cpp2regex.h2"
+#line 646 "cpp2regex.h2"
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool
 {
     word_class<CharT> words {}; 
@@ -1100,32 +1126,47 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
     return is_match; 
 }
 
-#line 684 "cpp2regex.h2"
+#line 690 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
             : matched{ matched_ }
             , ctx{ ctx_ }
             , pos{ cpp2::unchecked_narrow<int>(std::distance(ctx_.begin, pos_)) }{
 
-#line 688 "cpp2regex.h2"
+#line 694 "cpp2regex.h2"
         }
 
-#line 690 "cpp2regex.h2"
+#line 696 "cpp2regex.h2"
+        template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
+            : matched{ false }
+            , ctx{ begin, end }
+            , pos{ 0 }{
+
+#line 700 "cpp2regex.h2"
+        }
+
+#line 702 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
-#line 691 "cpp2regex.h2"
+#line 703 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
-#line 692 "cpp2regex.h2"
+#line 704 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
-#line 693 "cpp2regex.h2"
+#line 705 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
 
-#line 695 "cpp2regex.h2"
+#line 707 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
-#line 696 "cpp2regex.h2"
+#line 708 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
-#line 697 "cpp2regex.h2"
+#line 709 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
 
-#line 699 "cpp2regex.h2"
+#line 711 "cpp2regex.h2"
+        template <typename CharT, typename matcher_wrapper> template <typename Iter> auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
+            matched = r.matched;
+            pos     = cpp2::unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
+        }
+
+#line 716 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
             auto group_id {matcher<Iter>::get_named_group_index(g)}; 
             if (-1 == group_id) {
@@ -1134,13 +1175,48 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             return group_id; 
         }
 
-#line 708 "cpp2regex.h2"
+#line 725 "cpp2regex.h2"
+    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
+#line 726 "cpp2regex.h2"
+    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
+#line 727 "cpp2regex.h2"
+    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
+#line 728 "cpp2regex.h2"
+    template <typename CharT, typename matcher_wrapper> template<typename Iter> auto regular_expression<CharT,matcher_wrapper>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
+    {
+        auto sr {search_return<Iter>(start, end)}; 
+        auto cont {true}; 
+        auto cur {start}; 
+
+        while( cont ) {
+            auto r {search_with_context(sr.ctx, cur)}; 
+            cont = r.matched; // First update the continue so that the user can override it.
+
+            if (r.matched) {
+                sr.update(cpp2::move(r));
+                cont = func(sr);
+            }
+
+            if (cont) {
+                // Prevent infinity loop for zero length match.
+                cont = 0 != sr.ctx.get_group_end(0) - sr.ctx.get_group_start(0);
+            }
+
+            // Check now if to continue, user may override
+            if (cont) {
+                cur = start + sr.ctx.get_group_end(0);
+                CPP2_UFCS(reset)(sr.ctx);
+            }
+        }
+    }
+
+#line 756 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
-#line 709 "cpp2regex.h2"
+#line 757 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
-#line 710 "cpp2regex.h2"
+#line 758 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
-#line 711 "cpp2regex.h2"
+#line 759 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
     {
         context<Iter> ctx {start, end}; 
@@ -1149,16 +1225,22 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return search_return<Iter>(r.matched && r.pos == end, cpp2::move(ctx), r.pos); 
     }
 
-#line 719 "cpp2regex.h2"
+#line 767 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
-#line 720 "cpp2regex.h2"
+#line 768 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
-#line 721 "cpp2regex.h2"
+#line 769 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
-#line 722 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>
-    {
+#line 770 "cpp2regex.h2"
+    template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
         context<Iter> ctx {start, end}; 
+        auto r {search_with_context(ctx, start)}; 
+        return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
+    }
+
+#line 776 "cpp2regex.h2"
+    template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
+    {
         auto r {ctx.fail()}; 
 
         auto cur {start}; 
@@ -1177,13 +1259,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             }
         }
 
-        return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
+        return r; 
     }
 
-#line 746 "cpp2regex.h2"
+#line 801 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::to_string() const& -> decltype(auto) { return matcher_wrapper::to_string();  }
 
-#line 750 "cpp2regex.h2"
+#line 805 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
@@ -1193,7 +1275,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 760 "cpp2regex.h2"
+#line 815 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -97,10 +97,10 @@ template<typename CharT, typename matcher_wrapper> class regular_expression;
 #define CPP2_CPP2REGEX_H
 
 template<typename matcher_wrapper, typename Iter, typename CharT>
-using matcher_wrapper_type = typename matcher_wrapper::template wrap<Iter, CharT>;
+using matcher_wrapper_type = typename matcher_wrapper::template wrap<CharT>;
 
-template<typename matcher>
-using matcher_context_type = typename matcher::context;
+template<typename matcher, typename Iter>
+using matcher_context_type = typename matcher::template context<Iter>;
 
 #line 22 "cpp2regex.h2"
 namespace cpp2 {
@@ -654,7 +654,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
 template<typename CharT, typename matcher_wrapper> class regular_expression
  {
     public: template<typename Iter> using matcher = matcher_wrapper_type<matcher_wrapper,Iter,CharT>;// TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
-    public: template<typename Iter> using context = matcher_context_type<matcher<Iter>>;// TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
+    public: template<typename Iter> using context = matcher_context_type<matcher<Iter>,Iter>;// TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
 
     public: template<typename Iter> class search_return
      {

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -24,56 +24,56 @@ template<typename Iter> class match_return;
 #line 54 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> class match_context;
 
-#line 120 "cpp2regex.h2"
+#line 125 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> class reverse_match_context;
 
-#line 193 "cpp2regex.h2"
+#line 202 "cpp2regex.h2"
 class true_end_func;
 
-#line 201 "cpp2regex.h2"
+#line 210 "cpp2regex.h2"
 class no_reset;
 
-#line 208 "cpp2regex.h2"
+#line 217 "cpp2regex.h2"
 template<typename Func> class on_return;
 
-#line 235 "cpp2regex.h2"
+#line 244 "cpp2regex.h2"
 template<typename CharT, CharT C> class single_class_entry;
 
-#line 244 "cpp2regex.h2"
+#line 253 "cpp2regex.h2"
 template<typename CharT, CharT Start, CharT End> class range_class_entry;
 
-#line 253 "cpp2regex.h2"
+#line 262 "cpp2regex.h2"
 template<typename CharT, typename ...List> class combined_class_entry;
 
-#line 262 "cpp2regex.h2"
+#line 271 "cpp2regex.h2"
 template<typename CharT, CharT ...List> class list_class_entry;
 
-#line 271 "cpp2regex.h2"
+#line 280 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry;
 
-#line 278 "cpp2regex.h2"
+#line 287 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry;
 
-#line 287 "cpp2regex.h2"
+#line 296 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry;
 
-#line 335 "cpp2regex.h2"
+#line 344 "cpp2regex.h2"
 template<typename CharT> class alternative_token_matcher;
 
-#line 413 "cpp2regex.h2"
+#line 422 "cpp2regex.h2"
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher;
 
-#line 588 "cpp2regex.h2"
+#line 597 "cpp2regex.h2"
 class range_flags;
     
 
-#line 597 "cpp2regex.h2"
+#line 606 "cpp2regex.h2"
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher;
 
-#line 769 "cpp2regex.h2"
+#line 778 "cpp2regex.h2"
 template<typename CharT, typename matcher> class regular_expression;
 
-#line 904 "cpp2regex.h2"
+#line 913 "cpp2regex.h2"
 }
 }
 
@@ -161,28 +161,33 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 #line 66 "cpp2regex.h2"
     public: auto operator=(match_context&& that) noexcept -> match_context& ;
 
+    // String end and start positions
+    //
+    public: [[nodiscard]] auto get_string_start() const& -> decltype(auto);
+    public: [[nodiscard]] auto get_string_end() const& -> decltype(auto);
+
     //  Getter and setter for groups
     //
     public: [[nodiscard]] auto get_group(auto const& group) const& -> decltype(auto);
 
     public: [[nodiscard]] auto get_group_end(auto const& group) const& -> int;
 
-#line 78 "cpp2regex.h2"
+#line 83 "cpp2regex.h2"
     public: [[nodiscard]] auto get_group_start(auto const& group) const& -> int;
 
-#line 84 "cpp2regex.h2"
+#line 89 "cpp2regex.h2"
     public: [[nodiscard]] auto get_group_string(auto const& group) const& -> std::string;
 
-#line 91 "cpp2regex.h2"
+#line 96 "cpp2regex.h2"
     public: auto set_group_end(auto const& group, auto const& pos) & -> void;
 
-#line 96 "cpp2regex.h2"
+#line 101 "cpp2regex.h2"
     public: auto set_group_invalid(auto const& group) & -> void;
 
-#line 100 "cpp2regex.h2"
+#line 105 "cpp2regex.h2"
     public: auto set_group_start(auto const& group, auto const& pos) & -> void;
 
-#line 104 "cpp2regex.h2"
+#line 109 "cpp2regex.h2"
     public: [[nodiscard]] auto size() const& -> decltype(auto);
 
     //  Misc functions
@@ -192,7 +197,7 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 
     public: auto reset() & -> void;
 
-#line 116 "cpp2regex.h2"
+#line 121 "cpp2regex.h2"
 };
 
 //  Modifiable state during matching.
@@ -206,17 +211,22 @@ template<typename CharT, typename Iter, int max_groups> class reverse_match_cont
             public: ReverseIter end; 
 
     public: explicit reverse_match_context(auto const& forward_context_);
-#line 128 "cpp2regex.h2"
+#line 133 "cpp2regex.h2"
     public: auto operator=(auto const& forward_context_) -> reverse_match_context& ;
 
-#line 134 "cpp2regex.h2"
+#line 139 "cpp2regex.h2"
     public: reverse_match_context(reverse_match_context const& that);
-#line 134 "cpp2regex.h2"
+#line 139 "cpp2regex.h2"
     public: auto operator=(reverse_match_context const& that) -> reverse_match_context& ;
-#line 134 "cpp2regex.h2"
+#line 139 "cpp2regex.h2"
     public: reverse_match_context(reverse_match_context&& that) noexcept;
-#line 134 "cpp2regex.h2"
+#line 139 "cpp2regex.h2"
     public: auto operator=(reverse_match_context&& that) noexcept -> reverse_match_context& ;
+
+    // String end and start positions
+    //
+    public: [[nodiscard]] auto get_string_start() const& -> decltype(auto);
+    public: [[nodiscard]] auto get_string_end() const& -> decltype(auto);
 
     //  Getter and setter for groups
     //
@@ -241,19 +251,15 @@ template<typename CharT, typename Iter, int max_groups> class reverse_match_cont
     //     return std::string(groups[group].start, groups[group].end);
     // }
 
-    // set_group_end: (inout this, group, pos) = {
-    //     groups[group].end = pos;
-    //     groups[group].matched = true;
-    // }
+    public: auto set_group_end(auto const& group, auto const& pos) & -> void;
 
-    // set_group_invalid: (inout this, group) = {
-    //     groups[group].matched = false;
-    // }
+#line 173 "cpp2regex.h2"
+    public: auto set_group_invalid(auto const& group) & -> void;
 
-    // set_group_start: (inout this, group, pos) = {
-    //     groups[group].start = pos;
-    // }
+#line 177 "cpp2regex.h2"
+    public: auto set_group_start(auto const& group, auto const& pos) & -> void;
 
+#line 181 "cpp2regex.h2"
     // size: (in this) = max_groups;
 
     //  Misc functions
@@ -270,7 +276,7 @@ template<typename CharT, typename Iter, int max_groups> class reverse_match_cont
 
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto;
 
-#line 191 "cpp2regex.h2"
+#line 200 "cpp2regex.h2"
 //  End function that returns a valid match.
 //
 class true_end_func
@@ -278,7 +284,7 @@ class true_end_func
     public: [[nodiscard]] auto operator()(auto const& cur, auto& ctx) const& -> decltype(auto);
 };
 
-#line 199 "cpp2regex.h2"
+#line 208 "cpp2regex.h2"
 //  Empty group reset function.
 //
 class no_reset
@@ -286,30 +292,30 @@ class no_reset
     public: auto operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void;
 };
 
-#line 207 "cpp2regex.h2"
+#line 216 "cpp2regex.h2"
 //  Evaluate func on destruction of the handle.
 template<typename Func> class on_return
  {
     private: Func func; 
 
     public: explicit on_return(Func const& f);
-#line 212 "cpp2regex.h2"
+#line 221 "cpp2regex.h2"
     public: auto operator=(Func const& f) -> on_return& ;
 
-#line 216 "cpp2regex.h2"
+#line 225 "cpp2regex.h2"
     public: ~on_return() noexcept;
     public: on_return(on_return const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(on_return const&) -> void = delete;
 
 
-#line 219 "cpp2regex.h2"
+#line 228 "cpp2regex.h2"
 };
 
-#line 222 "cpp2regex.h2"
+#line 231 "cpp2regex.h2"
 //  Helper for auto deduction of the Func type.
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto);
 
-#line 226 "cpp2regex.h2"
+#line 235 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Character classes for regular expressions.
@@ -327,10 +333,10 @@ template<typename CharT, CharT C> class single_class_entry
     public: single_class_entry(single_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(single_class_entry const&) -> void = delete;
 
-#line 239 "cpp2regex.h2"
+#line 248 "cpp2regex.h2"
 };
 
-#line 242 "cpp2regex.h2"
+#line 251 "cpp2regex.h2"
 //  Class syntax: - Example: a-c
 //
 template<typename CharT, CharT Start, CharT End> class range_class_entry
@@ -341,10 +347,10 @@ template<typename CharT, CharT Start, CharT End> class range_class_entry
     public: range_class_entry(range_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_class_entry const&) -> void = delete;
 
-#line 248 "cpp2regex.h2"
+#line 257 "cpp2regex.h2"
 };
 
-#line 251 "cpp2regex.h2"
+#line 260 "cpp2regex.h2"
 //  Helper for combining two character classes
 //
 template<typename CharT, typename ...List> class combined_class_entry
@@ -355,10 +361,10 @@ template<typename CharT, typename ...List> class combined_class_entry
     public: combined_class_entry(combined_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(combined_class_entry const&) -> void = delete;
 
-#line 257 "cpp2regex.h2"
+#line 266 "cpp2regex.h2"
 };
 
-#line 260 "cpp2regex.h2"
+#line 269 "cpp2regex.h2"
 //  Class syntax: <list of characters>  Example: abcd
 //
 template<typename CharT, CharT ...List> class list_class_entry
@@ -369,10 +375,10 @@ template<typename CharT, CharT ...List> class list_class_entry
     public: list_class_entry(list_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(list_class_entry const&) -> void = delete;
 
-#line 266 "cpp2regex.h2"
+#line 275 "cpp2regex.h2"
 };
 
-#line 269 "cpp2regex.h2"
+#line 278 "cpp2regex.h2"
 //  Class syntax: [:<class name:]  Example: [:alnum:]
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry
@@ -383,10 +389,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class n
     public: named_class_entry(named_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(named_class_entry const&) -> void = delete;
 
-#line 275 "cpp2regex.h2"
+#line 284 "cpp2regex.h2"
 };
 
-#line 278 "cpp2regex.h2"
+#line 287 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry
 : public Inner {
 
@@ -395,10 +401,10 @@ template<typename CharT, typename Inner> class negated_class_entry
     public: negated_class_entry(negated_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(negated_class_entry const&) -> void = delete;
 
-#line 282 "cpp2regex.h2"
+#line 291 "cpp2regex.h2"
 };
 
-#line 285 "cpp2regex.h2"
+#line 294 "cpp2regex.h2"
 //  Short class syntax: \<character>  Example: \w
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry
@@ -409,10 +415,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class s
     public: shorthand_class_entry(shorthand_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(shorthand_class_entry const&) -> void = delete;
 
-#line 291 "cpp2regex.h2"
+#line 300 "cpp2regex.h2"
 };
 
-#line 294 "cpp2regex.h2"
+#line 303 "cpp2regex.h2"
 //  Named basic character classes
 //
 template        <typename CharT> using digits_class = named_class_entry<CharT,"digits",range_class_entry<CharT,'0','9'>>;
@@ -449,7 +455,7 @@ template                     <typename CharT> using short_not_space_class = nega
 template<typename CharT> using short_not_vert_space_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\V",ver_space_class<CharT>>>;
 template                     <typename CharT> using short_not_word_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\W",word_class<CharT>>>;
 
-#line 331 "cpp2regex.h2"
+#line 340 "cpp2regex.h2"
 //  Regex syntax: |  Example: ab|ba
 //
 //  Non greedy implementation. First alternative that matches is chosen.
@@ -458,22 +464,22 @@ template<typename CharT> class alternative_token_matcher
  {
     public: [[nodiscard]] static auto match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto;
 
-#line 341 "cpp2regex.h2"
+#line 350 "cpp2regex.h2"
     private: template<typename ...Other> [[nodiscard]] static auto match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto;
     public: alternative_token_matcher() = default;
     public: alternative_token_matcher(alternative_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(alternative_token_matcher const&) -> void = delete;
 
 
-#line 359 "cpp2regex.h2"
+#line 368 "cpp2regex.h2"
 };
 
-#line 362 "cpp2regex.h2"
+#line 371 "cpp2regex.h2"
 //  Regex syntax: .
 //
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 377 "cpp2regex.h2"
+#line 386 "cpp2regex.h2"
 // TODO: Check if vectorization works at some point with this implementation.
 // char_token_matcher: <tokens: string_util::fixed_string> (inout cur, inout ctx) -> bool = {
 //     if !(std::distance(cur, ctx.end) < tokens..size()) {
@@ -507,21 +513,21 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
 //     return matched;
 // }
 
-#line 411 "cpp2regex.h2"
+#line 420 "cpp2regex.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher
  {
     public: [[nodiscard]] static auto match(auto& cur, auto& ctx) -> bool;
 
-#line 444 "cpp2regex.h2"
+#line 453 "cpp2regex.h2"
     private: template<typename First, typename ...Other> [[nodiscard]] static auto match_any(cpp2::impl::in<CharT> c) -> bool;
     public: class_token_matcher() = default;
     public: class_token_matcher(class_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(class_token_matcher const&) -> void = delete;
 
 
-#line 457 "cpp2regex.h2"
+#line 466 "cpp2regex.h2"
     // TODO: Implement proper to string
     // to_string: () -> bstring<CharT> = {
     //     r: bstring<CharT> = "[";
@@ -533,10 +539,10 @@ template<typename CharT, bool negate, bool case_insensitive, typename ...List> c
 
     //     return r;
     // }
-#line 468 "cpp2regex.h2"
+#line 477 "cpp2regex.h2"
 };
 
-#line 471 "cpp2regex.h2"
+#line 480 "cpp2regex.h2"
 // Named short classes
 //
 template                    <typename CharT,          bool case_insensitive> using named_class_no_new_line = class_token_matcher<CharT,true,case_insensitive,single_class_entry<CharT,'\n'>>;
@@ -552,7 +558,7 @@ template                    <typename CharT,          bool case_insensitive> usi
 template                    <typename CharT,          bool case_insensitive> using named_class_not_ver_space = class_token_matcher<CharT,true,case_insensitive,ver_space_class<CharT>>;
 template                    <typename CharT,          bool case_insensitive> using named_class_not_word = class_token_matcher<CharT,true,case_insensitive,word_class<CharT>>;
 
-#line 487 "cpp2regex.h2"
+#line 496 "cpp2regex.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -561,30 +567,30 @@ template                    <typename CharT,          bool case_insensitive> usi
 //
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 532 "cpp2regex.h2"
+#line 541 "cpp2regex.h2"
 //  Regex syntax: $  Example: aa$
 //
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 548 "cpp2regex.h2"
+#line 557 "cpp2regex.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 557 "cpp2regex.h2"
+#line 566 "cpp2regex.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 571 "cpp2regex.h2"
+#line 580 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 584 "cpp2regex.h2"
+#line 593 "cpp2regex.h2"
 // TODO: @enum as template parameter currently not working. See issue https://github.com/hsutter/cppfront/issues/1147
 
-#line 587 "cpp2regex.h2"
+#line 596 "cpp2regex.h2"
 //  Options for range matching.
 class range_flags {
     public: static const int not_greedy;// Try to take as few as possible.
@@ -595,9 +601,9 @@ class range_flags {
     public: range_flags(range_flags const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_flags const&) -> void = delete;
 };
-#line 593 "cpp2regex.h2"
+#line 602 "cpp2regex.h2"
 
-#line 595 "cpp2regex.h2"
+#line 604 "cpp2regex.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher
@@ -605,42 +611,42 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 
     public: template<typename Iter> [[nodiscard]] static auto match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto;
 
-#line 613 "cpp2regex.h2"
+#line 622 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_upper_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 618 "cpp2regex.h2"
+#line 627 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_lower_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 623 "cpp2regex.h2"
+#line 632 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_in_range(cpp2::impl::in<int> count) -> bool;
 
-#line 629 "cpp2regex.h2"
+#line 638 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto;
 
-#line 645 "cpp2regex.h2"
+#line 654 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 675 "cpp2regex.h2"
+#line 684 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 703 "cpp2regex.h2"
+#line 712 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
     public: range_token_matcher() = default;
     public: range_token_matcher(range_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_token_matcher const&) -> void = delete;
 
 
-#line 729 "cpp2regex.h2"
+#line 738 "cpp2regex.h2"
 };
 
-#line 732 "cpp2regex.h2"
+#line 741 "cpp2regex.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 761 "cpp2regex.h2"
+#line 770 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Regular expression implementation.
@@ -661,10 +667,10 @@ template<typename CharT, typename matcher> class regular_expression
 
         public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
-#line 785 "cpp2regex.h2"
+#line 794 "cpp2regex.h2"
         public: explicit search_return(Iter const& begin, Iter const& end);
 
-#line 791 "cpp2regex.h2"
+#line 800 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
         public: [[nodiscard]] auto group(cpp2::impl::in<int> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_start(cpp2::impl::in<int> g) const& -> decltype(auto);
@@ -676,13 +682,13 @@ template<typename CharT, typename matcher> class regular_expression
 
         public: auto update(cpp2::impl::in<match_return<Iter>> r) & -> void;
 
-#line 805 "cpp2regex.h2"
+#line 814 "cpp2regex.h2"
         private: [[nodiscard]] auto get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto;
         public: search_return(search_return const&) = delete; /* No 'that' constructor, suppress copy */
         public: auto operator=(search_return const&) -> void = delete;
 
 
-#line 812 "cpp2regex.h2"
+#line 821 "cpp2regex.h2"
     };
 
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
@@ -690,22 +696,22 @@ template<typename CharT, typename matcher> class regular_expression
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto);
     public: template<typename Iter> auto find_all(auto const& func, Iter const& start, Iter const& end) const& -> void;
 
-#line 845 "cpp2regex.h2"
+#line 854 "cpp2regex.h2"
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto match(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 856 "cpp2regex.h2"
+#line 865 "cpp2regex.h2"
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 865 "cpp2regex.h2"
+#line 874 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] auto search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>;
 
-#line 890 "cpp2regex.h2"
+#line 899 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -716,7 +722,7 @@ template<typename CharT, typename matcher> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 902 "cpp2regex.h2"
+#line 911 "cpp2regex.h2"
 };
 
 }
@@ -775,23 +781,28 @@ template <typename Iter> match_return<Iter>::match_return(){}
                                    return *this; }
 
 #line 70 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_string_start() const& -> decltype(auto) { return begin;  }
+#line 71 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_string_end() const& -> decltype(auto) { return end;  }
+
+#line 75 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group(auto const& group) const& -> decltype(auto) { return CPP2_ASSERT_IN_BOUNDS(groups, group);  }
 
-#line 72 "cpp2regex.h2"
+#line 77 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_end(auto const& group) const& -> int{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return 0; 
         }
         return cpp2::unchecked_narrow<int>(std::distance(begin, CPP2_ASSERT_IN_BOUNDS(groups, group).end)); 
     }
-#line 78 "cpp2regex.h2"
+#line 83 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_start(auto const& group) const& -> int{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return 0; 
         }
         return cpp2::unchecked_narrow<int>(std::distance(begin, CPP2_ASSERT_IN_BOUNDS(groups, group).start)); 
     }
-#line 84 "cpp2regex.h2"
+#line 89 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_string(auto const& group) const& -> std::string{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return ""; 
@@ -799,155 +810,175 @@ template <typename Iter> match_return<Iter>::match_return(){}
         return std::string(CPP2_ASSERT_IN_BOUNDS(groups, group).start, CPP2_ASSERT_IN_BOUNDS(groups, group).end); 
     }
 
-#line 91 "cpp2regex.h2"
+#line 96 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_end(auto const& group, auto const& pos) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).end = pos;
         CPP2_ASSERT_IN_BOUNDS(groups, group).matched = true;
     }
 
-#line 96 "cpp2regex.h2"
+#line 101 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_invalid(auto const& group) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).matched = false;
     }
 
-#line 100 "cpp2regex.h2"
+#line 105 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_start(auto const& group, auto const& pos) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).start = pos;
     }
 
-#line 104 "cpp2regex.h2"
+#line 109 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::size() const& -> decltype(auto) { return max_groups;  }
 
-#line 108 "cpp2regex.h2"
+#line 113 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::fail() const& -> decltype(auto) { return match_return<Iter>(false, end); }
-#line 109 "cpp2regex.h2"
+#line 114 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<Iter> cur) const& -> decltype(auto) { return match_return<Iter>(true, cur);  }
 
-#line 111 "cpp2regex.h2"
+#line 116 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::reset() & -> void{
         for ( auto& g : groups ) {
             g.matched = false;
         }
     }
 
-#line 128 "cpp2regex.h2"
+#line 133 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> reverse_match_context<CharT,Iter,max_groups>::reverse_match_context(auto const& forward_context_)
         : forward_context{ forward_context_ }
         , begin{ std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).end) }
         , end{ std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).begin) }{
 
-#line 132 "cpp2regex.h2"
+#line 137 "cpp2regex.h2"
     }
-#line 128 "cpp2regex.h2"
+#line 133 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::operator=(auto const& forward_context_) -> reverse_match_context& {
         forward_context = forward_context_;
         begin = std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).end);
         end = std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).begin);
         return *this;
 
-#line 132 "cpp2regex.h2"
+#line 137 "cpp2regex.h2"
     }
 
-#line 134 "cpp2regex.h2"
+#line 139 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> reverse_match_context<CharT,Iter,max_groups>::reverse_match_context(reverse_match_context const& that)
                                    : forward_context{ that.forward_context }
                                    , begin{ that.begin }
                                    , end{ that.end }{}
-#line 134 "cpp2regex.h2"
+#line 139 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::operator=(reverse_match_context const& that) -> reverse_match_context& {
                                    forward_context = that.forward_context;
                                    begin = that.begin;
                                    end = that.end;
                                    return *this; }
-#line 134 "cpp2regex.h2"
+#line 139 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> reverse_match_context<CharT,Iter,max_groups>::reverse_match_context(reverse_match_context&& that) noexcept
                                    : forward_context{ std::move(that).forward_context }
                                    , begin{ std::move(that).begin }
                                    , end{ std::move(that).end }{}
-#line 134 "cpp2regex.h2"
+#line 139 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::operator=(reverse_match_context&& that) noexcept -> reverse_match_context& {
                                    forward_context = std::move(that).forward_context;
                                    begin = std::move(that).begin;
                                    end = std::move(that).end;
                                    return *this; }
 
-#line 176 "cpp2regex.h2"
-    template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::fail() const& -> decltype(auto) { return match_return<ReverseIter>(false, end); }
+#line 143 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::get_string_start() const& -> decltype(auto) { return end;  }
+#line 144 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::get_string_end() const& -> decltype(auto) { return begin;  }
+
+#line 169 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::set_group_end(auto const& group, auto const& pos) & -> void{
+        (*cpp2::impl::assert_not_null(forward_context)).set_group_end(group, CPP2_UFCS(base)((pos)));
+    }
+
+#line 173 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::set_group_invalid(auto const& group) & -> void{
+        (*cpp2::impl::assert_not_null(forward_context)).set_group_invalid(group);
+    }
+
 #line 177 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::set_group_start(auto const& group, auto const& pos) & -> void{
+        (*cpp2::impl::assert_not_null(forward_context)).set_group_start(group, CPP2_UFCS(base)((pos)));
+    }
+
+#line 185 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::fail() const& -> decltype(auto) { return match_return<ReverseIter>(false, end); }
+#line 186 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<ReverseIter> cur) const& -> decltype(auto) { return match_return<ReverseIter>(true, cur);  }
 
-#line 186 "cpp2regex.h2"
+#line 195 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto{
     return reverse_match_context<CharT,Iter,max_groups>(&ctx); 
 }
 
-#line 195 "cpp2regex.h2"
+#line 204 "cpp2regex.h2"
     [[nodiscard]] auto true_end_func::operator()(auto const& cur, auto& ctx) const& -> decltype(auto) { return ctx.pass(cur);  }
 
-#line 203 "cpp2regex.h2"
+#line 212 "cpp2regex.h2"
     auto no_reset::operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void{}
 
-#line 212 "cpp2regex.h2"
+#line 221 "cpp2regex.h2"
     template <typename Func> on_return<Func>::on_return(Func const& f)
         : func{ f }{
 
-#line 214 "cpp2regex.h2"
+#line 223 "cpp2regex.h2"
     }
-#line 212 "cpp2regex.h2"
+#line 221 "cpp2regex.h2"
     template <typename Func> auto on_return<Func>::operator=(Func const& f) -> on_return& {
         func = f;
         return *this;
 
-#line 214 "cpp2regex.h2"
+#line 223 "cpp2regex.h2"
     }
 
-#line 216 "cpp2regex.h2"
+#line 225 "cpp2regex.h2"
     template <typename Func> on_return<Func>::~on_return() noexcept{
         cpp2::move(*this).func();
     }
 
-#line 223 "cpp2regex.h2"
+#line 232 "cpp2regex.h2"
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto) { return on_return<Func>(func);  }
 
-#line 237 "cpp2regex.h2"
+#line 246 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return c == C;  }
-#line 238 "cpp2regex.h2"
+#line 247 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::to_string() -> decltype(auto) { return bstring<CharT>(1, C); }
 
-#line 246 "cpp2regex.h2"
+#line 255 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return [_0 = Start, _1 = c, _2 = End]{ return cpp2::impl::cmp_less_eq(_0,_1) && cpp2::impl::cmp_less_eq(_1,_2); }();  }
-#line 247 "cpp2regex.h2"
+#line 256 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::to_string() -> decltype(auto) { return "" + cpp2::to_string(Start) + "-" + cpp2::to_string(End) + ""; }
 
-#line 255 "cpp2regex.h2"
+#line 264 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || List::includes(c));  }
-#line 256 "cpp2regex.h2"
+#line 265 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List::to_string()); }
 
-#line 264 "cpp2regex.h2"
+#line 273 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || (List == c));  }
-#line 265 "cpp2regex.h2"
+#line 274 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List); }
 
-#line 273 "cpp2regex.h2"
+#line 282 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 274 "cpp2regex.h2"
+#line 283 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return "[:" + cpp2::to_string(Name.data()) + ":]"; }
 
-#line 281 "cpp2regex.h2"
+#line 290 "cpp2regex.h2"
     template <typename CharT, typename Inner> [[nodiscard]] auto negated_class_entry<CharT,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return !(Inner::includes(c));  }
 
-#line 289 "cpp2regex.h2"
+#line 298 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 290 "cpp2regex.h2"
+#line 299 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return Name.str(); }
 
-#line 337 "cpp2regex.h2"
+#line 346 "cpp2regex.h2"
     template <typename CharT> [[nodiscard]] auto alternative_token_matcher<CharT>::match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto{
         return match_first(cur, ctx, end_func, tail, functions...); 
     }
 
-#line 341 "cpp2regex.h2"
+#line 350 "cpp2regex.h2"
     template <typename CharT> template<typename ...Other> [[nodiscard]] auto alternative_token_matcher<CharT>::match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto
     {
         auto inner_call {[_0 = (tail), _1 = (end_func)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -967,7 +998,7 @@ template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> d
         }
     }
 
-#line 364 "cpp2regex.h2"
+#line 373 "cpp2regex.h2"
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool
 {
     if ( cur != ctx.end                     // any char except the end
@@ -980,7 +1011,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
     return false; 
 }
 
-#line 415 "cpp2regex.h2"
+#line 424 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match(auto& cur, auto& ctx) -> bool
     {
         if constexpr (case_insensitive) 
@@ -1010,7 +1041,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         }
     }
 
-#line 444 "cpp2regex.h2"
+#line 453 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> template<typename First, typename ...Other> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match_any(cpp2::impl::in<CharT> c) -> bool
     {
         bool r {First::includes(c)}; 
@@ -1024,7 +1055,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         return r; 
     }
 
-#line 493 "cpp2regex.h2"
+#line 502 "cpp2regex.h2"
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
 {
     auto g {ctx.get_group(group)}; 
@@ -1063,13 +1094,13 @@ template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodis
     }
 }
 
-#line 534 "cpp2regex.h2"
+#line 543 "cpp2regex.h2"
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool
 {
-    if (cur == ctx.end || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
+    if (cur == CPP2_UFCS(get_string_end)(ctx) || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
         return true; 
     }
-    else {if (match_new_line_before_end && (*cpp2::impl::assert_not_null(cur) == '\n' && (cur + 1) == ctx.end)) {// Special case for new line at end.
+    else {if (match_new_line_before_end && (*cpp2::impl::assert_not_null(cur) == '\n' && (cur + 1) == CPP2_UFCS(get_string_end)(ctx))) {// Special case for new line at end.
         return true; 
     }
     else {
@@ -1077,14 +1108,14 @@ template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[
     }}
 }
 
-#line 550 "cpp2regex.h2"
+#line 559 "cpp2regex.h2"
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool
 {
-    return cur == ctx.begin || // Start of string
+    return cur == CPP2_UFCS(get_string_start)(ctx) || // Start of string
            (match_new_line && *cpp2::impl::assert_not_null((cur - 1)) == '\n'); // Start of new line
 }
 
-#line 561 "cpp2regex.h2"
+#line 570 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(cur, ctx, true_end_func())}; 
@@ -1095,7 +1126,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
     return cpp2::move(r).matched; 
 }
 
-#line 571 "cpp2regex.h2"
+#line 580 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto reverse_ctx {make_reverse_match_context(ctx)}; 
@@ -1108,12 +1139,12 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
     return cpp2::move(r).matched; 
 }
 
-#line 589 "cpp2regex.h2"
+#line 598 "cpp2regex.h2"
     inline CPP2_CONSTEXPR int range_flags::not_greedy{ 1 };
     inline CPP2_CONSTEXPR int range_flags::greedy{ 2 };
     inline CPP2_CONSTEXPR int range_flags::possessive{ 3 };
 
-#line 600 "cpp2regex.h2"
+#line 609 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto
     {
         if (range_flags::possessive == kind) {
@@ -1127,26 +1158,26 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         }}
     }
 
-#line 613 "cpp2regex.h2"
+#line 622 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_upper_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == max_count) {return true; }
         else {return cpp2::impl::cmp_less(count,max_count); }
     }
 
-#line 618 "cpp2regex.h2"
+#line 627 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_lower_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == min_count) {return false; }
         else {return cpp2::impl::cmp_less(count,min_count); }
     }
 
-#line 623 "cpp2regex.h2"
+#line 632 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_in_range(cpp2::impl::in<int> count) -> bool{
         if (-1 != min_count && cpp2::impl::cmp_less(count,min_count)) {return false; }
         if (-1 != max_count && cpp2::impl::cmp_greater(count,max_count)) {return false; }
         return true; 
     }
 
-#line 629 "cpp2regex.h2"
+#line 638 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto
     {   // TODO: count_r as out parameter introduces a performance loss.
         auto res {ctx.pass(cur)}; 
@@ -1163,7 +1194,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return res; 
     }
 
-#line 645 "cpp2regex.h2"
+#line 654 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto inner_call {[_0 = (count + 1), _1 = (cur), _2 = (inner), _3 = (reset_func), _4 = (end_func), _5 = (other)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1194,7 +1225,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return r; 
     }
 
-#line 675 "cpp2regex.h2"
+#line 684 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1223,7 +1254,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); 
     }
 
-#line 703 "cpp2regex.h2"
+#line 712 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1251,20 +1282,20 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); // Upper bound reached.
     }
 
-#line 736 "cpp2regex.h2"
+#line 745 "cpp2regex.h2"
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool
 {
     word_class<CharT> words {}; 
     auto is_match {false}; 
-    if (cur == ctx.begin) {// String start
+    if (cur == ctx.begin) {// Iteration start
         if (cur != ctx.end) {// No empty string
             is_match = cpp2::move(words).includes(*cpp2::impl::assert_not_null(cur));
         }
     }
-    else {if (cur == ctx.end) {// String end
+    else {if (cur == ctx.end) {// Iteration end
         is_match = cpp2::move(words).includes(*cpp2::impl::assert_not_null((cur - 1)));
     }
-    else { // Middle of string
+    else { // Middle of iteration
         is_match = 
                 (words.includes(*cpp2::impl::assert_not_null((cur - 1))) && !(words.includes(*cpp2::impl::assert_not_null(cur)))) // End of word: \w\W
             || (!(words.includes(*cpp2::impl::assert_not_null((cur - 1)))) && words.includes(*cpp2::impl::assert_not_null(cur)));// Start of word: \W\w
@@ -1276,47 +1307,47 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
     return is_match; 
 }
 
-#line 779 "cpp2regex.h2"
+#line 788 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
             : matched{ matched_ }
             , ctx{ ctx_ }
             , pos{ cpp2::unchecked_narrow<int>(std::distance(ctx_.begin, pos_)) }{
 
-#line 783 "cpp2regex.h2"
+#line 792 "cpp2regex.h2"
         }
 
-#line 785 "cpp2regex.h2"
+#line 794 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
             : matched{ false }
             , ctx{ begin, end }
             , pos{ 0 }{
 
-#line 789 "cpp2regex.h2"
+#line 798 "cpp2regex.h2"
         }
 
-#line 791 "cpp2regex.h2"
+#line 800 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
-#line 792 "cpp2regex.h2"
+#line 801 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
-#line 793 "cpp2regex.h2"
+#line 802 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
-#line 794 "cpp2regex.h2"
+#line 803 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
 
-#line 796 "cpp2regex.h2"
+#line 805 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
-#line 797 "cpp2regex.h2"
+#line 806 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
-#line 798 "cpp2regex.h2"
+#line 807 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
 
-#line 800 "cpp2regex.h2"
+#line 809 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> auto regular_expression<CharT,matcher>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
             matched = r.matched;
             pos     = cpp2::unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
         }
 
-#line 805 "cpp2regex.h2"
+#line 814 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
             auto group_id {matcher::get_named_group_index(g)}; 
             if (-1 == group_id) {
@@ -1325,13 +1356,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             return group_id; 
         }
 
-#line 814 "cpp2regex.h2"
+#line 823 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
-#line 815 "cpp2regex.h2"
+#line 824 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
-#line 816 "cpp2regex.h2"
+#line 825 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
-#line 817 "cpp2regex.h2"
+#line 826 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> auto regular_expression<CharT,matcher>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
     {
         auto sr {search_return<Iter>(start, end)}; 
@@ -1360,13 +1391,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 845 "cpp2regex.h2"
+#line 854 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
-#line 846 "cpp2regex.h2"
+#line 855 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
-#line 847 "cpp2regex.h2"
+#line 856 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
-#line 848 "cpp2regex.h2"
+#line 857 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
     {
         context<Iter> ctx {start, end}; 
@@ -1375,20 +1406,20 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return search_return<Iter>(r.matched && r.pos == end, cpp2::move(ctx), r.pos); 
     }
 
-#line 856 "cpp2regex.h2"
+#line 865 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
-#line 857 "cpp2regex.h2"
+#line 866 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
-#line 858 "cpp2regex.h2"
+#line 867 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
-#line 859 "cpp2regex.h2"
+#line 868 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
         context<Iter> ctx {start, end}; 
         auto r {search_with_context(ctx, start)}; 
         return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
     }
 
-#line 865 "cpp2regex.h2"
+#line 874 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
     {
         auto r {ctx.fail()}; 
@@ -1412,10 +1443,10 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return r; 
     }
 
-#line 890 "cpp2regex.h2"
+#line 899 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::to_string() const& -> decltype(auto) { return matcher::to_string();  }
 
-#line 894 "cpp2regex.h2"
+#line 903 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
@@ -1425,7 +1456,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 904 "cpp2regex.h2"
+#line 913 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -24,53 +24,53 @@ template<typename Iter> class match_return;
 #line 56 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> class match_context;
 
-#line 123 "cpp2regex.h2"
+#line 126 "cpp2regex.h2"
 class true_end_func;
 
-#line 131 "cpp2regex.h2"
+#line 134 "cpp2regex.h2"
 class no_reset;
 
-#line 138 "cpp2regex.h2"
+#line 141 "cpp2regex.h2"
 template<typename Func> class on_return;
 
-#line 165 "cpp2regex.h2"
+#line 168 "cpp2regex.h2"
 template<typename CharT, CharT C> class single_class_entry;
 
-#line 174 "cpp2regex.h2"
+#line 177 "cpp2regex.h2"
 template<typename CharT, CharT Start, CharT End> class range_class_entry;
 
-#line 183 "cpp2regex.h2"
+#line 186 "cpp2regex.h2"
 template<typename CharT, typename ...List> class combined_class_entry;
 
-#line 192 "cpp2regex.h2"
+#line 195 "cpp2regex.h2"
 template<typename CharT, CharT ...List> class list_class_entry;
 
-#line 201 "cpp2regex.h2"
+#line 204 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry;
 
-#line 208 "cpp2regex.h2"
+#line 211 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry;
 
-#line 217 "cpp2regex.h2"
+#line 220 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry;
 
-#line 265 "cpp2regex.h2"
+#line 268 "cpp2regex.h2"
 template<typename CharT> class alternative_token_matcher;
 
-#line 343 "cpp2regex.h2"
+#line 346 "cpp2regex.h2"
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher;
 
-#line 506 "cpp2regex.h2"
+#line 521 "cpp2regex.h2"
 class range_flags;
     
 
-#line 515 "cpp2regex.h2"
+#line 530 "cpp2regex.h2"
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher;
 
-#line 687 "cpp2regex.h2"
+#line 702 "cpp2regex.h2"
 template<typename CharT, typename matcher_wrapper> class regular_expression;
 
-#line 823 "cpp2regex.h2"
+#line 838 "cpp2regex.h2"
 }
 }
 
@@ -160,28 +160,31 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 #line 68 "cpp2regex.h2"
     public: auto operator=(match_context&& that) noexcept -> match_context& ;
 
+    // Helper functions
+    public: auto reverse() & -> void;
+
     //  Getter and setter for groups
     //
     public: [[nodiscard]] auto get_group(auto const& group) const& -> decltype(auto);
 
     public: [[nodiscard]] auto get_group_end(auto const& group) const& -> int;
 
-#line 80 "cpp2regex.h2"
+#line 83 "cpp2regex.h2"
     public: [[nodiscard]] auto get_group_start(auto const& group) const& -> int;
 
-#line 86 "cpp2regex.h2"
+#line 89 "cpp2regex.h2"
     public: [[nodiscard]] auto get_group_string(auto const& group) const& -> std::string;
 
-#line 93 "cpp2regex.h2"
+#line 96 "cpp2regex.h2"
     public: auto set_group_end(auto const& group, auto const& pos) & -> void;
 
-#line 98 "cpp2regex.h2"
+#line 101 "cpp2regex.h2"
     public: auto set_group_invalid(auto const& group) & -> void;
 
-#line 102 "cpp2regex.h2"
+#line 105 "cpp2regex.h2"
     public: auto set_group_start(auto const& group, auto const& pos) & -> void;
 
-#line 106 "cpp2regex.h2"
+#line 109 "cpp2regex.h2"
     public: [[nodiscard]] auto size() const& -> decltype(auto);
 
     //  Misc functions
@@ -191,10 +194,10 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 
     public: auto reset() & -> void;
 
-#line 118 "cpp2regex.h2"
+#line 121 "cpp2regex.h2"
 };
 
-#line 121 "cpp2regex.h2"
+#line 124 "cpp2regex.h2"
 //  End function that returns a valid match.
 //
 class true_end_func
@@ -202,7 +205,7 @@ class true_end_func
     public: [[nodiscard]] auto operator()(auto const& cur, auto& ctx) const& -> decltype(auto);
 };
 
-#line 129 "cpp2regex.h2"
+#line 132 "cpp2regex.h2"
 //  Empty group reset function.
 //
 class no_reset
@@ -210,30 +213,30 @@ class no_reset
     public: auto operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void;
 };
 
-#line 137 "cpp2regex.h2"
+#line 140 "cpp2regex.h2"
 //  Evaluate func on destruction of the handle.
 template<typename Func> class on_return
  {
     private: Func func; 
 
     public: explicit on_return(Func const& f);
-#line 142 "cpp2regex.h2"
+#line 145 "cpp2regex.h2"
     public: auto operator=(Func const& f) -> on_return& ;
 
-#line 146 "cpp2regex.h2"
+#line 149 "cpp2regex.h2"
     public: ~on_return() noexcept;
     public: on_return(on_return const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(on_return const&) -> void = delete;
 
 
-#line 149 "cpp2regex.h2"
+#line 152 "cpp2regex.h2"
 };
 
-#line 152 "cpp2regex.h2"
+#line 155 "cpp2regex.h2"
 //  Helper for auto deduction of the Func type.
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto);
 
-#line 156 "cpp2regex.h2"
+#line 159 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Character classes for regular expressions.
@@ -251,10 +254,10 @@ template<typename CharT, CharT C> class single_class_entry
     public: single_class_entry(single_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(single_class_entry const&) -> void = delete;
 
-#line 169 "cpp2regex.h2"
+#line 172 "cpp2regex.h2"
 };
 
-#line 172 "cpp2regex.h2"
+#line 175 "cpp2regex.h2"
 //  Class syntax: - Example: a-c
 //
 template<typename CharT, CharT Start, CharT End> class range_class_entry
@@ -265,10 +268,10 @@ template<typename CharT, CharT Start, CharT End> class range_class_entry
     public: range_class_entry(range_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_class_entry const&) -> void = delete;
 
-#line 178 "cpp2regex.h2"
+#line 181 "cpp2regex.h2"
 };
 
-#line 181 "cpp2regex.h2"
+#line 184 "cpp2regex.h2"
 //  Helper for combining two character classes
 //
 template<typename CharT, typename ...List> class combined_class_entry
@@ -279,10 +282,10 @@ template<typename CharT, typename ...List> class combined_class_entry
     public: combined_class_entry(combined_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(combined_class_entry const&) -> void = delete;
 
-#line 187 "cpp2regex.h2"
+#line 190 "cpp2regex.h2"
 };
 
-#line 190 "cpp2regex.h2"
+#line 193 "cpp2regex.h2"
 //  Class syntax: <list of characters>  Example: abcd
 //
 template<typename CharT, CharT ...List> class list_class_entry
@@ -293,10 +296,10 @@ template<typename CharT, CharT ...List> class list_class_entry
     public: list_class_entry(list_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(list_class_entry const&) -> void = delete;
 
-#line 196 "cpp2regex.h2"
+#line 199 "cpp2regex.h2"
 };
 
-#line 199 "cpp2regex.h2"
+#line 202 "cpp2regex.h2"
 //  Class syntax: [:<class name:]  Example: [:alnum:]
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry
@@ -307,10 +310,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class n
     public: named_class_entry(named_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(named_class_entry const&) -> void = delete;
 
-#line 205 "cpp2regex.h2"
+#line 208 "cpp2regex.h2"
 };
 
-#line 208 "cpp2regex.h2"
+#line 211 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry
 : public Inner {
 
@@ -319,10 +322,10 @@ template<typename CharT, typename Inner> class negated_class_entry
     public: negated_class_entry(negated_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(negated_class_entry const&) -> void = delete;
 
-#line 212 "cpp2regex.h2"
+#line 215 "cpp2regex.h2"
 };
 
-#line 215 "cpp2regex.h2"
+#line 218 "cpp2regex.h2"
 //  Short class syntax: \<character>  Example: \w
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry
@@ -333,10 +336,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class s
     public: shorthand_class_entry(shorthand_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(shorthand_class_entry const&) -> void = delete;
 
-#line 221 "cpp2regex.h2"
+#line 224 "cpp2regex.h2"
 };
 
-#line 224 "cpp2regex.h2"
+#line 227 "cpp2regex.h2"
 //  Named basic character classes
 //
 template        <typename CharT> using digits_class = named_class_entry<CharT,"digits",range_class_entry<CharT,'0','9'>>;
@@ -373,7 +376,7 @@ template                     <typename CharT> using short_not_space_class = nega
 template<typename CharT> using short_not_vert_space_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\V",ver_space_class<CharT>>>;
 template                     <typename CharT> using short_not_word_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\W",word_class<CharT>>>;
 
-#line 261 "cpp2regex.h2"
+#line 264 "cpp2regex.h2"
 //  Regex syntax: |  Example: ab|ba
 //
 //  Non greedy implementation. First alternative that matches is chosen.
@@ -382,22 +385,22 @@ template<typename CharT> class alternative_token_matcher
  {
     public: [[nodiscard]] static auto match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto;
 
-#line 271 "cpp2regex.h2"
+#line 274 "cpp2regex.h2"
     private: template<typename ...Other> [[nodiscard]] static auto match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto;
     public: alternative_token_matcher() = default;
     public: alternative_token_matcher(alternative_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(alternative_token_matcher const&) -> void = delete;
 
 
-#line 289 "cpp2regex.h2"
+#line 292 "cpp2regex.h2"
 };
 
-#line 292 "cpp2regex.h2"
+#line 295 "cpp2regex.h2"
 //  Regex syntax: .
 //
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 307 "cpp2regex.h2"
+#line 310 "cpp2regex.h2"
 // TODO: Check if vectorization works at some point with this implementation.
 // char_token_matcher: <tokens: string_util::fixed_string> (inout cur, inout ctx) -> bool = {
 //     if !(std::distance(cur, ctx.end) < tokens..size()) {
@@ -431,21 +434,21 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
 //     return matched;
 // }
 
-#line 341 "cpp2regex.h2"
+#line 344 "cpp2regex.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher
  {
     public: [[nodiscard]] static auto match(auto& cur, auto& ctx) -> bool;
 
-#line 374 "cpp2regex.h2"
+#line 377 "cpp2regex.h2"
     private: template<typename First, typename ...Other> [[nodiscard]] static auto match_any(cpp2::impl::in<CharT> c) -> bool;
     public: class_token_matcher() = default;
     public: class_token_matcher(class_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(class_token_matcher const&) -> void = delete;
 
 
-#line 387 "cpp2regex.h2"
+#line 390 "cpp2regex.h2"
     // TODO: Implement proper to string
     // to_string: () -> bstring<CharT> = {
     //     r: bstring<CharT> = "[";
@@ -457,10 +460,10 @@ template<typename CharT, bool negate, bool case_insensitive, typename ...List> c
 
     //     return r;
     // }
-#line 398 "cpp2regex.h2"
+#line 401 "cpp2regex.h2"
 };
 
-#line 401 "cpp2regex.h2"
+#line 404 "cpp2regex.h2"
 // Named short classes
 //
 template                    <typename CharT,          bool case_insensitive> using named_class_no_new_line = class_token_matcher<CharT,true,case_insensitive,single_class_entry<CharT,'\n'>>;
@@ -476,7 +479,7 @@ template                    <typename CharT,          bool case_insensitive> usi
 template                    <typename CharT,          bool case_insensitive> using named_class_not_ver_space = class_token_matcher<CharT,true,case_insensitive,ver_space_class<CharT>>;
 template                    <typename CharT,          bool case_insensitive> using named_class_not_word = class_token_matcher<CharT,true,case_insensitive,word_class<CharT>>;
 
-#line 417 "cpp2regex.h2"
+#line 420 "cpp2regex.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -485,27 +488,30 @@ template                    <typename CharT,          bool case_insensitive> usi
 //
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 462 "cpp2regex.h2"
+#line 465 "cpp2regex.h2"
 //  Regex syntax: $  Example: aa$
 //
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 478 "cpp2regex.h2"
+#line 481 "cpp2regex.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 487 "cpp2regex.h2"
+#line 490 "cpp2regex.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 502 "cpp2regex.h2"
+#line 504 "cpp2regex.h2"
+template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
+
+#line 517 "cpp2regex.h2"
 // TODO: @enum as template parameter currently not working. See issue https://github.com/hsutter/cppfront/issues/1147
 
-#line 505 "cpp2regex.h2"
+#line 520 "cpp2regex.h2"
 //  Options for range matching.
 class range_flags {
     public: static const int not_greedy;// Try to take as few as possible.
@@ -516,9 +522,9 @@ class range_flags {
     public: range_flags(range_flags const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_flags const&) -> void = delete;
 };
-#line 511 "cpp2regex.h2"
+#line 526 "cpp2regex.h2"
 
-#line 513 "cpp2regex.h2"
+#line 528 "cpp2regex.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher
@@ -526,42 +532,42 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 
     public: template<typename Iter> [[nodiscard]] static auto match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto;
 
-#line 531 "cpp2regex.h2"
+#line 546 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_upper_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 536 "cpp2regex.h2"
+#line 551 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_lower_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 541 "cpp2regex.h2"
+#line 556 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_in_range(cpp2::impl::in<int> count) -> bool;
 
-#line 547 "cpp2regex.h2"
+#line 562 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto;
 
-#line 563 "cpp2regex.h2"
+#line 578 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 593 "cpp2regex.h2"
+#line 608 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 621 "cpp2regex.h2"
+#line 636 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
     public: range_token_matcher() = default;
     public: range_token_matcher(range_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_token_matcher const&) -> void = delete;
 
 
-#line 647 "cpp2regex.h2"
+#line 662 "cpp2regex.h2"
 };
 
-#line 650 "cpp2regex.h2"
+#line 665 "cpp2regex.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 679 "cpp2regex.h2"
+#line 694 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Regular expression implementation.
@@ -583,10 +589,10 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
         public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
-#line 704 "cpp2regex.h2"
+#line 719 "cpp2regex.h2"
         public: explicit search_return(Iter const& begin, Iter const& end);
 
-#line 710 "cpp2regex.h2"
+#line 725 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
         public: [[nodiscard]] auto group(cpp2::impl::in<int> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_start(cpp2::impl::in<int> g) const& -> decltype(auto);
@@ -598,13 +604,13 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
         public: auto update(cpp2::impl::in<match_return<Iter>> r) & -> void;
 
-#line 724 "cpp2regex.h2"
+#line 739 "cpp2regex.h2"
         private: [[nodiscard]] auto get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto;
         public: search_return(search_return const&) = delete; /* No 'that' constructor, suppress copy */
         public: auto operator=(search_return const&) -> void = delete;
 
 
-#line 731 "cpp2regex.h2"
+#line 746 "cpp2regex.h2"
     };
 
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
@@ -612,22 +618,22 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto);
     public: template<typename Iter> auto find_all(auto const& func, Iter const& start, Iter const& end) const& -> void;
 
-#line 764 "cpp2regex.h2"
+#line 779 "cpp2regex.h2"
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto match(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 775 "cpp2regex.h2"
+#line 790 "cpp2regex.h2"
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 784 "cpp2regex.h2"
+#line 799 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] auto search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>;
 
-#line 809 "cpp2regex.h2"
+#line 824 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -638,7 +644,7 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 821 "cpp2regex.h2"
+#line 836 "cpp2regex.h2"
 };
 
 }
@@ -696,24 +702,27 @@ template <typename Iter> match_return<Iter>::match_return(){}
                                    groups = std::move(that).groups;
                                    return *this; }
 
-#line 72 "cpp2regex.h2"
+#line 71 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::reverse() & -> void{std::swap(begin, end); }
+
+#line 75 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group(auto const& group) const& -> decltype(auto) { return CPP2_ASSERT_IN_BOUNDS(groups, group);  }
 
-#line 74 "cpp2regex.h2"
+#line 77 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_end(auto const& group) const& -> int{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return 0; 
         }
         return cpp2::unchecked_narrow<int>(std::distance(begin, CPP2_ASSERT_IN_BOUNDS(groups, group).end)); 
     }
-#line 80 "cpp2regex.h2"
+#line 83 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_start(auto const& group) const& -> int{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return 0; 
         }
         return cpp2::unchecked_narrow<int>(std::distance(begin, CPP2_ASSERT_IN_BOUNDS(groups, group).start)); 
     }
-#line 86 "cpp2regex.h2"
+#line 89 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_string(auto const& group) const& -> std::string{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return ""; 
@@ -721,104 +730,104 @@ template <typename Iter> match_return<Iter>::match_return(){}
         return std::string(CPP2_ASSERT_IN_BOUNDS(groups, group).start, CPP2_ASSERT_IN_BOUNDS(groups, group).end); 
     }
 
-#line 93 "cpp2regex.h2"
+#line 96 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_end(auto const& group, auto const& pos) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).end = pos;
         CPP2_ASSERT_IN_BOUNDS(groups, group).matched = true;
     }
 
-#line 98 "cpp2regex.h2"
+#line 101 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_invalid(auto const& group) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).matched = false;
     }
 
-#line 102 "cpp2regex.h2"
+#line 105 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_start(auto const& group, auto const& pos) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).start = pos;
     }
 
-#line 106 "cpp2regex.h2"
+#line 109 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::size() const& -> decltype(auto) { return max_groups;  }
 
-#line 110 "cpp2regex.h2"
+#line 113 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::fail() const& -> decltype(auto) { return match_return<Iter>(false, end); }
-#line 111 "cpp2regex.h2"
+#line 114 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<Iter> cur) const& -> decltype(auto) { return match_return<Iter>(true, cur);  }
 
-#line 113 "cpp2regex.h2"
+#line 116 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::reset() & -> void{
         for ( auto& g : groups ) {
             g.matched = false;
         }
     }
 
-#line 125 "cpp2regex.h2"
+#line 128 "cpp2regex.h2"
     [[nodiscard]] auto true_end_func::operator()(auto const& cur, auto& ctx) const& -> decltype(auto) { return ctx.pass(cur);  }
 
-#line 133 "cpp2regex.h2"
+#line 136 "cpp2regex.h2"
     auto no_reset::operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void{}
 
-#line 142 "cpp2regex.h2"
+#line 145 "cpp2regex.h2"
     template <typename Func> on_return<Func>::on_return(Func const& f)
         : func{ f }{
 
-#line 144 "cpp2regex.h2"
+#line 147 "cpp2regex.h2"
     }
-#line 142 "cpp2regex.h2"
+#line 145 "cpp2regex.h2"
     template <typename Func> auto on_return<Func>::operator=(Func const& f) -> on_return& {
         func = f;
         return *this;
 
-#line 144 "cpp2regex.h2"
+#line 147 "cpp2regex.h2"
     }
 
-#line 146 "cpp2regex.h2"
+#line 149 "cpp2regex.h2"
     template <typename Func> on_return<Func>::~on_return() noexcept{
         cpp2::move(*this).func();
     }
 
-#line 153 "cpp2regex.h2"
+#line 156 "cpp2regex.h2"
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto) { return on_return<Func>(func);  }
 
-#line 167 "cpp2regex.h2"
+#line 170 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return c == C;  }
-#line 168 "cpp2regex.h2"
+#line 171 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::to_string() -> decltype(auto) { return bstring<CharT>(1, C); }
 
-#line 176 "cpp2regex.h2"
+#line 179 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return [_0 = Start, _1 = c, _2 = End]{ return cpp2::impl::cmp_less_eq(_0,_1) && cpp2::impl::cmp_less_eq(_1,_2); }();  }
-#line 177 "cpp2regex.h2"
+#line 180 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::to_string() -> decltype(auto) { return "" + cpp2::to_string(Start) + "-" + cpp2::to_string(End) + ""; }
 
-#line 185 "cpp2regex.h2"
+#line 188 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || List::includes(c));  }
-#line 186 "cpp2regex.h2"
+#line 189 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List::to_string()); }
 
-#line 194 "cpp2regex.h2"
+#line 197 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || (List == c));  }
-#line 195 "cpp2regex.h2"
+#line 198 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List); }
 
-#line 203 "cpp2regex.h2"
+#line 206 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 204 "cpp2regex.h2"
+#line 207 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return "[:" + cpp2::to_string(Name.data()) + ":]"; }
 
-#line 211 "cpp2regex.h2"
+#line 214 "cpp2regex.h2"
     template <typename CharT, typename Inner> [[nodiscard]] auto negated_class_entry<CharT,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return !(Inner::includes(c));  }
 
-#line 219 "cpp2regex.h2"
+#line 222 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 220 "cpp2regex.h2"
+#line 223 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return Name.str(); }
 
-#line 267 "cpp2regex.h2"
+#line 270 "cpp2regex.h2"
     template <typename CharT> [[nodiscard]] auto alternative_token_matcher<CharT>::match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto{
         return match_first(cur, ctx, end_func, tail, functions...); 
     }
 
-#line 271 "cpp2regex.h2"
+#line 274 "cpp2regex.h2"
     template <typename CharT> template<typename ...Other> [[nodiscard]] auto alternative_token_matcher<CharT>::match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto
     {
         auto inner_call {[_0 = (tail), _1 = (end_func)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -838,7 +847,7 @@ template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> d
         }
     }
 
-#line 294 "cpp2regex.h2"
+#line 297 "cpp2regex.h2"
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool
 {
     if ( cur != ctx.end                     // any char except the end
@@ -851,7 +860,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
     return false; 
 }
 
-#line 345 "cpp2regex.h2"
+#line 348 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match(auto& cur, auto& ctx) -> bool
     {
         if constexpr (case_insensitive) 
@@ -881,7 +890,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         }
     }
 
-#line 374 "cpp2regex.h2"
+#line 377 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> template<typename First, typename ...Other> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match_any(cpp2::impl::in<CharT> c) -> bool
     {
         bool r {First::includes(c)}; 
@@ -895,7 +904,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         return r; 
     }
 
-#line 423 "cpp2regex.h2"
+#line 426 "cpp2regex.h2"
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
 {
     auto g {ctx.get_group(group)}; 
@@ -934,7 +943,7 @@ template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodis
     }
 }
 
-#line 464 "cpp2regex.h2"
+#line 467 "cpp2regex.h2"
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     if (cur == ctx.end || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
@@ -948,14 +957,14 @@ template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[
     }}
 }
 
-#line 480 "cpp2regex.h2"
+#line 483 "cpp2regex.h2"
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     return cur == ctx.begin || // Start of string
            (match_new_line && *cpp2::impl::assert_not_null((cur - 1)) == '\n'); // Start of new line
 }
 
-#line 491 "cpp2regex.h2"
+#line 494 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(cur, ctx, true_end_func())}; 
@@ -966,12 +975,25 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
     return cpp2::move(r).matched; 
 }
 
-#line 507 "cpp2regex.h2"
+#line 504 "cpp2regex.h2"
+template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
+{
+    ctx.reverse();
+    auto r {func(std::make_reverse_iterator(cur), ctx, true_end_func())}; 
+    if (!(positive)) {
+        r.matched = !(r.matched);
+    }
+    ctx.reverse();
+
+    return cpp2::move(r).matched; 
+}
+
+#line 522 "cpp2regex.h2"
     inline CPP2_CONSTEXPR int range_flags::not_greedy{ 1 };
     inline CPP2_CONSTEXPR int range_flags::greedy{ 2 };
     inline CPP2_CONSTEXPR int range_flags::possessive{ 3 };
 
-#line 518 "cpp2regex.h2"
+#line 533 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto
     {
         if (range_flags::possessive == kind) {
@@ -985,26 +1007,26 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         }}
     }
 
-#line 531 "cpp2regex.h2"
+#line 546 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_upper_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == max_count) {return true; }
         else {return cpp2::impl::cmp_less(count,max_count); }
     }
 
-#line 536 "cpp2regex.h2"
+#line 551 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_lower_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == min_count) {return false; }
         else {return cpp2::impl::cmp_less(count,min_count); }
     }
 
-#line 541 "cpp2regex.h2"
+#line 556 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_in_range(cpp2::impl::in<int> count) -> bool{
         if (-1 != min_count && cpp2::impl::cmp_less(count,min_count)) {return false; }
         if (-1 != max_count && cpp2::impl::cmp_greater(count,max_count)) {return false; }
         return true; 
     }
 
-#line 547 "cpp2regex.h2"
+#line 562 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto
     {   // TODO: count_r as out parameter introduces a performance loss.
         auto res {ctx.pass(cur)}; 
@@ -1021,7 +1043,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return res; 
     }
 
-#line 563 "cpp2regex.h2"
+#line 578 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto inner_call {[_0 = (count + 1), _1 = (cur), _2 = (inner), _3 = (reset_func), _4 = (end_func), _5 = (other)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1052,7 +1074,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return r; 
     }
 
-#line 593 "cpp2regex.h2"
+#line 608 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1081,7 +1103,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return other(cpp2::move(pos), ctx, end_func); 
     }
 
-#line 621 "cpp2regex.h2"
+#line 636 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1109,7 +1131,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return other(cpp2::move(pos), ctx, end_func); // Upper bound reached.
     }
 
-#line 654 "cpp2regex.h2"
+#line 669 "cpp2regex.h2"
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool
 {
     word_class<CharT> words {}; 
@@ -1134,47 +1156,47 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
     return is_match; 
 }
 
-#line 698 "cpp2regex.h2"
+#line 713 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
             : matched{ matched_ }
             , ctx{ ctx_ }
             , pos{ cpp2::unchecked_narrow<int>(std::distance(ctx_.begin, pos_)) }{
 
-#line 702 "cpp2regex.h2"
+#line 717 "cpp2regex.h2"
         }
 
-#line 704 "cpp2regex.h2"
+#line 719 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
             : matched{ false }
             , ctx{ begin, end }
             , pos{ 0 }{
 
-#line 708 "cpp2regex.h2"
+#line 723 "cpp2regex.h2"
         }
 
-#line 710 "cpp2regex.h2"
+#line 725 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
-#line 711 "cpp2regex.h2"
+#line 726 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
-#line 712 "cpp2regex.h2"
+#line 727 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
-#line 713 "cpp2regex.h2"
+#line 728 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
 
-#line 715 "cpp2regex.h2"
+#line 730 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
-#line 716 "cpp2regex.h2"
+#line 731 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
-#line 717 "cpp2regex.h2"
+#line 732 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
 
-#line 719 "cpp2regex.h2"
+#line 734 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
             matched = r.matched;
             pos     = cpp2::unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
         }
 
-#line 724 "cpp2regex.h2"
+#line 739 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
             auto group_id {matcher<Iter>::get_named_group_index(g)}; 
             if (-1 == group_id) {
@@ -1183,13 +1205,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             return group_id; 
         }
 
-#line 733 "cpp2regex.h2"
+#line 748 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
-#line 734 "cpp2regex.h2"
+#line 749 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
-#line 735 "cpp2regex.h2"
+#line 750 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
-#line 736 "cpp2regex.h2"
+#line 751 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> auto regular_expression<CharT,matcher_wrapper>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
     {
         auto sr {search_return<Iter>(start, end)}; 
@@ -1218,13 +1240,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 764 "cpp2regex.h2"
+#line 779 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
-#line 765 "cpp2regex.h2"
+#line 780 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
-#line 766 "cpp2regex.h2"
+#line 781 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
-#line 767 "cpp2regex.h2"
+#line 782 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
     {
         context<Iter> ctx {start, end}; 
@@ -1233,20 +1255,20 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return search_return<Iter>(r.matched && r.pos == end, cpp2::move(ctx), r.pos); 
     }
 
-#line 775 "cpp2regex.h2"
+#line 790 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
-#line 776 "cpp2regex.h2"
+#line 791 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
-#line 777 "cpp2regex.h2"
+#line 792 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
-#line 778 "cpp2regex.h2"
+#line 793 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
         context<Iter> ctx {start, end}; 
         auto r {search_with_context(ctx, start)}; 
         return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
     }
 
-#line 784 "cpp2regex.h2"
+#line 799 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
     {
         auto r {ctx.fail()}; 
@@ -1270,10 +1292,10 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return r; 
     }
 
-#line 809 "cpp2regex.h2"
+#line 824 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::to_string() const& -> decltype(auto) { return matcher_wrapper::to_string();  }
 
-#line 813 "cpp2regex.h2"
+#line 828 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
@@ -1283,7 +1305,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 823 "cpp2regex.h2"
+#line 838 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -24,53 +24,56 @@ template<typename Iter> class match_return;
 #line 56 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> class match_context;
 
-#line 126 "cpp2regex.h2"
-class true_end_func;
-
-#line 134 "cpp2regex.h2"
-class no_reset;
-
-#line 141 "cpp2regex.h2"
-template<typename Func> class on_return;
-
-#line 168 "cpp2regex.h2"
-template<typename CharT, CharT C> class single_class_entry;
-
-#line 177 "cpp2regex.h2"
-template<typename CharT, CharT Start, CharT End> class range_class_entry;
-
-#line 186 "cpp2regex.h2"
-template<typename CharT, typename ...List> class combined_class_entry;
+#line 122 "cpp2regex.h2"
+template<typename CharT, typename Iter, int max_groups> class reverse_match_context;
 
 #line 195 "cpp2regex.h2"
+class true_end_func;
+
+#line 203 "cpp2regex.h2"
+class no_reset;
+
+#line 210 "cpp2regex.h2"
+template<typename Func> class on_return;
+
+#line 237 "cpp2regex.h2"
+template<typename CharT, CharT C> class single_class_entry;
+
+#line 246 "cpp2regex.h2"
+template<typename CharT, CharT Start, CharT End> class range_class_entry;
+
+#line 255 "cpp2regex.h2"
+template<typename CharT, typename ...List> class combined_class_entry;
+
+#line 264 "cpp2regex.h2"
 template<typename CharT, CharT ...List> class list_class_entry;
 
-#line 204 "cpp2regex.h2"
+#line 273 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry;
 
-#line 211 "cpp2regex.h2"
+#line 280 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry;
 
-#line 220 "cpp2regex.h2"
+#line 289 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry;
 
-#line 268 "cpp2regex.h2"
+#line 337 "cpp2regex.h2"
 template<typename CharT> class alternative_token_matcher;
 
-#line 346 "cpp2regex.h2"
+#line 415 "cpp2regex.h2"
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher;
 
-#line 521 "cpp2regex.h2"
+#line 590 "cpp2regex.h2"
 class range_flags;
     
 
-#line 530 "cpp2regex.h2"
+#line 599 "cpp2regex.h2"
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher;
 
-#line 702 "cpp2regex.h2"
+#line 771 "cpp2regex.h2"
 template<typename CharT, typename matcher_wrapper> class regular_expression;
 
-#line 838 "cpp2regex.h2"
+#line 907 "cpp2regex.h2"
 }
 }
 
@@ -160,31 +163,28 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 #line 68 "cpp2regex.h2"
     public: auto operator=(match_context&& that) noexcept -> match_context& ;
 
-    // Helper functions
-    public: auto reverse() & -> void;
-
     //  Getter and setter for groups
     //
     public: [[nodiscard]] auto get_group(auto const& group) const& -> decltype(auto);
 
     public: [[nodiscard]] auto get_group_end(auto const& group) const& -> int;
 
-#line 83 "cpp2regex.h2"
+#line 80 "cpp2regex.h2"
     public: [[nodiscard]] auto get_group_start(auto const& group) const& -> int;
 
-#line 89 "cpp2regex.h2"
+#line 86 "cpp2regex.h2"
     public: [[nodiscard]] auto get_group_string(auto const& group) const& -> std::string;
 
-#line 96 "cpp2regex.h2"
+#line 93 "cpp2regex.h2"
     public: auto set_group_end(auto const& group, auto const& pos) & -> void;
 
-#line 101 "cpp2regex.h2"
+#line 98 "cpp2regex.h2"
     public: auto set_group_invalid(auto const& group) & -> void;
 
-#line 105 "cpp2regex.h2"
+#line 102 "cpp2regex.h2"
     public: auto set_group_start(auto const& group, auto const& pos) & -> void;
 
-#line 109 "cpp2regex.h2"
+#line 106 "cpp2regex.h2"
     public: [[nodiscard]] auto size() const& -> decltype(auto);
 
     //  Misc functions
@@ -194,10 +194,85 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 
     public: auto reset() & -> void;
 
-#line 121 "cpp2regex.h2"
+#line 118 "cpp2regex.h2"
 };
 
-#line 124 "cpp2regex.h2"
+//  Modifiable state during matching.
+//
+template<typename CharT, typename Iter, int max_groups> class reverse_match_context
+ {
+    public: using ReverseIter = std::reverse_iterator<Iter>;
+    public: match_context<CharT,Iter,max_groups>* forward_context; 
+
+            public: ReverseIter begin; 
+            public: ReverseIter end; 
+
+    public: explicit reverse_match_context(auto const& forward_context_);
+#line 130 "cpp2regex.h2"
+    public: auto operator=(auto const& forward_context_) -> reverse_match_context& ;
+
+#line 136 "cpp2regex.h2"
+    public: reverse_match_context(reverse_match_context const& that);
+#line 136 "cpp2regex.h2"
+    public: auto operator=(reverse_match_context const& that) -> reverse_match_context& ;
+#line 136 "cpp2regex.h2"
+    public: reverse_match_context(reverse_match_context&& that) noexcept;
+#line 136 "cpp2regex.h2"
+    public: auto operator=(reverse_match_context&& that) noexcept -> reverse_match_context& ;
+
+    //  Getter and setter for groups
+    //
+    //get_group: (in this, group) = groups[group];
+
+    // get_group_end:    (in this, group) -> int = {
+    //     if group >= max_groups || !groups[group].matched {
+    //         return 0;
+    //     }
+    //     return cpp2::unchecked_narrow<int>( std::distance(begin, groups[group].end) );
+    // }
+    // get_group_start:  (in this, group) -> int = {
+    //     if group >= max_groups || !groups[group].matched {
+    //         return 0;
+    //     }
+    //     return cpp2::unchecked_narrow<int>( std::distance(begin, groups[group].start) );
+    // }
+    // get_group_string: (in this, group) -> std::string = {
+    //     if group >= max_groups || !groups[group].matched {
+    //         return "";
+    //     }
+    //     return std::string(groups[group].start, groups[group].end);
+    // }
+
+    // set_group_end: (inout this, group, pos) = {
+    //     groups[group].end = pos;
+    //     groups[group].matched = true;
+    // }
+
+    // set_group_invalid: (inout this, group) = {
+    //     groups[group].matched = false;
+    // }
+
+    // set_group_start: (inout this, group, pos) = {
+    //     groups[group].start = pos;
+    // }
+
+    // size: (in this) = max_groups;
+
+    //  Misc functions
+    //
+    public: [[nodiscard]] auto fail() const& -> decltype(auto);
+    public: [[nodiscard]] auto pass(cpp2::impl::in<ReverseIter> cur) const& -> decltype(auto);
+
+    // reset: (inout this) = {
+    //     for groups do (inout g) {
+    //         g.matched = false;
+    //     }
+    // }
+};
+
+template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto;
+
+#line 193 "cpp2regex.h2"
 //  End function that returns a valid match.
 //
 class true_end_func
@@ -205,7 +280,7 @@ class true_end_func
     public: [[nodiscard]] auto operator()(auto const& cur, auto& ctx) const& -> decltype(auto);
 };
 
-#line 132 "cpp2regex.h2"
+#line 201 "cpp2regex.h2"
 //  Empty group reset function.
 //
 class no_reset
@@ -213,30 +288,30 @@ class no_reset
     public: auto operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void;
 };
 
-#line 140 "cpp2regex.h2"
+#line 209 "cpp2regex.h2"
 //  Evaluate func on destruction of the handle.
 template<typename Func> class on_return
  {
     private: Func func; 
 
     public: explicit on_return(Func const& f);
-#line 145 "cpp2regex.h2"
+#line 214 "cpp2regex.h2"
     public: auto operator=(Func const& f) -> on_return& ;
 
-#line 149 "cpp2regex.h2"
+#line 218 "cpp2regex.h2"
     public: ~on_return() noexcept;
     public: on_return(on_return const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(on_return const&) -> void = delete;
 
 
-#line 152 "cpp2regex.h2"
+#line 221 "cpp2regex.h2"
 };
 
-#line 155 "cpp2regex.h2"
+#line 224 "cpp2regex.h2"
 //  Helper for auto deduction of the Func type.
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto);
 
-#line 159 "cpp2regex.h2"
+#line 228 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Character classes for regular expressions.
@@ -254,10 +329,10 @@ template<typename CharT, CharT C> class single_class_entry
     public: single_class_entry(single_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(single_class_entry const&) -> void = delete;
 
-#line 172 "cpp2regex.h2"
+#line 241 "cpp2regex.h2"
 };
 
-#line 175 "cpp2regex.h2"
+#line 244 "cpp2regex.h2"
 //  Class syntax: - Example: a-c
 //
 template<typename CharT, CharT Start, CharT End> class range_class_entry
@@ -268,10 +343,10 @@ template<typename CharT, CharT Start, CharT End> class range_class_entry
     public: range_class_entry(range_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_class_entry const&) -> void = delete;
 
-#line 181 "cpp2regex.h2"
+#line 250 "cpp2regex.h2"
 };
 
-#line 184 "cpp2regex.h2"
+#line 253 "cpp2regex.h2"
 //  Helper for combining two character classes
 //
 template<typename CharT, typename ...List> class combined_class_entry
@@ -282,10 +357,10 @@ template<typename CharT, typename ...List> class combined_class_entry
     public: combined_class_entry(combined_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(combined_class_entry const&) -> void = delete;
 
-#line 190 "cpp2regex.h2"
+#line 259 "cpp2regex.h2"
 };
 
-#line 193 "cpp2regex.h2"
+#line 262 "cpp2regex.h2"
 //  Class syntax: <list of characters>  Example: abcd
 //
 template<typename CharT, CharT ...List> class list_class_entry
@@ -296,10 +371,10 @@ template<typename CharT, CharT ...List> class list_class_entry
     public: list_class_entry(list_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(list_class_entry const&) -> void = delete;
 
-#line 199 "cpp2regex.h2"
+#line 268 "cpp2regex.h2"
 };
 
-#line 202 "cpp2regex.h2"
+#line 271 "cpp2regex.h2"
 //  Class syntax: [:<class name:]  Example: [:alnum:]
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry
@@ -310,10 +385,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class n
     public: named_class_entry(named_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(named_class_entry const&) -> void = delete;
 
-#line 208 "cpp2regex.h2"
+#line 277 "cpp2regex.h2"
 };
 
-#line 211 "cpp2regex.h2"
+#line 280 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry
 : public Inner {
 
@@ -322,10 +397,10 @@ template<typename CharT, typename Inner> class negated_class_entry
     public: negated_class_entry(negated_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(negated_class_entry const&) -> void = delete;
 
-#line 215 "cpp2regex.h2"
+#line 284 "cpp2regex.h2"
 };
 
-#line 218 "cpp2regex.h2"
+#line 287 "cpp2regex.h2"
 //  Short class syntax: \<character>  Example: \w
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry
@@ -336,10 +411,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class s
     public: shorthand_class_entry(shorthand_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(shorthand_class_entry const&) -> void = delete;
 
-#line 224 "cpp2regex.h2"
+#line 293 "cpp2regex.h2"
 };
 
-#line 227 "cpp2regex.h2"
+#line 296 "cpp2regex.h2"
 //  Named basic character classes
 //
 template        <typename CharT> using digits_class = named_class_entry<CharT,"digits",range_class_entry<CharT,'0','9'>>;
@@ -376,7 +451,7 @@ template                     <typename CharT> using short_not_space_class = nega
 template<typename CharT> using short_not_vert_space_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\V",ver_space_class<CharT>>>;
 template                     <typename CharT> using short_not_word_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\W",word_class<CharT>>>;
 
-#line 264 "cpp2regex.h2"
+#line 333 "cpp2regex.h2"
 //  Regex syntax: |  Example: ab|ba
 //
 //  Non greedy implementation. First alternative that matches is chosen.
@@ -385,22 +460,22 @@ template<typename CharT> class alternative_token_matcher
  {
     public: [[nodiscard]] static auto match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto;
 
-#line 274 "cpp2regex.h2"
+#line 343 "cpp2regex.h2"
     private: template<typename ...Other> [[nodiscard]] static auto match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto;
     public: alternative_token_matcher() = default;
     public: alternative_token_matcher(alternative_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(alternative_token_matcher const&) -> void = delete;
 
 
-#line 292 "cpp2regex.h2"
+#line 361 "cpp2regex.h2"
 };
 
-#line 295 "cpp2regex.h2"
+#line 364 "cpp2regex.h2"
 //  Regex syntax: .
 //
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 310 "cpp2regex.h2"
+#line 379 "cpp2regex.h2"
 // TODO: Check if vectorization works at some point with this implementation.
 // char_token_matcher: <tokens: string_util::fixed_string> (inout cur, inout ctx) -> bool = {
 //     if !(std::distance(cur, ctx.end) < tokens..size()) {
@@ -434,21 +509,21 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
 //     return matched;
 // }
 
-#line 344 "cpp2regex.h2"
+#line 413 "cpp2regex.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher
  {
     public: [[nodiscard]] static auto match(auto& cur, auto& ctx) -> bool;
 
-#line 377 "cpp2regex.h2"
+#line 446 "cpp2regex.h2"
     private: template<typename First, typename ...Other> [[nodiscard]] static auto match_any(cpp2::impl::in<CharT> c) -> bool;
     public: class_token_matcher() = default;
     public: class_token_matcher(class_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(class_token_matcher const&) -> void = delete;
 
 
-#line 390 "cpp2regex.h2"
+#line 459 "cpp2regex.h2"
     // TODO: Implement proper to string
     // to_string: () -> bstring<CharT> = {
     //     r: bstring<CharT> = "[";
@@ -460,10 +535,10 @@ template<typename CharT, bool negate, bool case_insensitive, typename ...List> c
 
     //     return r;
     // }
-#line 401 "cpp2regex.h2"
+#line 470 "cpp2regex.h2"
 };
 
-#line 404 "cpp2regex.h2"
+#line 473 "cpp2regex.h2"
 // Named short classes
 //
 template                    <typename CharT,          bool case_insensitive> using named_class_no_new_line = class_token_matcher<CharT,true,case_insensitive,single_class_entry<CharT,'\n'>>;
@@ -479,7 +554,7 @@ template                    <typename CharT,          bool case_insensitive> usi
 template                    <typename CharT,          bool case_insensitive> using named_class_not_ver_space = class_token_matcher<CharT,true,case_insensitive,ver_space_class<CharT>>;
 template                    <typename CharT,          bool case_insensitive> using named_class_not_word = class_token_matcher<CharT,true,case_insensitive,word_class<CharT>>;
 
-#line 420 "cpp2regex.h2"
+#line 489 "cpp2regex.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -488,30 +563,30 @@ template                    <typename CharT,          bool case_insensitive> usi
 //
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 465 "cpp2regex.h2"
+#line 534 "cpp2regex.h2"
 //  Regex syntax: $  Example: aa$
 //
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 481 "cpp2regex.h2"
+#line 550 "cpp2regex.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 490 "cpp2regex.h2"
+#line 559 "cpp2regex.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 504 "cpp2regex.h2"
+#line 573 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 517 "cpp2regex.h2"
+#line 586 "cpp2regex.h2"
 // TODO: @enum as template parameter currently not working. See issue https://github.com/hsutter/cppfront/issues/1147
 
-#line 520 "cpp2regex.h2"
+#line 589 "cpp2regex.h2"
 //  Options for range matching.
 class range_flags {
     public: static const int not_greedy;// Try to take as few as possible.
@@ -522,9 +597,9 @@ class range_flags {
     public: range_flags(range_flags const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_flags const&) -> void = delete;
 };
-#line 526 "cpp2regex.h2"
+#line 595 "cpp2regex.h2"
 
-#line 528 "cpp2regex.h2"
+#line 597 "cpp2regex.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher
@@ -532,42 +607,42 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 
     public: template<typename Iter> [[nodiscard]] static auto match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto;
 
-#line 546 "cpp2regex.h2"
+#line 615 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_upper_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 551 "cpp2regex.h2"
+#line 620 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_lower_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 556 "cpp2regex.h2"
+#line 625 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_in_range(cpp2::impl::in<int> count) -> bool;
 
-#line 562 "cpp2regex.h2"
+#line 631 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto;
 
-#line 578 "cpp2regex.h2"
+#line 647 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 608 "cpp2regex.h2"
+#line 677 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 636 "cpp2regex.h2"
+#line 705 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
     public: range_token_matcher() = default;
     public: range_token_matcher(range_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_token_matcher const&) -> void = delete;
 
 
-#line 662 "cpp2regex.h2"
+#line 731 "cpp2regex.h2"
 };
 
-#line 665 "cpp2regex.h2"
+#line 734 "cpp2regex.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 694 "cpp2regex.h2"
+#line 763 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Regular expression implementation.
@@ -589,10 +664,10 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
         public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
-#line 719 "cpp2regex.h2"
+#line 788 "cpp2regex.h2"
         public: explicit search_return(Iter const& begin, Iter const& end);
 
-#line 725 "cpp2regex.h2"
+#line 794 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
         public: [[nodiscard]] auto group(cpp2::impl::in<int> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_start(cpp2::impl::in<int> g) const& -> decltype(auto);
@@ -604,13 +679,13 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
         public: auto update(cpp2::impl::in<match_return<Iter>> r) & -> void;
 
-#line 739 "cpp2regex.h2"
+#line 808 "cpp2regex.h2"
         private: [[nodiscard]] auto get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto;
         public: search_return(search_return const&) = delete; /* No 'that' constructor, suppress copy */
         public: auto operator=(search_return const&) -> void = delete;
 
 
-#line 746 "cpp2regex.h2"
+#line 815 "cpp2regex.h2"
     };
 
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
@@ -618,22 +693,22 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto);
     public: template<typename Iter> auto find_all(auto const& func, Iter const& start, Iter const& end) const& -> void;
 
-#line 779 "cpp2regex.h2"
+#line 848 "cpp2regex.h2"
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto match(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 790 "cpp2regex.h2"
+#line 859 "cpp2regex.h2"
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 799 "cpp2regex.h2"
+#line 868 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] auto search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>;
 
-#line 824 "cpp2regex.h2"
+#line 893 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -644,7 +719,7 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 836 "cpp2regex.h2"
+#line 905 "cpp2regex.h2"
 };
 
 }
@@ -702,27 +777,24 @@ template <typename Iter> match_return<Iter>::match_return(){}
                                    groups = std::move(that).groups;
                                    return *this; }
 
-#line 71 "cpp2regex.h2"
-    template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::reverse() & -> void{std::swap(begin, end); }
-
-#line 75 "cpp2regex.h2"
+#line 72 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group(auto const& group) const& -> decltype(auto) { return CPP2_ASSERT_IN_BOUNDS(groups, group);  }
 
-#line 77 "cpp2regex.h2"
+#line 74 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_end(auto const& group) const& -> int{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return 0; 
         }
         return cpp2::unchecked_narrow<int>(std::distance(begin, CPP2_ASSERT_IN_BOUNDS(groups, group).end)); 
     }
-#line 83 "cpp2regex.h2"
+#line 80 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_start(auto const& group) const& -> int{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return 0; 
         }
         return cpp2::unchecked_narrow<int>(std::distance(begin, CPP2_ASSERT_IN_BOUNDS(groups, group).start)); 
     }
-#line 89 "cpp2regex.h2"
+#line 86 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_string(auto const& group) const& -> std::string{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return ""; 
@@ -730,104 +802,155 @@ template <typename Iter> match_return<Iter>::match_return(){}
         return std::string(CPP2_ASSERT_IN_BOUNDS(groups, group).start, CPP2_ASSERT_IN_BOUNDS(groups, group).end); 
     }
 
-#line 96 "cpp2regex.h2"
+#line 93 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_end(auto const& group, auto const& pos) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).end = pos;
         CPP2_ASSERT_IN_BOUNDS(groups, group).matched = true;
     }
 
-#line 101 "cpp2regex.h2"
+#line 98 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_invalid(auto const& group) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).matched = false;
     }
 
-#line 105 "cpp2regex.h2"
+#line 102 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_start(auto const& group, auto const& pos) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).start = pos;
     }
 
-#line 109 "cpp2regex.h2"
+#line 106 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::size() const& -> decltype(auto) { return max_groups;  }
 
-#line 113 "cpp2regex.h2"
+#line 110 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::fail() const& -> decltype(auto) { return match_return<Iter>(false, end); }
-#line 114 "cpp2regex.h2"
+#line 111 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<Iter> cur) const& -> decltype(auto) { return match_return<Iter>(true, cur);  }
 
-#line 116 "cpp2regex.h2"
+#line 113 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::reset() & -> void{
         for ( auto& g : groups ) {
             g.matched = false;
         }
     }
 
-#line 128 "cpp2regex.h2"
-    [[nodiscard]] auto true_end_func::operator()(auto const& cur, auto& ctx) const& -> decltype(auto) { return ctx.pass(cur);  }
+#line 130 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> reverse_match_context<CharT,Iter,max_groups>::reverse_match_context(auto const& forward_context_)
+        : forward_context{ forward_context_ }
+        , begin{ std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).end) }
+        , end{ std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).begin) }{
+
+#line 134 "cpp2regex.h2"
+    }
+#line 130 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::operator=(auto const& forward_context_) -> reverse_match_context& {
+        forward_context = forward_context_;
+        begin = std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).end);
+        end = std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).begin);
+        return *this;
+
+#line 134 "cpp2regex.h2"
+    }
 
 #line 136 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> reverse_match_context<CharT,Iter,max_groups>::reverse_match_context(reverse_match_context const& that)
+                                   : forward_context{ that.forward_context }
+                                   , begin{ that.begin }
+                                   , end{ that.end }{}
+#line 136 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::operator=(reverse_match_context const& that) -> reverse_match_context& {
+                                   forward_context = that.forward_context;
+                                   begin = that.begin;
+                                   end = that.end;
+                                   return *this; }
+#line 136 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> reverse_match_context<CharT,Iter,max_groups>::reverse_match_context(reverse_match_context&& that) noexcept
+                                   : forward_context{ std::move(that).forward_context }
+                                   , begin{ std::move(that).begin }
+                                   , end{ std::move(that).end }{}
+#line 136 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::operator=(reverse_match_context&& that) noexcept -> reverse_match_context& {
+                                   forward_context = std::move(that).forward_context;
+                                   begin = std::move(that).begin;
+                                   end = std::move(that).end;
+                                   return *this; }
+
+#line 178 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::fail() const& -> decltype(auto) { return match_return<ReverseIter>(false, end); }
+#line 179 "cpp2regex.h2"
+    template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<ReverseIter> cur) const& -> decltype(auto) { return match_return<ReverseIter>(true, cur);  }
+
+#line 188 "cpp2regex.h2"
+template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto{
+    return reverse_match_context<CharT,Iter,max_groups>(&ctx); 
+}
+
+#line 197 "cpp2regex.h2"
+    [[nodiscard]] auto true_end_func::operator()(auto const& cur, auto& ctx) const& -> decltype(auto) { return ctx.pass(cur);  }
+
+#line 205 "cpp2regex.h2"
     auto no_reset::operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void{}
 
-#line 145 "cpp2regex.h2"
+#line 214 "cpp2regex.h2"
     template <typename Func> on_return<Func>::on_return(Func const& f)
         : func{ f }{
 
-#line 147 "cpp2regex.h2"
+#line 216 "cpp2regex.h2"
     }
-#line 145 "cpp2regex.h2"
+#line 214 "cpp2regex.h2"
     template <typename Func> auto on_return<Func>::operator=(Func const& f) -> on_return& {
         func = f;
         return *this;
 
-#line 147 "cpp2regex.h2"
+#line 216 "cpp2regex.h2"
     }
 
-#line 149 "cpp2regex.h2"
+#line 218 "cpp2regex.h2"
     template <typename Func> on_return<Func>::~on_return() noexcept{
         cpp2::move(*this).func();
     }
 
-#line 156 "cpp2regex.h2"
+#line 225 "cpp2regex.h2"
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto) { return on_return<Func>(func);  }
 
-#line 170 "cpp2regex.h2"
+#line 239 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return c == C;  }
-#line 171 "cpp2regex.h2"
+#line 240 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::to_string() -> decltype(auto) { return bstring<CharT>(1, C); }
 
-#line 179 "cpp2regex.h2"
+#line 248 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return [_0 = Start, _1 = c, _2 = End]{ return cpp2::impl::cmp_less_eq(_0,_1) && cpp2::impl::cmp_less_eq(_1,_2); }();  }
-#line 180 "cpp2regex.h2"
+#line 249 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::to_string() -> decltype(auto) { return "" + cpp2::to_string(Start) + "-" + cpp2::to_string(End) + ""; }
 
-#line 188 "cpp2regex.h2"
+#line 257 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || List::includes(c));  }
-#line 189 "cpp2regex.h2"
+#line 258 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List::to_string()); }
 
-#line 197 "cpp2regex.h2"
+#line 266 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || (List == c));  }
-#line 198 "cpp2regex.h2"
+#line 267 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List); }
 
-#line 206 "cpp2regex.h2"
+#line 275 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 207 "cpp2regex.h2"
+#line 276 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return "[:" + cpp2::to_string(Name.data()) + ":]"; }
 
-#line 214 "cpp2regex.h2"
+#line 283 "cpp2regex.h2"
     template <typename CharT, typename Inner> [[nodiscard]] auto negated_class_entry<CharT,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return !(Inner::includes(c));  }
 
-#line 222 "cpp2regex.h2"
+#line 291 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 223 "cpp2regex.h2"
+#line 292 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return Name.str(); }
 
-#line 270 "cpp2regex.h2"
+#line 339 "cpp2regex.h2"
     template <typename CharT> [[nodiscard]] auto alternative_token_matcher<CharT>::match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto{
         return match_first(cur, ctx, end_func, tail, functions...); 
     }
 
-#line 274 "cpp2regex.h2"
+#line 343 "cpp2regex.h2"
     template <typename CharT> template<typename ...Other> [[nodiscard]] auto alternative_token_matcher<CharT>::match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto
     {
         auto inner_call {[_0 = (tail), _1 = (end_func)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -847,7 +970,7 @@ template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> d
         }
     }
 
-#line 297 "cpp2regex.h2"
+#line 366 "cpp2regex.h2"
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool
 {
     if ( cur != ctx.end                     // any char except the end
@@ -860,7 +983,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
     return false; 
 }
 
-#line 348 "cpp2regex.h2"
+#line 417 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match(auto& cur, auto& ctx) -> bool
     {
         if constexpr (case_insensitive) 
@@ -890,7 +1013,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         }
     }
 
-#line 377 "cpp2regex.h2"
+#line 446 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> template<typename First, typename ...Other> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match_any(cpp2::impl::in<CharT> c) -> bool
     {
         bool r {First::includes(c)}; 
@@ -904,7 +1027,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         return r; 
     }
 
-#line 426 "cpp2regex.h2"
+#line 495 "cpp2regex.h2"
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
 {
     auto g {ctx.get_group(group)}; 
@@ -943,7 +1066,7 @@ template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodis
     }
 }
 
-#line 467 "cpp2regex.h2"
+#line 536 "cpp2regex.h2"
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     if (cur == ctx.end || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
@@ -957,14 +1080,14 @@ template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[
     }}
 }
 
-#line 483 "cpp2regex.h2"
+#line 552 "cpp2regex.h2"
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     return cur == ctx.begin || // Start of string
            (match_new_line && *cpp2::impl::assert_not_null((cur - 1)) == '\n'); // Start of new line
 }
 
-#line 494 "cpp2regex.h2"
+#line 563 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(cur, ctx, true_end_func())}; 
@@ -975,25 +1098,25 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
     return cpp2::move(r).matched; 
 }
 
-#line 504 "cpp2regex.h2"
+#line 573 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
-    ctx.reverse();
-    auto r {func(std::make_reverse_iterator(cur), ctx, true_end_func())}; 
+    auto reverse_ctx {make_reverse_match_context(ctx)}; 
+    auto r {func(std::make_reverse_iterator(cur), reverse_ctx, true_end_func())}; 
+    static_cast<void>(cpp2::move(reverse_ctx));
     if (!(positive)) {
         r.matched = !(r.matched);
     }
-    ctx.reverse();
 
     return cpp2::move(r).matched; 
 }
 
-#line 522 "cpp2regex.h2"
+#line 591 "cpp2regex.h2"
     inline CPP2_CONSTEXPR int range_flags::not_greedy{ 1 };
     inline CPP2_CONSTEXPR int range_flags::greedy{ 2 };
     inline CPP2_CONSTEXPR int range_flags::possessive{ 3 };
 
-#line 533 "cpp2regex.h2"
+#line 602 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto
     {
         if (range_flags::possessive == kind) {
@@ -1007,26 +1130,26 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         }}
     }
 
-#line 546 "cpp2regex.h2"
+#line 615 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_upper_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == max_count) {return true; }
         else {return cpp2::impl::cmp_less(count,max_count); }
     }
 
-#line 551 "cpp2regex.h2"
+#line 620 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_lower_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == min_count) {return false; }
         else {return cpp2::impl::cmp_less(count,min_count); }
     }
 
-#line 556 "cpp2regex.h2"
+#line 625 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_in_range(cpp2::impl::in<int> count) -> bool{
         if (-1 != min_count && cpp2::impl::cmp_less(count,min_count)) {return false; }
         if (-1 != max_count && cpp2::impl::cmp_greater(count,max_count)) {return false; }
         return true; 
     }
 
-#line 562 "cpp2regex.h2"
+#line 631 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto
     {   // TODO: count_r as out parameter introduces a performance loss.
         auto res {ctx.pass(cur)}; 
@@ -1043,7 +1166,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return res; 
     }
 
-#line 578 "cpp2regex.h2"
+#line 647 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto inner_call {[_0 = (count + 1), _1 = (cur), _2 = (inner), _3 = (reset_func), _4 = (end_func), _5 = (other)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1074,7 +1197,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return r; 
     }
 
-#line 608 "cpp2regex.h2"
+#line 677 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1103,7 +1226,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); 
     }
 
-#line 636 "cpp2regex.h2"
+#line 705 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1131,7 +1254,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); // Upper bound reached.
     }
 
-#line 669 "cpp2regex.h2"
+#line 738 "cpp2regex.h2"
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool
 {
     word_class<CharT> words {}; 
@@ -1156,47 +1279,47 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
     return is_match; 
 }
 
-#line 713 "cpp2regex.h2"
+#line 782 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
             : matched{ matched_ }
             , ctx{ ctx_ }
             , pos{ cpp2::unchecked_narrow<int>(std::distance(ctx_.begin, pos_)) }{
 
-#line 717 "cpp2regex.h2"
+#line 786 "cpp2regex.h2"
         }
 
-#line 719 "cpp2regex.h2"
+#line 788 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
             : matched{ false }
             , ctx{ begin, end }
             , pos{ 0 }{
 
-#line 723 "cpp2regex.h2"
+#line 792 "cpp2regex.h2"
         }
 
-#line 725 "cpp2regex.h2"
+#line 794 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
-#line 726 "cpp2regex.h2"
+#line 795 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
-#line 727 "cpp2regex.h2"
+#line 796 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
-#line 728 "cpp2regex.h2"
+#line 797 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
 
-#line 730 "cpp2regex.h2"
+#line 799 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
-#line 731 "cpp2regex.h2"
+#line 800 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
-#line 732 "cpp2regex.h2"
+#line 801 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
 
-#line 734 "cpp2regex.h2"
+#line 803 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
             matched = r.matched;
             pos     = cpp2::unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
         }
 
-#line 739 "cpp2regex.h2"
+#line 808 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
             auto group_id {matcher<Iter>::get_named_group_index(g)}; 
             if (-1 == group_id) {
@@ -1205,13 +1328,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             return group_id; 
         }
 
-#line 748 "cpp2regex.h2"
+#line 817 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
-#line 749 "cpp2regex.h2"
+#line 818 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
-#line 750 "cpp2regex.h2"
+#line 819 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
-#line 751 "cpp2regex.h2"
+#line 820 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> auto regular_expression<CharT,matcher_wrapper>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
     {
         auto sr {search_return<Iter>(start, end)}; 
@@ -1240,13 +1363,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 779 "cpp2regex.h2"
+#line 848 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
-#line 780 "cpp2regex.h2"
+#line 849 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
-#line 781 "cpp2regex.h2"
+#line 850 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
-#line 782 "cpp2regex.h2"
+#line 851 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
     {
         context<Iter> ctx {start, end}; 
@@ -1255,20 +1378,20 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return search_return<Iter>(r.matched && r.pos == end, cpp2::move(ctx), r.pos); 
     }
 
-#line 790 "cpp2regex.h2"
+#line 859 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
-#line 791 "cpp2regex.h2"
+#line 860 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
-#line 792 "cpp2regex.h2"
+#line 861 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
-#line 793 "cpp2regex.h2"
+#line 862 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
         context<Iter> ctx {start, end}; 
         auto r {search_with_context(ctx, start)}; 
         return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
     }
 
-#line 799 "cpp2regex.h2"
+#line 868 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
     {
         auto r {ctx.fail()}; 
@@ -1292,10 +1415,10 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return r; 
     }
 
-#line 824 "cpp2regex.h2"
+#line 893 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::to_string() const& -> decltype(auto) { return matcher_wrapper::to_string();  }
 
-#line 828 "cpp2regex.h2"
+#line 897 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
@@ -1305,7 +1428,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 838 "cpp2regex.h2"
+#line 907 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -27,53 +27,53 @@ template<typename CharT, typename Iter, int max_groups> class match_context;
 #line 125 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> class reverse_match_context;
 
-#line 202 "cpp2regex.h2"
+#line 219 "cpp2regex.h2"
 class true_end_func;
 
-#line 210 "cpp2regex.h2"
+#line 227 "cpp2regex.h2"
 class no_reset;
 
-#line 217 "cpp2regex.h2"
+#line 234 "cpp2regex.h2"
 template<typename Func> class on_return;
 
-#line 244 "cpp2regex.h2"
+#line 261 "cpp2regex.h2"
 template<typename CharT, CharT C> class single_class_entry;
 
-#line 253 "cpp2regex.h2"
+#line 270 "cpp2regex.h2"
 template<typename CharT, CharT Start, CharT End> class range_class_entry;
 
-#line 262 "cpp2regex.h2"
+#line 279 "cpp2regex.h2"
 template<typename CharT, typename ...List> class combined_class_entry;
 
-#line 271 "cpp2regex.h2"
+#line 288 "cpp2regex.h2"
 template<typename CharT, CharT ...List> class list_class_entry;
 
-#line 280 "cpp2regex.h2"
+#line 297 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry;
 
-#line 287 "cpp2regex.h2"
+#line 304 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry;
 
-#line 296 "cpp2regex.h2"
+#line 313 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry;
 
-#line 344 "cpp2regex.h2"
+#line 361 "cpp2regex.h2"
 template<typename CharT> class alternative_token_matcher;
 
-#line 422 "cpp2regex.h2"
+#line 439 "cpp2regex.h2"
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher;
 
-#line 597 "cpp2regex.h2"
+#line 616 "cpp2regex.h2"
 class range_flags;
     
 
-#line 606 "cpp2regex.h2"
+#line 625 "cpp2regex.h2"
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher;
 
-#line 778 "cpp2regex.h2"
+#line 797 "cpp2regex.h2"
 template<typename CharT, typename matcher> class regular_expression;
 
-#line 913 "cpp2regex.h2"
+#line 932 "cpp2regex.h2"
 }
 }
 
@@ -274,9 +274,24 @@ template<typename CharT, typename Iter, int max_groups> class reverse_match_cont
     // }
 };
 
+template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_forward_match_context(match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto);
+
+#line 199 "cpp2regex.h2"
+template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_forward_match_context(reverse_match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto);
+
+#line 203 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto;
 
-#line 200 "cpp2regex.h2"
+#line 207 "cpp2regex.h2"
+template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(reverse_match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto);
+
+#line 211 "cpp2regex.h2"
+template               <typename Iter> [[nodiscard]] auto make_forward_iterator(Iter const& pos) -> auto;
+template               <typename Iter> [[nodiscard]] auto make_forward_iterator(std::reverse_iterator<Iter> const& pos) -> auto;
+template               <typename Iter> [[nodiscard]] auto make_reverse_iterator(Iter const& pos) -> auto;
+template<typename Iter> [[nodiscard]] auto make_reverse_iterator(std::reverse_iterator<Iter> const& pos) -> auto;
+
+#line 217 "cpp2regex.h2"
 //  End function that returns a valid match.
 //
 class true_end_func
@@ -284,7 +299,7 @@ class true_end_func
     public: [[nodiscard]] auto operator()(auto const& cur, auto& ctx) const& -> decltype(auto);
 };
 
-#line 208 "cpp2regex.h2"
+#line 225 "cpp2regex.h2"
 //  Empty group reset function.
 //
 class no_reset
@@ -292,30 +307,30 @@ class no_reset
     public: auto operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void;
 };
 
-#line 216 "cpp2regex.h2"
+#line 233 "cpp2regex.h2"
 //  Evaluate func on destruction of the handle.
 template<typename Func> class on_return
  {
     private: Func func; 
 
     public: explicit on_return(Func const& f);
-#line 221 "cpp2regex.h2"
+#line 238 "cpp2regex.h2"
     public: auto operator=(Func const& f) -> on_return& ;
 
-#line 225 "cpp2regex.h2"
+#line 242 "cpp2regex.h2"
     public: ~on_return() noexcept;
     public: on_return(on_return const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(on_return const&) -> void = delete;
 
 
-#line 228 "cpp2regex.h2"
+#line 245 "cpp2regex.h2"
 };
 
-#line 231 "cpp2regex.h2"
+#line 248 "cpp2regex.h2"
 //  Helper for auto deduction of the Func type.
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto);
 
-#line 235 "cpp2regex.h2"
+#line 252 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Character classes for regular expressions.
@@ -333,10 +348,10 @@ template<typename CharT, CharT C> class single_class_entry
     public: single_class_entry(single_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(single_class_entry const&) -> void = delete;
 
-#line 248 "cpp2regex.h2"
+#line 265 "cpp2regex.h2"
 };
 
-#line 251 "cpp2regex.h2"
+#line 268 "cpp2regex.h2"
 //  Class syntax: - Example: a-c
 //
 template<typename CharT, CharT Start, CharT End> class range_class_entry
@@ -347,10 +362,10 @@ template<typename CharT, CharT Start, CharT End> class range_class_entry
     public: range_class_entry(range_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_class_entry const&) -> void = delete;
 
-#line 257 "cpp2regex.h2"
+#line 274 "cpp2regex.h2"
 };
 
-#line 260 "cpp2regex.h2"
+#line 277 "cpp2regex.h2"
 //  Helper for combining two character classes
 //
 template<typename CharT, typename ...List> class combined_class_entry
@@ -361,10 +376,10 @@ template<typename CharT, typename ...List> class combined_class_entry
     public: combined_class_entry(combined_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(combined_class_entry const&) -> void = delete;
 
-#line 266 "cpp2regex.h2"
+#line 283 "cpp2regex.h2"
 };
 
-#line 269 "cpp2regex.h2"
+#line 286 "cpp2regex.h2"
 //  Class syntax: <list of characters>  Example: abcd
 //
 template<typename CharT, CharT ...List> class list_class_entry
@@ -375,10 +390,10 @@ template<typename CharT, CharT ...List> class list_class_entry
     public: list_class_entry(list_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(list_class_entry const&) -> void = delete;
 
-#line 275 "cpp2regex.h2"
+#line 292 "cpp2regex.h2"
 };
 
-#line 278 "cpp2regex.h2"
+#line 295 "cpp2regex.h2"
 //  Class syntax: [:<class name:]  Example: [:alnum:]
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry
@@ -389,10 +404,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class n
     public: named_class_entry(named_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(named_class_entry const&) -> void = delete;
 
-#line 284 "cpp2regex.h2"
+#line 301 "cpp2regex.h2"
 };
 
-#line 287 "cpp2regex.h2"
+#line 304 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry
 : public Inner {
 
@@ -401,10 +416,10 @@ template<typename CharT, typename Inner> class negated_class_entry
     public: negated_class_entry(negated_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(negated_class_entry const&) -> void = delete;
 
-#line 291 "cpp2regex.h2"
+#line 308 "cpp2regex.h2"
 };
 
-#line 294 "cpp2regex.h2"
+#line 311 "cpp2regex.h2"
 //  Short class syntax: \<character>  Example: \w
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry
@@ -415,10 +430,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class s
     public: shorthand_class_entry(shorthand_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(shorthand_class_entry const&) -> void = delete;
 
-#line 300 "cpp2regex.h2"
+#line 317 "cpp2regex.h2"
 };
 
-#line 303 "cpp2regex.h2"
+#line 320 "cpp2regex.h2"
 //  Named basic character classes
 //
 template        <typename CharT> using digits_class = named_class_entry<CharT,"digits",range_class_entry<CharT,'0','9'>>;
@@ -455,7 +470,7 @@ template                     <typename CharT> using short_not_space_class = nega
 template<typename CharT> using short_not_vert_space_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\V",ver_space_class<CharT>>>;
 template                     <typename CharT> using short_not_word_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\W",word_class<CharT>>>;
 
-#line 340 "cpp2regex.h2"
+#line 357 "cpp2regex.h2"
 //  Regex syntax: |  Example: ab|ba
 //
 //  Non greedy implementation. First alternative that matches is chosen.
@@ -464,22 +479,22 @@ template<typename CharT> class alternative_token_matcher
  {
     public: [[nodiscard]] static auto match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto;
 
-#line 350 "cpp2regex.h2"
+#line 367 "cpp2regex.h2"
     private: template<typename ...Other> [[nodiscard]] static auto match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto;
     public: alternative_token_matcher() = default;
     public: alternative_token_matcher(alternative_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(alternative_token_matcher const&) -> void = delete;
 
 
-#line 368 "cpp2regex.h2"
+#line 385 "cpp2regex.h2"
 };
 
-#line 371 "cpp2regex.h2"
+#line 388 "cpp2regex.h2"
 //  Regex syntax: .
 //
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 386 "cpp2regex.h2"
+#line 403 "cpp2regex.h2"
 // TODO: Check if vectorization works at some point with this implementation.
 // char_token_matcher: <tokens: string_util::fixed_string> (inout cur, inout ctx) -> bool = {
 //     if !(std::distance(cur, ctx.end) < tokens..size()) {
@@ -513,21 +528,21 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
 //     return matched;
 // }
 
-#line 420 "cpp2regex.h2"
+#line 437 "cpp2regex.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher
  {
     public: [[nodiscard]] static auto match(auto& cur, auto& ctx) -> bool;
 
-#line 453 "cpp2regex.h2"
+#line 470 "cpp2regex.h2"
     private: template<typename First, typename ...Other> [[nodiscard]] static auto match_any(cpp2::impl::in<CharT> c) -> bool;
     public: class_token_matcher() = default;
     public: class_token_matcher(class_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(class_token_matcher const&) -> void = delete;
 
 
-#line 466 "cpp2regex.h2"
+#line 483 "cpp2regex.h2"
     // TODO: Implement proper to string
     // to_string: () -> bstring<CharT> = {
     //     r: bstring<CharT> = "[";
@@ -539,10 +554,10 @@ template<typename CharT, bool negate, bool case_insensitive, typename ...List> c
 
     //     return r;
     // }
-#line 477 "cpp2regex.h2"
+#line 494 "cpp2regex.h2"
 };
 
-#line 480 "cpp2regex.h2"
+#line 497 "cpp2regex.h2"
 // Named short classes
 //
 template                    <typename CharT,          bool case_insensitive> using named_class_no_new_line = class_token_matcher<CharT,true,case_insensitive,single_class_entry<CharT,'\n'>>;
@@ -558,7 +573,7 @@ template                    <typename CharT,          bool case_insensitive> usi
 template                    <typename CharT,          bool case_insensitive> using named_class_not_ver_space = class_token_matcher<CharT,true,case_insensitive,ver_space_class<CharT>>;
 template                    <typename CharT,          bool case_insensitive> using named_class_not_word = class_token_matcher<CharT,true,case_insensitive,word_class<CharT>>;
 
-#line 496 "cpp2regex.h2"
+#line 513 "cpp2regex.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -567,30 +582,34 @@ template                    <typename CharT,          bool case_insensitive> usi
 //
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 541 "cpp2regex.h2"
+#line 558 "cpp2regex.h2"
 //  Regex syntax: $  Example: aa$
 //
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 557 "cpp2regex.h2"
+#line 574 "cpp2regex.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 566 "cpp2regex.h2"
+#line 583 "cpp2regex.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 580 "cpp2regex.h2"
+#line 597 "cpp2regex.h2"
+//  Regex syntax: (?<=) or (?<!) or (*plb), etc.  Example: (?<=AA)
+//
+//  Parsed in group_token.
+//
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 593 "cpp2regex.h2"
+#line 612 "cpp2regex.h2"
 // TODO: @enum as template parameter currently not working. See issue https://github.com/hsutter/cppfront/issues/1147
 
-#line 596 "cpp2regex.h2"
+#line 615 "cpp2regex.h2"
 //  Options for range matching.
 class range_flags {
     public: static const int not_greedy;// Try to take as few as possible.
@@ -601,9 +620,9 @@ class range_flags {
     public: range_flags(range_flags const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_flags const&) -> void = delete;
 };
-#line 602 "cpp2regex.h2"
+#line 621 "cpp2regex.h2"
 
-#line 604 "cpp2regex.h2"
+#line 623 "cpp2regex.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher
@@ -611,42 +630,42 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 
     public: template<typename Iter> [[nodiscard]] static auto match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto;
 
-#line 622 "cpp2regex.h2"
+#line 641 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_upper_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 627 "cpp2regex.h2"
+#line 646 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_lower_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 632 "cpp2regex.h2"
+#line 651 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_in_range(cpp2::impl::in<int> count) -> bool;
 
-#line 638 "cpp2regex.h2"
+#line 657 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto;
 
-#line 654 "cpp2regex.h2"
+#line 673 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 684 "cpp2regex.h2"
+#line 703 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 712 "cpp2regex.h2"
+#line 731 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
     public: range_token_matcher() = default;
     public: range_token_matcher(range_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_token_matcher const&) -> void = delete;
 
 
-#line 738 "cpp2regex.h2"
+#line 757 "cpp2regex.h2"
 };
 
-#line 741 "cpp2regex.h2"
+#line 760 "cpp2regex.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 770 "cpp2regex.h2"
+#line 789 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Regular expression implementation.
@@ -667,10 +686,10 @@ template<typename CharT, typename matcher> class regular_expression
 
         public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
-#line 794 "cpp2regex.h2"
+#line 813 "cpp2regex.h2"
         public: explicit search_return(Iter const& begin, Iter const& end);
 
-#line 800 "cpp2regex.h2"
+#line 819 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
         public: [[nodiscard]] auto group(cpp2::impl::in<int> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_start(cpp2::impl::in<int> g) const& -> decltype(auto);
@@ -682,13 +701,13 @@ template<typename CharT, typename matcher> class regular_expression
 
         public: auto update(cpp2::impl::in<match_return<Iter>> r) & -> void;
 
-#line 814 "cpp2regex.h2"
+#line 833 "cpp2regex.h2"
         private: [[nodiscard]] auto get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto;
         public: search_return(search_return const&) = delete; /* No 'that' constructor, suppress copy */
         public: auto operator=(search_return const&) -> void = delete;
 
 
-#line 821 "cpp2regex.h2"
+#line 840 "cpp2regex.h2"
     };
 
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
@@ -696,22 +715,22 @@ template<typename CharT, typename matcher> class regular_expression
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto);
     public: template<typename Iter> auto find_all(auto const& func, Iter const& start, Iter const& end) const& -> void;
 
-#line 854 "cpp2regex.h2"
+#line 873 "cpp2regex.h2"
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto match(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 865 "cpp2regex.h2"
+#line 884 "cpp2regex.h2"
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 874 "cpp2regex.h2"
+#line 893 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] auto search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>;
 
-#line 899 "cpp2regex.h2"
+#line 918 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -722,7 +741,7 @@ template<typename CharT, typename matcher> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 911 "cpp2regex.h2"
+#line 930 "cpp2regex.h2"
 };
 
 }
@@ -908,77 +927,101 @@ template <typename Iter> match_return<Iter>::match_return(){}
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<ReverseIter> cur) const& -> decltype(auto) { return match_return<ReverseIter>(true, cur);  }
 
 #line 195 "cpp2regex.h2"
+template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_forward_match_context(match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto){
+    return ctx; 
+}
+
+#line 199 "cpp2regex.h2"
+template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_forward_match_context(reverse_match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto){
+    return *cpp2::impl::assert_not_null(ctx.forward_context); 
+}
+
+#line 203 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto{
     return reverse_match_context<CharT,Iter,max_groups>(&ctx); 
 }
 
-#line 204 "cpp2regex.h2"
-    [[nodiscard]] auto true_end_func::operator()(auto const& cur, auto& ctx) const& -> decltype(auto) { return ctx.pass(cur);  }
+#line 207 "cpp2regex.h2"
+template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(reverse_match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto){
+    return ctx; 
+}
 
+#line 211 "cpp2regex.h2"
+template               <typename Iter> [[nodiscard]] auto make_forward_iterator(Iter const& pos) -> auto { return pos; }
 #line 212 "cpp2regex.h2"
-    auto no_reset::operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void{}
+template               <typename Iter> [[nodiscard]] auto make_forward_iterator(std::reverse_iterator<Iter> const& pos) -> auto { return CPP2_UFCS(base)(pos); }
+#line 213 "cpp2regex.h2"
+template               <typename Iter> [[nodiscard]] auto make_reverse_iterator(Iter const& pos) -> auto { return std::make_reverse_iterator(pos); }
+#line 214 "cpp2regex.h2"
+template<typename Iter> [[nodiscard]] auto make_reverse_iterator(std::reverse_iterator<Iter> const& pos) -> auto { return pos;  }
 
 #line 221 "cpp2regex.h2"
+    [[nodiscard]] auto true_end_func::operator()(auto const& cur, auto& ctx) const& -> decltype(auto) { return ctx.pass(cur);  }
+
+#line 229 "cpp2regex.h2"
+    auto no_reset::operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void{}
+
+#line 238 "cpp2regex.h2"
     template <typename Func> on_return<Func>::on_return(Func const& f)
         : func{ f }{
 
-#line 223 "cpp2regex.h2"
+#line 240 "cpp2regex.h2"
     }
-#line 221 "cpp2regex.h2"
+#line 238 "cpp2regex.h2"
     template <typename Func> auto on_return<Func>::operator=(Func const& f) -> on_return& {
         func = f;
         return *this;
 
-#line 223 "cpp2regex.h2"
+#line 240 "cpp2regex.h2"
     }
 
-#line 225 "cpp2regex.h2"
+#line 242 "cpp2regex.h2"
     template <typename Func> on_return<Func>::~on_return() noexcept{
         cpp2::move(*this).func();
     }
 
-#line 232 "cpp2regex.h2"
+#line 249 "cpp2regex.h2"
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto) { return on_return<Func>(func);  }
 
-#line 246 "cpp2regex.h2"
+#line 263 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return c == C;  }
-#line 247 "cpp2regex.h2"
+#line 264 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::to_string() -> decltype(auto) { return bstring<CharT>(1, C); }
 
-#line 255 "cpp2regex.h2"
+#line 272 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return [_0 = Start, _1 = c, _2 = End]{ return cpp2::impl::cmp_less_eq(_0,_1) && cpp2::impl::cmp_less_eq(_1,_2); }();  }
-#line 256 "cpp2regex.h2"
+#line 273 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::to_string() -> decltype(auto) { return "" + cpp2::to_string(Start) + "-" + cpp2::to_string(End) + ""; }
 
-#line 264 "cpp2regex.h2"
+#line 281 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || List::includes(c));  }
-#line 265 "cpp2regex.h2"
+#line 282 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List::to_string()); }
 
-#line 273 "cpp2regex.h2"
+#line 290 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || (List == c));  }
-#line 274 "cpp2regex.h2"
+#line 291 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List); }
 
-#line 282 "cpp2regex.h2"
+#line 299 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 283 "cpp2regex.h2"
+#line 300 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return "[:" + cpp2::to_string(Name.data()) + ":]"; }
 
-#line 290 "cpp2regex.h2"
+#line 307 "cpp2regex.h2"
     template <typename CharT, typename Inner> [[nodiscard]] auto negated_class_entry<CharT,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return !(Inner::includes(c));  }
 
-#line 298 "cpp2regex.h2"
+#line 315 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 299 "cpp2regex.h2"
+#line 316 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return Name.str(); }
 
-#line 346 "cpp2regex.h2"
+#line 363 "cpp2regex.h2"
     template <typename CharT> [[nodiscard]] auto alternative_token_matcher<CharT>::match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto{
         return match_first(cur, ctx, end_func, tail, functions...); 
     }
 
-#line 350 "cpp2regex.h2"
+#line 367 "cpp2regex.h2"
     template <typename CharT> template<typename ...Other> [[nodiscard]] auto alternative_token_matcher<CharT>::match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto
     {
         auto inner_call {[_0 = (tail), _1 = (end_func)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -998,7 +1041,7 @@ template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> d
         }
     }
 
-#line 373 "cpp2regex.h2"
+#line 390 "cpp2regex.h2"
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool
 {
     if ( cur != ctx.end                     // any char except the end
@@ -1011,7 +1054,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
     return false; 
 }
 
-#line 424 "cpp2regex.h2"
+#line 441 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match(auto& cur, auto& ctx) -> bool
     {
         if constexpr (case_insensitive) 
@@ -1041,7 +1084,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         }
     }
 
-#line 453 "cpp2regex.h2"
+#line 470 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> template<typename First, typename ...Other> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match_any(cpp2::impl::in<CharT> c) -> bool
     {
         bool r {First::includes(c)}; 
@@ -1055,7 +1098,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         return r; 
     }
 
-#line 502 "cpp2regex.h2"
+#line 519 "cpp2regex.h2"
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
 {
     auto g {ctx.get_group(group)}; 
@@ -1094,7 +1137,7 @@ template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodis
     }
 }
 
-#line 543 "cpp2regex.h2"
+#line 560 "cpp2regex.h2"
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     if (cur == CPP2_UFCS(get_string_end)(ctx) || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
@@ -1108,17 +1151,17 @@ template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[
     }}
 }
 
-#line 559 "cpp2regex.h2"
+#line 576 "cpp2regex.h2"
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     return cur == CPP2_UFCS(get_string_start)(ctx) || // Start of string
            (match_new_line && *cpp2::impl::assert_not_null((cur - 1)) == '\n'); // Start of new line
 }
 
-#line 570 "cpp2regex.h2"
+#line 587 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
-    auto r {func(cur, ctx, true_end_func())}; 
+    auto r {func(make_forward_iterator(cur), make_forward_match_context(ctx), true_end_func())}; 
     if (!(positive)) {
         r.matched = !(r.matched);
     }
@@ -1126,12 +1169,10 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
     return cpp2::move(r).matched; 
 }
 
-#line 580 "cpp2regex.h2"
+#line 601 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
-    auto reverse_ctx {make_reverse_match_context(ctx)}; 
-    auto r {func(std::make_reverse_iterator(cur), reverse_ctx, true_end_func())}; 
-    static_cast<void>(cpp2::move(reverse_ctx));
+    auto r {func(make_reverse_iterator(cur), make_reverse_match_context(ctx), true_end_func())}; 
     if (!(positive)) {
         r.matched = !(r.matched);
     }
@@ -1139,12 +1180,12 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
     return cpp2::move(r).matched; 
 }
 
-#line 598 "cpp2regex.h2"
+#line 617 "cpp2regex.h2"
     inline CPP2_CONSTEXPR int range_flags::not_greedy{ 1 };
     inline CPP2_CONSTEXPR int range_flags::greedy{ 2 };
     inline CPP2_CONSTEXPR int range_flags::possessive{ 3 };
 
-#line 609 "cpp2regex.h2"
+#line 628 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto
     {
         if (range_flags::possessive == kind) {
@@ -1158,26 +1199,26 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         }}
     }
 
-#line 622 "cpp2regex.h2"
+#line 641 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_upper_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == max_count) {return true; }
         else {return cpp2::impl::cmp_less(count,max_count); }
     }
 
-#line 627 "cpp2regex.h2"
+#line 646 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_lower_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == min_count) {return false; }
         else {return cpp2::impl::cmp_less(count,min_count); }
     }
 
-#line 632 "cpp2regex.h2"
+#line 651 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_in_range(cpp2::impl::in<int> count) -> bool{
         if (-1 != min_count && cpp2::impl::cmp_less(count,min_count)) {return false; }
         if (-1 != max_count && cpp2::impl::cmp_greater(count,max_count)) {return false; }
         return true; 
     }
 
-#line 638 "cpp2regex.h2"
+#line 657 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto
     {   // TODO: count_r as out parameter introduces a performance loss.
         auto res {ctx.pass(cur)}; 
@@ -1194,7 +1235,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return res; 
     }
 
-#line 654 "cpp2regex.h2"
+#line 673 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto inner_call {[_0 = (count + 1), _1 = (cur), _2 = (inner), _3 = (reset_func), _4 = (end_func), _5 = (other)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1225,7 +1266,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return r; 
     }
 
-#line 684 "cpp2regex.h2"
+#line 703 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1254,7 +1295,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); 
     }
 
-#line 712 "cpp2regex.h2"
+#line 731 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1282,7 +1323,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); // Upper bound reached.
     }
 
-#line 745 "cpp2regex.h2"
+#line 764 "cpp2regex.h2"
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool
 {
     word_class<CharT> words {}; 
@@ -1307,47 +1348,47 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
     return is_match; 
 }
 
-#line 788 "cpp2regex.h2"
+#line 807 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
             : matched{ matched_ }
             , ctx{ ctx_ }
             , pos{ cpp2::unchecked_narrow<int>(std::distance(ctx_.begin, pos_)) }{
 
-#line 792 "cpp2regex.h2"
+#line 811 "cpp2regex.h2"
         }
 
-#line 794 "cpp2regex.h2"
+#line 813 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
             : matched{ false }
             , ctx{ begin, end }
             , pos{ 0 }{
 
-#line 798 "cpp2regex.h2"
+#line 817 "cpp2regex.h2"
         }
 
-#line 800 "cpp2regex.h2"
+#line 819 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
-#line 801 "cpp2regex.h2"
+#line 820 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
-#line 802 "cpp2regex.h2"
+#line 821 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
-#line 803 "cpp2regex.h2"
+#line 822 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
 
-#line 805 "cpp2regex.h2"
+#line 824 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
-#line 806 "cpp2regex.h2"
+#line 825 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
-#line 807 "cpp2regex.h2"
+#line 826 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
 
-#line 809 "cpp2regex.h2"
+#line 828 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> auto regular_expression<CharT,matcher>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
             matched = r.matched;
             pos     = cpp2::unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
         }
 
-#line 814 "cpp2regex.h2"
+#line 833 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
             auto group_id {matcher::get_named_group_index(g)}; 
             if (-1 == group_id) {
@@ -1356,13 +1397,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             return group_id; 
         }
 
-#line 823 "cpp2regex.h2"
+#line 842 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
-#line 824 "cpp2regex.h2"
+#line 843 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
-#line 825 "cpp2regex.h2"
+#line 844 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
-#line 826 "cpp2regex.h2"
+#line 845 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> auto regular_expression<CharT,matcher>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
     {
         auto sr {search_return<Iter>(start, end)}; 
@@ -1391,13 +1432,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 854 "cpp2regex.h2"
+#line 873 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
-#line 855 "cpp2regex.h2"
+#line 874 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
-#line 856 "cpp2regex.h2"
+#line 875 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
-#line 857 "cpp2regex.h2"
+#line 876 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
     {
         context<Iter> ctx {start, end}; 
@@ -1406,20 +1447,20 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return search_return<Iter>(r.matched && r.pos == end, cpp2::move(ctx), r.pos); 
     }
 
-#line 865 "cpp2regex.h2"
+#line 884 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
-#line 866 "cpp2regex.h2"
+#line 885 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
-#line 867 "cpp2regex.h2"
+#line 886 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
-#line 868 "cpp2regex.h2"
+#line 887 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
         context<Iter> ctx {start, end}; 
         auto r {search_with_context(ctx, start)}; 
         return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
     }
 
-#line 874 "cpp2regex.h2"
+#line 893 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
     {
         auto r {ctx.fail()}; 
@@ -1443,10 +1484,10 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return r; 
     }
 
-#line 899 "cpp2regex.h2"
+#line 918 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::to_string() const& -> decltype(auto) { return matcher::to_string();  }
 
-#line 903 "cpp2regex.h2"
+#line 922 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
@@ -1456,7 +1497,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 913 "cpp2regex.h2"
+#line 932 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -70,7 +70,7 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 #line 673 "cpp2regex.h2"
 template<typename CharT, typename matcher_wrapper> class regular_expression;
 
-#line 756 "cpp2regex.h2"
+#line 760 "cpp2regex.h2"
 }
 }
 
@@ -149,7 +149,7 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 
     private: std::array<match_group<Iter>,max_groups> groups {}; 
 
-    public: match_context(Iter const& begin_, Iter const& end_);
+    public: explicit match_context(Iter const& begin_, Iter const& end_);
 
 #line 68 "cpp2regex.h2"
     public: match_context(match_context const& that);
@@ -212,7 +212,7 @@ template<typename Func> class on_return
  {
     private: Func func; 
 
-    public: on_return(Func const& f);
+    public: explicit on_return(Func const& f);
 #line 136 "cpp2regex.h2"
     public: auto operator=(Func const& f) -> on_return& ;
 
@@ -577,7 +577,7 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
         public: context<Iter> ctx; 
         public: int pos; 
 
-        public: search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
+        public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
 #line 690 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
@@ -608,7 +608,7 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 742 "cpp2regex.h2"
+#line 746 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -619,7 +619,7 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 754 "cpp2regex.h2"
+#line 758 "cpp2regex.h2"
 };
 
 }
@@ -1171,15 +1171,19 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             if (cur == ctx.end) {
                 break;
             }
+
+            if (matcher<Iter>::is_start_match()) {
+                break; // Always break with \G option.
+            }
         }
 
         return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
     }
 
-#line 742 "cpp2regex.h2"
+#line 746 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::to_string() const& -> decltype(auto) { return matcher_wrapper::to_string();  }
 
-#line 746 "cpp2regex.h2"
+#line 750 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
@@ -1189,7 +1193,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 756 "cpp2regex.h2"
+#line 760 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -27,53 +27,53 @@ template<typename CharT, typename Iter, int max_groups> class match_context;
 #line 125 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> class reverse_match_context;
 
-#line 219 "cpp2regex.h2"
+#line 194 "cpp2regex.h2"
 class true_end_func;
 
-#line 227 "cpp2regex.h2"
+#line 202 "cpp2regex.h2"
 class no_reset;
 
-#line 234 "cpp2regex.h2"
+#line 209 "cpp2regex.h2"
 template<typename Func> class on_return;
 
-#line 261 "cpp2regex.h2"
+#line 236 "cpp2regex.h2"
 template<typename CharT, CharT C> class single_class_entry;
 
-#line 270 "cpp2regex.h2"
+#line 245 "cpp2regex.h2"
 template<typename CharT, CharT Start, CharT End> class range_class_entry;
 
-#line 279 "cpp2regex.h2"
+#line 254 "cpp2regex.h2"
 template<typename CharT, typename ...List> class combined_class_entry;
 
-#line 288 "cpp2regex.h2"
+#line 263 "cpp2regex.h2"
 template<typename CharT, CharT ...List> class list_class_entry;
 
-#line 297 "cpp2regex.h2"
+#line 272 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry;
 
-#line 304 "cpp2regex.h2"
+#line 279 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry;
 
-#line 313 "cpp2regex.h2"
+#line 288 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry;
 
-#line 361 "cpp2regex.h2"
+#line 336 "cpp2regex.h2"
 template<typename CharT> class alternative_token_matcher;
 
-#line 452 "cpp2regex.h2"
+#line 427 "cpp2regex.h2"
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher;
 
-#line 629 "cpp2regex.h2"
+#line 604 "cpp2regex.h2"
 class range_flags;
     
 
-#line 638 "cpp2regex.h2"
+#line 613 "cpp2regex.h2"
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher;
 
-#line 810 "cpp2regex.h2"
+#line 785 "cpp2regex.h2"
 template<typename CharT, typename matcher> class regular_expression;
 
-#line 945 "cpp2regex.h2"
+#line 921 "cpp2regex.h2"
 }
 }
 
@@ -200,7 +200,7 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 #line 121 "cpp2regex.h2"
 };
 
-//  Modifiable state during matching.
+//  Wrapper of context for reverse matches. Implements only the minimal interface for matching.
 //
 template<typename CharT, typename Iter, int max_groups> class reverse_match_context
  {
@@ -230,68 +230,43 @@ template<typename CharT, typename Iter, int max_groups> class reverse_match_cont
 
     //  Getter and setter for groups
     //
-    //get_group: (in this, group) = groups[group];
-
-    // get_group_end:    (in this, group) -> int = {
-    //     if group >= max_groups || !groups[group].matched {
-    //         return 0;
-    //     }
-    //     return cpp2::unchecked_narrow<int>( std::distance(begin, groups[group].end) );
-    // }
-    // get_group_start:  (in this, group) -> int = {
-    //     if group >= max_groups || !groups[group].matched {
-    //         return 0;
-    //     }
-    //     return cpp2::unchecked_narrow<int>( std::distance(begin, groups[group].start) );
-    // }
-    // get_group_string: (in this, group) -> std::string = {
-    //     if group >= max_groups || !groups[group].matched {
-    //         return "";
-    //     }
-    //     return std::string(groups[group].start, groups[group].end);
-    // }
-
     public: auto set_group_end(auto const& group, auto const& pos) & -> void;
 
-#line 173 "cpp2regex.h2"
+#line 152 "cpp2regex.h2"
     public: auto set_group_invalid(auto const& group) & -> void;
 
-#line 177 "cpp2regex.h2"
+#line 156 "cpp2regex.h2"
     public: auto set_group_start(auto const& group, auto const& pos) & -> void;
 
-#line 181 "cpp2regex.h2"
-    // size: (in this) = max_groups;
-
+#line 160 "cpp2regex.h2"
     //  Misc functions
     //
     public: [[nodiscard]] auto fail() const& -> decltype(auto);
     public: [[nodiscard]] auto pass(cpp2::impl::in<ReverseIter> cur) const& -> decltype(auto);
-
-    // reset: (inout this) = {
-    //     for groups do (inout g) {
-    //         g.matched = false;
-    //     }
-    // }
 };
 
+//  Helpers for creating wrappers of the match context.
+//
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_forward_match_context(match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto);
 
-#line 199 "cpp2regex.h2"
+#line 172 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_forward_match_context(reverse_match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto);
 
-#line 203 "cpp2regex.h2"
+#line 176 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto;
 
-#line 207 "cpp2regex.h2"
+#line 180 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(reverse_match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto);
 
-#line 211 "cpp2regex.h2"
+#line 184 "cpp2regex.h2"
+//  Helpers for creating wrappers of the iterators.
+//
 template               <typename Iter> [[nodiscard]] auto make_forward_iterator(Iter const& pos) -> auto;
 template               <typename Iter> [[nodiscard]] auto make_forward_iterator(std::reverse_iterator<Iter> const& pos) -> auto;
 template               <typename Iter> [[nodiscard]] auto make_reverse_iterator(Iter const& pos) -> auto;
 template<typename Iter> [[nodiscard]] auto make_reverse_iterator(std::reverse_iterator<Iter> const& pos) -> auto;
 
-#line 217 "cpp2regex.h2"
+#line 192 "cpp2regex.h2"
 //  End function that returns a valid match.
 //
 class true_end_func
@@ -299,7 +274,7 @@ class true_end_func
     public: [[nodiscard]] auto operator()(auto const& cur, auto& ctx) const& -> decltype(auto);
 };
 
-#line 225 "cpp2regex.h2"
+#line 200 "cpp2regex.h2"
 //  Empty group reset function.
 //
 class no_reset
@@ -307,30 +282,30 @@ class no_reset
     public: auto operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void;
 };
 
-#line 233 "cpp2regex.h2"
+#line 208 "cpp2regex.h2"
 //  Evaluate func on destruction of the handle.
 template<typename Func> class on_return
  {
     private: Func func; 
 
     public: explicit on_return(Func const& f);
-#line 238 "cpp2regex.h2"
+#line 213 "cpp2regex.h2"
     public: auto operator=(Func const& f) -> on_return& ;
 
-#line 242 "cpp2regex.h2"
+#line 217 "cpp2regex.h2"
     public: ~on_return() noexcept;
     public: on_return(on_return const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(on_return const&) -> void = delete;
 
 
-#line 245 "cpp2regex.h2"
+#line 220 "cpp2regex.h2"
 };
 
-#line 248 "cpp2regex.h2"
+#line 223 "cpp2regex.h2"
 //  Helper for auto deduction of the Func type.
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto);
 
-#line 252 "cpp2regex.h2"
+#line 227 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Character classes for regular expressions.
@@ -348,10 +323,10 @@ template<typename CharT, CharT C> class single_class_entry
     public: single_class_entry(single_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(single_class_entry const&) -> void = delete;
 
-#line 265 "cpp2regex.h2"
+#line 240 "cpp2regex.h2"
 };
 
-#line 268 "cpp2regex.h2"
+#line 243 "cpp2regex.h2"
 //  Class syntax: - Example: a-c
 //
 template<typename CharT, CharT Start, CharT End> class range_class_entry
@@ -362,10 +337,10 @@ template<typename CharT, CharT Start, CharT End> class range_class_entry
     public: range_class_entry(range_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_class_entry const&) -> void = delete;
 
-#line 274 "cpp2regex.h2"
+#line 249 "cpp2regex.h2"
 };
 
-#line 277 "cpp2regex.h2"
+#line 252 "cpp2regex.h2"
 //  Helper for combining two character classes
 //
 template<typename CharT, typename ...List> class combined_class_entry
@@ -376,10 +351,10 @@ template<typename CharT, typename ...List> class combined_class_entry
     public: combined_class_entry(combined_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(combined_class_entry const&) -> void = delete;
 
-#line 283 "cpp2regex.h2"
+#line 258 "cpp2regex.h2"
 };
 
-#line 286 "cpp2regex.h2"
+#line 261 "cpp2regex.h2"
 //  Class syntax: <list of characters>  Example: abcd
 //
 template<typename CharT, CharT ...List> class list_class_entry
@@ -390,10 +365,10 @@ template<typename CharT, CharT ...List> class list_class_entry
     public: list_class_entry(list_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(list_class_entry const&) -> void = delete;
 
-#line 292 "cpp2regex.h2"
+#line 267 "cpp2regex.h2"
 };
 
-#line 295 "cpp2regex.h2"
+#line 270 "cpp2regex.h2"
 //  Class syntax: [:<class name:]  Example: [:alnum:]
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry
@@ -404,10 +379,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class n
     public: named_class_entry(named_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(named_class_entry const&) -> void = delete;
 
-#line 301 "cpp2regex.h2"
+#line 276 "cpp2regex.h2"
 };
 
-#line 304 "cpp2regex.h2"
+#line 279 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry
 : public Inner {
 
@@ -416,10 +391,10 @@ template<typename CharT, typename Inner> class negated_class_entry
     public: negated_class_entry(negated_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(negated_class_entry const&) -> void = delete;
 
-#line 308 "cpp2regex.h2"
+#line 283 "cpp2regex.h2"
 };
 
-#line 311 "cpp2regex.h2"
+#line 286 "cpp2regex.h2"
 //  Short class syntax: \<character>  Example: \w
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry
@@ -430,10 +405,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class s
     public: shorthand_class_entry(shorthand_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(shorthand_class_entry const&) -> void = delete;
 
-#line 317 "cpp2regex.h2"
+#line 292 "cpp2regex.h2"
 };
 
-#line 320 "cpp2regex.h2"
+#line 295 "cpp2regex.h2"
 //  Named basic character classes
 //
 template        <typename CharT> using digits_class = named_class_entry<CharT,"digits",range_class_entry<CharT,'0','9'>>;
@@ -470,7 +445,7 @@ template                     <typename CharT> using short_not_space_class = nega
 template<typename CharT> using short_not_vert_space_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\V",ver_space_class<CharT>>>;
 template                     <typename CharT> using short_not_word_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\W",word_class<CharT>>>;
 
-#line 357 "cpp2regex.h2"
+#line 332 "cpp2regex.h2"
 //  Regex syntax: |  Example: ab|ba
 //
 //  Non greedy implementation. First alternative that matches is chosen.
@@ -479,27 +454,27 @@ template<typename CharT> class alternative_token_matcher
  {
     public: [[nodiscard]] static auto match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto;
 
-#line 367 "cpp2regex.h2"
+#line 342 "cpp2regex.h2"
     private: template<typename ...Other> [[nodiscard]] static auto match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto;
     public: alternative_token_matcher() = default;
     public: alternative_token_matcher(alternative_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(alternative_token_matcher const&) -> void = delete;
 
 
-#line 385 "cpp2regex.h2"
+#line 360 "cpp2regex.h2"
 };
 
-#line 388 "cpp2regex.h2"
+#line 363 "cpp2regex.h2"
 //  Regex syntax: .
 //
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 402 "cpp2regex.h2"
+#line 377 "cpp2regex.h2"
 //  Regex syntax: (?><matcher>)  Example: a(?>bc|c)c
 //
 template<typename CharT, typename Iter> [[nodiscard]] auto atomic_group_matcher(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> auto;
 
-#line 416 "cpp2regex.h2"
+#line 391 "cpp2regex.h2"
 // TODO: Check if vectorization works at some point with this implementation.
 // char_token_matcher: <tokens: string_util::fixed_string> (inout cur, inout ctx) -> bool = {
 //     if !(std::distance(cur, ctx.end) < tokens..size()) {
@@ -533,21 +508,21 @@ template<typename CharT, typename Iter> [[nodiscard]] auto atomic_group_matcher(
 //     return matched;
 // }
 
-#line 450 "cpp2regex.h2"
+#line 425 "cpp2regex.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher
  {
     public: [[nodiscard]] static auto match(auto& cur, auto& ctx) -> bool;
 
-#line 483 "cpp2regex.h2"
+#line 458 "cpp2regex.h2"
     private: template<typename First, typename ...Other> [[nodiscard]] static auto match_any(cpp2::impl::in<CharT> c) -> bool;
     public: class_token_matcher() = default;
     public: class_token_matcher(class_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(class_token_matcher const&) -> void = delete;
 
 
-#line 496 "cpp2regex.h2"
+#line 471 "cpp2regex.h2"
     // TODO: Implement proper to string
     // to_string: () -> bstring<CharT> = {
     //     r: bstring<CharT> = "[";
@@ -559,10 +534,10 @@ template<typename CharT, bool negate, bool case_insensitive, typename ...List> c
 
     //     return r;
     // }
-#line 507 "cpp2regex.h2"
+#line 482 "cpp2regex.h2"
 };
 
-#line 510 "cpp2regex.h2"
+#line 485 "cpp2regex.h2"
 // Named short classes
 //
 template                    <typename CharT,          bool case_insensitive> using named_class_no_new_line = class_token_matcher<CharT,true,case_insensitive,single_class_entry<CharT,'\n'>>;
@@ -578,7 +553,7 @@ template                    <typename CharT,          bool case_insensitive> usi
 template                    <typename CharT,          bool case_insensitive> using named_class_not_ver_space = class_token_matcher<CharT,true,case_insensitive,ver_space_class<CharT>>;
 template                    <typename CharT,          bool case_insensitive> using named_class_not_word = class_token_matcher<CharT,true,case_insensitive,word_class<CharT>>;
 
-#line 526 "cpp2regex.h2"
+#line 501 "cpp2regex.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -587,34 +562,34 @@ template                    <typename CharT,          bool case_insensitive> usi
 //
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 571 "cpp2regex.h2"
+#line 546 "cpp2regex.h2"
 //  Regex syntax: $  Example: aa$
 //
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 587 "cpp2regex.h2"
+#line 562 "cpp2regex.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 596 "cpp2regex.h2"
+#line 571 "cpp2regex.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 610 "cpp2regex.h2"
+#line 585 "cpp2regex.h2"
 //  Regex syntax: (?<=) or (?<!) or (*plb), etc.  Example: (?<=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 625 "cpp2regex.h2"
+#line 600 "cpp2regex.h2"
 // TODO: @enum as template parameter currently not working. See issue https://github.com/hsutter/cppfront/issues/1147
 
-#line 628 "cpp2regex.h2"
+#line 603 "cpp2regex.h2"
 //  Options for range matching.
 class range_flags {
     public: static const int not_greedy;// Try to take as few as possible.
@@ -625,9 +600,9 @@ class range_flags {
     public: range_flags(range_flags const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_flags const&) -> void = delete;
 };
-#line 634 "cpp2regex.h2"
+#line 609 "cpp2regex.h2"
 
-#line 636 "cpp2regex.h2"
+#line 611 "cpp2regex.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher
@@ -635,42 +610,42 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 
     public: template<typename Iter> [[nodiscard]] static auto match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto;
 
-#line 654 "cpp2regex.h2"
+#line 629 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_upper_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 659 "cpp2regex.h2"
+#line 634 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_lower_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 664 "cpp2regex.h2"
+#line 639 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_in_range(cpp2::impl::in<int> count) -> bool;
 
-#line 670 "cpp2regex.h2"
+#line 645 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto;
 
-#line 686 "cpp2regex.h2"
+#line 661 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 716 "cpp2regex.h2"
+#line 691 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 744 "cpp2regex.h2"
+#line 719 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
     public: range_token_matcher() = default;
     public: range_token_matcher(range_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_token_matcher const&) -> void = delete;
 
 
-#line 770 "cpp2regex.h2"
+#line 745 "cpp2regex.h2"
 };
 
-#line 773 "cpp2regex.h2"
+#line 748 "cpp2regex.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 802 "cpp2regex.h2"
+#line 777 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Regular expression implementation.
@@ -691,10 +666,10 @@ template<typename CharT, typename matcher> class regular_expression
 
         public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
-#line 826 "cpp2regex.h2"
+#line 801 "cpp2regex.h2"
         public: explicit search_return(Iter const& begin, Iter const& end);
 
-#line 832 "cpp2regex.h2"
+#line 807 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
         public: [[nodiscard]] auto group(cpp2::impl::in<int> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_start(cpp2::impl::in<int> g) const& -> decltype(auto);
@@ -706,13 +681,13 @@ template<typename CharT, typename matcher> class regular_expression
 
         public: auto update(cpp2::impl::in<match_return<Iter>> r) & -> void;
 
-#line 846 "cpp2regex.h2"
+#line 821 "cpp2regex.h2"
         private: [[nodiscard]] auto get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto;
         public: search_return(search_return const&) = delete; /* No 'that' constructor, suppress copy */
         public: auto operator=(search_return const&) -> void = delete;
 
 
-#line 853 "cpp2regex.h2"
+#line 828 "cpp2regex.h2"
     };
 
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
@@ -720,22 +695,22 @@ template<typename CharT, typename matcher> class regular_expression
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto);
     public: template<typename Iter> auto find_all(auto const& func, Iter const& start, Iter const& end) const& -> void;
 
-#line 886 "cpp2regex.h2"
+#line 861 "cpp2regex.h2"
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto match(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 897 "cpp2regex.h2"
+#line 872 "cpp2regex.h2"
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 906 "cpp2regex.h2"
+#line 882 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] auto search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>;
 
-#line 931 "cpp2regex.h2"
+#line 907 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -746,7 +721,7 @@ template<typename CharT, typename matcher> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 943 "cpp2regex.h2"
+#line 919 "cpp2regex.h2"
 };
 
 }
@@ -911,122 +886,122 @@ template <typename Iter> match_return<Iter>::match_return(){}
 #line 144 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::get_string_end() const& -> decltype(auto) { return begin;  }
 
-#line 169 "cpp2regex.h2"
+#line 148 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::set_group_end(auto const& group, auto const& pos) & -> void{
         (*cpp2::impl::assert_not_null(forward_context)).set_group_end(group, CPP2_UFCS(base)((pos)));
     }
 
-#line 173 "cpp2regex.h2"
+#line 152 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::set_group_invalid(auto const& group) & -> void{
         (*cpp2::impl::assert_not_null(forward_context)).set_group_invalid(group);
     }
 
-#line 177 "cpp2regex.h2"
+#line 156 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::set_group_start(auto const& group, auto const& pos) & -> void{
         (*cpp2::impl::assert_not_null(forward_context)).set_group_start(group, CPP2_UFCS(base)((pos)));
     }
 
-#line 185 "cpp2regex.h2"
+#line 162 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::fail() const& -> decltype(auto) { return match_return<ReverseIter>(false, end); }
-#line 186 "cpp2regex.h2"
+#line 163 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<ReverseIter> cur) const& -> decltype(auto) { return match_return<ReverseIter>(true, cur);  }
 
-#line 195 "cpp2regex.h2"
+#line 168 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_forward_match_context(match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto){
     return ctx; 
 }
 
-#line 199 "cpp2regex.h2"
+#line 172 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_forward_match_context(reverse_match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto){
     return *cpp2::impl::assert_not_null(ctx.forward_context); 
 }
 
-#line 203 "cpp2regex.h2"
+#line 176 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto{
     return reverse_match_context<CharT,Iter,max_groups>(&ctx); 
 }
 
-#line 207 "cpp2regex.h2"
+#line 180 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(reverse_match_context<CharT,Iter,max_groups>& ctx) -> decltype(auto){
     return ctx; 
 }
 
-#line 211 "cpp2regex.h2"
+#line 186 "cpp2regex.h2"
 template               <typename Iter> [[nodiscard]] auto make_forward_iterator(Iter const& pos) -> auto { return pos; }
-#line 212 "cpp2regex.h2"
+#line 187 "cpp2regex.h2"
 template               <typename Iter> [[nodiscard]] auto make_forward_iterator(std::reverse_iterator<Iter> const& pos) -> auto { return CPP2_UFCS(base)(pos); }
-#line 213 "cpp2regex.h2"
+#line 188 "cpp2regex.h2"
 template               <typename Iter> [[nodiscard]] auto make_reverse_iterator(Iter const& pos) -> auto { return std::make_reverse_iterator(pos); }
-#line 214 "cpp2regex.h2"
+#line 189 "cpp2regex.h2"
 template<typename Iter> [[nodiscard]] auto make_reverse_iterator(std::reverse_iterator<Iter> const& pos) -> auto { return pos;  }
 
-#line 221 "cpp2regex.h2"
+#line 196 "cpp2regex.h2"
     [[nodiscard]] auto true_end_func::operator()(auto const& cur, auto& ctx) const& -> decltype(auto) { return ctx.pass(cur);  }
 
-#line 229 "cpp2regex.h2"
+#line 204 "cpp2regex.h2"
     auto no_reset::operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void{}
 
-#line 238 "cpp2regex.h2"
+#line 213 "cpp2regex.h2"
     template <typename Func> on_return<Func>::on_return(Func const& f)
         : func{ f }{
 
-#line 240 "cpp2regex.h2"
+#line 215 "cpp2regex.h2"
     }
-#line 238 "cpp2regex.h2"
+#line 213 "cpp2regex.h2"
     template <typename Func> auto on_return<Func>::operator=(Func const& f) -> on_return& {
         func = f;
         return *this;
 
-#line 240 "cpp2regex.h2"
+#line 215 "cpp2regex.h2"
     }
 
-#line 242 "cpp2regex.h2"
+#line 217 "cpp2regex.h2"
     template <typename Func> on_return<Func>::~on_return() noexcept{
         cpp2::move(*this).func();
     }
 
-#line 249 "cpp2regex.h2"
+#line 224 "cpp2regex.h2"
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto) { return on_return<Func>(func);  }
 
-#line 263 "cpp2regex.h2"
+#line 238 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return c == C;  }
-#line 264 "cpp2regex.h2"
+#line 239 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::to_string() -> decltype(auto) { return bstring<CharT>(1, C); }
 
-#line 272 "cpp2regex.h2"
+#line 247 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return [_0 = Start, _1 = c, _2 = End]{ return cpp2::impl::cmp_less_eq(_0,_1) && cpp2::impl::cmp_less_eq(_1,_2); }();  }
-#line 273 "cpp2regex.h2"
+#line 248 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::to_string() -> decltype(auto) { return "" + cpp2::to_string(Start) + "-" + cpp2::to_string(End) + ""; }
 
-#line 281 "cpp2regex.h2"
+#line 256 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || List::includes(c));  }
-#line 282 "cpp2regex.h2"
+#line 257 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List::to_string()); }
 
-#line 290 "cpp2regex.h2"
+#line 265 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || (List == c));  }
-#line 291 "cpp2regex.h2"
+#line 266 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List); }
 
-#line 299 "cpp2regex.h2"
+#line 274 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 300 "cpp2regex.h2"
+#line 275 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return "[:" + cpp2::to_string(Name.data()) + ":]"; }
 
-#line 307 "cpp2regex.h2"
+#line 282 "cpp2regex.h2"
     template <typename CharT, typename Inner> [[nodiscard]] auto negated_class_entry<CharT,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return !(Inner::includes(c));  }
 
-#line 315 "cpp2regex.h2"
+#line 290 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 316 "cpp2regex.h2"
+#line 291 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return Name.str(); }
 
-#line 363 "cpp2regex.h2"
+#line 338 "cpp2regex.h2"
     template <typename CharT> [[nodiscard]] auto alternative_token_matcher<CharT>::match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto{
         return match_first(cur, ctx, end_func, tail, functions...); 
     }
 
-#line 367 "cpp2regex.h2"
+#line 342 "cpp2regex.h2"
     template <typename CharT> template<typename ...Other> [[nodiscard]] auto alternative_token_matcher<CharT>::match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto
     {
         auto inner_call {[_0 = (tail), _1 = (end_func)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1046,7 +1021,7 @@ template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> d
         }
     }
 
-#line 390 "cpp2regex.h2"
+#line 365 "cpp2regex.h2"
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool
 {
     if ( cur != ctx.end                     // any char except the end
@@ -1059,7 +1034,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
     return false; 
 }
 
-#line 404 "cpp2regex.h2"
+#line 379 "cpp2regex.h2"
 template<typename CharT, typename Iter> [[nodiscard]] auto atomic_group_matcher(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> auto
 {
     auto r {inner(cur, ctx, true_end_func())}; 
@@ -1071,7 +1046,7 @@ template<typename CharT, typename Iter> [[nodiscard]] auto atomic_group_matcher(
     return r; 
 }
 
-#line 454 "cpp2regex.h2"
+#line 429 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match(auto& cur, auto& ctx) -> bool
     {
         if constexpr (case_insensitive) 
@@ -1101,7 +1076,7 @@ template<typename CharT, typename Iter> [[nodiscard]] auto atomic_group_matcher(
         }
     }
 
-#line 483 "cpp2regex.h2"
+#line 458 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> template<typename First, typename ...Other> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match_any(cpp2::impl::in<CharT> c) -> bool
     {
         bool r {First::includes(c)}; 
@@ -1115,7 +1090,7 @@ template<typename CharT, typename Iter> [[nodiscard]] auto atomic_group_matcher(
         return r; 
     }
 
-#line 532 "cpp2regex.h2"
+#line 507 "cpp2regex.h2"
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
 {
     auto g {ctx.get_group(group)}; 
@@ -1154,7 +1129,7 @@ template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodis
     }
 }
 
-#line 573 "cpp2regex.h2"
+#line 548 "cpp2regex.h2"
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     if (cur == CPP2_UFCS(get_string_end)(ctx) || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
@@ -1168,14 +1143,14 @@ template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[
     }}
 }
 
-#line 589 "cpp2regex.h2"
+#line 564 "cpp2regex.h2"
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     return cur == CPP2_UFCS(get_string_start)(ctx) || // Start of string
            (match_new_line && *cpp2::impl::assert_not_null((cur - 1)) == '\n'); // Start of new line
 }
 
-#line 600 "cpp2regex.h2"
+#line 575 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(make_forward_iterator(cur), make_forward_match_context(ctx), true_end_func())}; 
@@ -1186,7 +1161,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
     return cpp2::move(r).matched; 
 }
 
-#line 614 "cpp2regex.h2"
+#line 589 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(make_reverse_iterator(cur), make_reverse_match_context(ctx), true_end_func())}; 
@@ -1197,12 +1172,12 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
     return cpp2::move(r).matched; 
 }
 
-#line 630 "cpp2regex.h2"
+#line 605 "cpp2regex.h2"
     inline CPP2_CONSTEXPR int range_flags::not_greedy{ 1 };
     inline CPP2_CONSTEXPR int range_flags::greedy{ 2 };
     inline CPP2_CONSTEXPR int range_flags::possessive{ 3 };
 
-#line 641 "cpp2regex.h2"
+#line 616 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto
     {
         if (range_flags::possessive == kind) {
@@ -1216,26 +1191,26 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         }}
     }
 
-#line 654 "cpp2regex.h2"
+#line 629 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_upper_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == max_count) {return true; }
         else {return cpp2::impl::cmp_less(count,max_count); }
     }
 
-#line 659 "cpp2regex.h2"
+#line 634 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_lower_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == min_count) {return false; }
         else {return cpp2::impl::cmp_less(count,min_count); }
     }
 
-#line 664 "cpp2regex.h2"
+#line 639 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_in_range(cpp2::impl::in<int> count) -> bool{
         if (-1 != min_count && cpp2::impl::cmp_less(count,min_count)) {return false; }
         if (-1 != max_count && cpp2::impl::cmp_greater(count,max_count)) {return false; }
         return true; 
     }
 
-#line 670 "cpp2regex.h2"
+#line 645 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto
     {   // TODO: count_r as out parameter introduces a performance loss.
         auto res {ctx.pass(cur)}; 
@@ -1252,7 +1227,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return res; 
     }
 
-#line 686 "cpp2regex.h2"
+#line 661 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto inner_call {[_0 = (count + 1), _1 = (cur), _2 = (inner), _3 = (reset_func), _4 = (end_func), _5 = (other)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1283,7 +1258,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return r; 
     }
 
-#line 716 "cpp2regex.h2"
+#line 691 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1312,7 +1287,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); 
     }
 
-#line 744 "cpp2regex.h2"
+#line 719 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1340,7 +1315,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); // Upper bound reached.
     }
 
-#line 777 "cpp2regex.h2"
+#line 752 "cpp2regex.h2"
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool
 {
     word_class<CharT> words {}; 
@@ -1365,47 +1340,47 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
     return is_match; 
 }
 
-#line 820 "cpp2regex.h2"
+#line 795 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
             : matched{ matched_ }
             , ctx{ ctx_ }
             , pos{ cpp2::unchecked_narrow<int>(std::distance(ctx_.begin, pos_)) }{
 
-#line 824 "cpp2regex.h2"
+#line 799 "cpp2regex.h2"
         }
 
-#line 826 "cpp2regex.h2"
+#line 801 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
             : matched{ false }
             , ctx{ begin, end }
             , pos{ 0 }{
 
-#line 830 "cpp2regex.h2"
+#line 805 "cpp2regex.h2"
         }
 
-#line 832 "cpp2regex.h2"
+#line 807 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
-#line 833 "cpp2regex.h2"
+#line 808 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
-#line 834 "cpp2regex.h2"
+#line 809 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
-#line 835 "cpp2regex.h2"
+#line 810 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
 
-#line 837 "cpp2regex.h2"
+#line 812 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
-#line 838 "cpp2regex.h2"
+#line 813 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
-#line 839 "cpp2regex.h2"
+#line 814 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
 
-#line 841 "cpp2regex.h2"
+#line 816 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> auto regular_expression<CharT,matcher>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
             matched = r.matched;
             pos     = cpp2::unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
         }
 
-#line 846 "cpp2regex.h2"
+#line 821 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
             auto group_id {matcher::get_named_group_index(g)}; 
             if (-1 == group_id) {
@@ -1414,13 +1389,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             return group_id; 
         }
 
-#line 855 "cpp2regex.h2"
+#line 830 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
-#line 856 "cpp2regex.h2"
+#line 831 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
-#line 857 "cpp2regex.h2"
+#line 832 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
-#line 858 "cpp2regex.h2"
+#line 833 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> auto regular_expression<CharT,matcher>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
     {
         auto sr {search_return<Iter>(start, end)}; 
@@ -1449,13 +1424,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 886 "cpp2regex.h2"
+#line 861 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
-#line 887 "cpp2regex.h2"
+#line 862 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
-#line 888 "cpp2regex.h2"
+#line 863 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
-#line 889 "cpp2regex.h2"
+#line 864 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
     {
         context<Iter> ctx {start, end}; 
@@ -1464,20 +1439,21 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return search_return<Iter>(r.matched && r.pos == end, cpp2::move(ctx), r.pos); 
     }
 
-#line 897 "cpp2regex.h2"
+#line 872 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
-#line 898 "cpp2regex.h2"
+#line 873 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
-#line 899 "cpp2regex.h2"
+#line 874 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
-#line 900 "cpp2regex.h2"
-    template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
+#line 875 "cpp2regex.h2"
+    template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>
+    {
         context<Iter> ctx {start, end}; 
         auto r {search_with_context(ctx, start)}; 
         return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
     }
 
-#line 906 "cpp2regex.h2"
+#line 882 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
     {
         auto r {ctx.fail()}; 
@@ -1501,10 +1477,10 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return r; 
     }
 
-#line 931 "cpp2regex.h2"
+#line 907 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::to_string() const& -> decltype(auto) { return matcher::to_string();  }
 
-#line 935 "cpp2regex.h2"
+#line 911 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
@@ -1514,7 +1490,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 945 "cpp2regex.h2"
+#line 921 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -60,20 +60,20 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class s
 #line 361 "cpp2regex.h2"
 template<typename CharT> class alternative_token_matcher;
 
-#line 439 "cpp2regex.h2"
+#line 452 "cpp2regex.h2"
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher;
 
-#line 616 "cpp2regex.h2"
+#line 629 "cpp2regex.h2"
 class range_flags;
     
 
-#line 625 "cpp2regex.h2"
+#line 638 "cpp2regex.h2"
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher;
 
-#line 797 "cpp2regex.h2"
+#line 810 "cpp2regex.h2"
 template<typename CharT, typename matcher> class regular_expression;
 
-#line 932 "cpp2regex.h2"
+#line 945 "cpp2regex.h2"
 }
 }
 
@@ -494,7 +494,12 @@ template<typename CharT> class alternative_token_matcher
 //
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 403 "cpp2regex.h2"
+#line 402 "cpp2regex.h2"
+//  Regex syntax: (?><matcher>)  Example: a(?>bc|c)c
+//
+template<typename CharT, typename Iter> [[nodiscard]] auto atomic_group_matcher(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> auto;
+
+#line 416 "cpp2regex.h2"
 // TODO: Check if vectorization works at some point with this implementation.
 // char_token_matcher: <tokens: string_util::fixed_string> (inout cur, inout ctx) -> bool = {
 //     if !(std::distance(cur, ctx.end) < tokens..size()) {
@@ -528,21 +533,21 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
 //     return matched;
 // }
 
-#line 437 "cpp2regex.h2"
+#line 450 "cpp2regex.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher
  {
     public: [[nodiscard]] static auto match(auto& cur, auto& ctx) -> bool;
 
-#line 470 "cpp2regex.h2"
+#line 483 "cpp2regex.h2"
     private: template<typename First, typename ...Other> [[nodiscard]] static auto match_any(cpp2::impl::in<CharT> c) -> bool;
     public: class_token_matcher() = default;
     public: class_token_matcher(class_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(class_token_matcher const&) -> void = delete;
 
 
-#line 483 "cpp2regex.h2"
+#line 496 "cpp2regex.h2"
     // TODO: Implement proper to string
     // to_string: () -> bstring<CharT> = {
     //     r: bstring<CharT> = "[";
@@ -554,10 +559,10 @@ template<typename CharT, bool negate, bool case_insensitive, typename ...List> c
 
     //     return r;
     // }
-#line 494 "cpp2regex.h2"
+#line 507 "cpp2regex.h2"
 };
 
-#line 497 "cpp2regex.h2"
+#line 510 "cpp2regex.h2"
 // Named short classes
 //
 template                    <typename CharT,          bool case_insensitive> using named_class_no_new_line = class_token_matcher<CharT,true,case_insensitive,single_class_entry<CharT,'\n'>>;
@@ -573,7 +578,7 @@ template                    <typename CharT,          bool case_insensitive> usi
 template                    <typename CharT,          bool case_insensitive> using named_class_not_ver_space = class_token_matcher<CharT,true,case_insensitive,ver_space_class<CharT>>;
 template                    <typename CharT,          bool case_insensitive> using named_class_not_word = class_token_matcher<CharT,true,case_insensitive,word_class<CharT>>;
 
-#line 513 "cpp2regex.h2"
+#line 526 "cpp2regex.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -582,34 +587,34 @@ template                    <typename CharT,          bool case_insensitive> usi
 //
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 558 "cpp2regex.h2"
+#line 571 "cpp2regex.h2"
 //  Regex syntax: $  Example: aa$
 //
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 574 "cpp2regex.h2"
+#line 587 "cpp2regex.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 583 "cpp2regex.h2"
+#line 596 "cpp2regex.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 597 "cpp2regex.h2"
+#line 610 "cpp2regex.h2"
 //  Regex syntax: (?<=) or (?<!) or (*plb), etc.  Example: (?<=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 612 "cpp2regex.h2"
+#line 625 "cpp2regex.h2"
 // TODO: @enum as template parameter currently not working. See issue https://github.com/hsutter/cppfront/issues/1147
 
-#line 615 "cpp2regex.h2"
+#line 628 "cpp2regex.h2"
 //  Options for range matching.
 class range_flags {
     public: static const int not_greedy;// Try to take as few as possible.
@@ -620,9 +625,9 @@ class range_flags {
     public: range_flags(range_flags const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_flags const&) -> void = delete;
 };
-#line 621 "cpp2regex.h2"
+#line 634 "cpp2regex.h2"
 
-#line 623 "cpp2regex.h2"
+#line 636 "cpp2regex.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher
@@ -630,42 +635,42 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 
     public: template<typename Iter> [[nodiscard]] static auto match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto;
 
-#line 641 "cpp2regex.h2"
+#line 654 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_upper_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 646 "cpp2regex.h2"
+#line 659 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_lower_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 651 "cpp2regex.h2"
+#line 664 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_in_range(cpp2::impl::in<int> count) -> bool;
 
-#line 657 "cpp2regex.h2"
+#line 670 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto;
 
-#line 673 "cpp2regex.h2"
+#line 686 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 703 "cpp2regex.h2"
+#line 716 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 731 "cpp2regex.h2"
+#line 744 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
     public: range_token_matcher() = default;
     public: range_token_matcher(range_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_token_matcher const&) -> void = delete;
 
 
-#line 757 "cpp2regex.h2"
+#line 770 "cpp2regex.h2"
 };
 
-#line 760 "cpp2regex.h2"
+#line 773 "cpp2regex.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 789 "cpp2regex.h2"
+#line 802 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Regular expression implementation.
@@ -686,10 +691,10 @@ template<typename CharT, typename matcher> class regular_expression
 
         public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
-#line 813 "cpp2regex.h2"
+#line 826 "cpp2regex.h2"
         public: explicit search_return(Iter const& begin, Iter const& end);
 
-#line 819 "cpp2regex.h2"
+#line 832 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
         public: [[nodiscard]] auto group(cpp2::impl::in<int> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_start(cpp2::impl::in<int> g) const& -> decltype(auto);
@@ -701,13 +706,13 @@ template<typename CharT, typename matcher> class regular_expression
 
         public: auto update(cpp2::impl::in<match_return<Iter>> r) & -> void;
 
-#line 833 "cpp2regex.h2"
+#line 846 "cpp2regex.h2"
         private: [[nodiscard]] auto get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto;
         public: search_return(search_return const&) = delete; /* No 'that' constructor, suppress copy */
         public: auto operator=(search_return const&) -> void = delete;
 
 
-#line 840 "cpp2regex.h2"
+#line 853 "cpp2regex.h2"
     };
 
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
@@ -715,22 +720,22 @@ template<typename CharT, typename matcher> class regular_expression
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto);
     public: template<typename Iter> auto find_all(auto const& func, Iter const& start, Iter const& end) const& -> void;
 
-#line 873 "cpp2regex.h2"
+#line 886 "cpp2regex.h2"
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto match(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 884 "cpp2regex.h2"
+#line 897 "cpp2regex.h2"
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 893 "cpp2regex.h2"
+#line 906 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] auto search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>;
 
-#line 918 "cpp2regex.h2"
+#line 931 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -741,7 +746,7 @@ template<typename CharT, typename matcher> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 930 "cpp2regex.h2"
+#line 943 "cpp2regex.h2"
 };
 
 }
@@ -1054,7 +1059,19 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
     return false; 
 }
 
-#line 441 "cpp2regex.h2"
+#line 404 "cpp2regex.h2"
+template<typename CharT, typename Iter> [[nodiscard]] auto atomic_group_matcher(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> auto
+{
+    auto r {inner(cur, ctx, true_end_func())}; 
+
+    if (r.matched) {
+        r = other(r.pos, ctx, end_func);
+    }
+
+    return r; 
+}
+
+#line 454 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match(auto& cur, auto& ctx) -> bool
     {
         if constexpr (case_insensitive) 
@@ -1084,7 +1101,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         }
     }
 
-#line 470 "cpp2regex.h2"
+#line 483 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> template<typename First, typename ...Other> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match_any(cpp2::impl::in<CharT> c) -> bool
     {
         bool r {First::includes(c)}; 
@@ -1098,7 +1115,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         return r; 
     }
 
-#line 519 "cpp2regex.h2"
+#line 532 "cpp2regex.h2"
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
 {
     auto g {ctx.get_group(group)}; 
@@ -1137,7 +1154,7 @@ template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodis
     }
 }
 
-#line 560 "cpp2regex.h2"
+#line 573 "cpp2regex.h2"
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     if (cur == CPP2_UFCS(get_string_end)(ctx) || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
@@ -1151,14 +1168,14 @@ template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[
     }}
 }
 
-#line 576 "cpp2regex.h2"
+#line 589 "cpp2regex.h2"
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     return cur == CPP2_UFCS(get_string_start)(ctx) || // Start of string
            (match_new_line && *cpp2::impl::assert_not_null((cur - 1)) == '\n'); // Start of new line
 }
 
-#line 587 "cpp2regex.h2"
+#line 600 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(make_forward_iterator(cur), make_forward_match_context(ctx), true_end_func())}; 
@@ -1169,7 +1186,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
     return cpp2::move(r).matched; 
 }
 
-#line 601 "cpp2regex.h2"
+#line 614 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(make_reverse_iterator(cur), make_reverse_match_context(ctx), true_end_func())}; 
@@ -1180,12 +1197,12 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
     return cpp2::move(r).matched; 
 }
 
-#line 617 "cpp2regex.h2"
+#line 630 "cpp2regex.h2"
     inline CPP2_CONSTEXPR int range_flags::not_greedy{ 1 };
     inline CPP2_CONSTEXPR int range_flags::greedy{ 2 };
     inline CPP2_CONSTEXPR int range_flags::possessive{ 3 };
 
-#line 628 "cpp2regex.h2"
+#line 641 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto
     {
         if (range_flags::possessive == kind) {
@@ -1199,26 +1216,26 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         }}
     }
 
-#line 641 "cpp2regex.h2"
+#line 654 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_upper_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == max_count) {return true; }
         else {return cpp2::impl::cmp_less(count,max_count); }
     }
 
-#line 646 "cpp2regex.h2"
+#line 659 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_lower_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == min_count) {return false; }
         else {return cpp2::impl::cmp_less(count,min_count); }
     }
 
-#line 651 "cpp2regex.h2"
+#line 664 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_in_range(cpp2::impl::in<int> count) -> bool{
         if (-1 != min_count && cpp2::impl::cmp_less(count,min_count)) {return false; }
         if (-1 != max_count && cpp2::impl::cmp_greater(count,max_count)) {return false; }
         return true; 
     }
 
-#line 657 "cpp2regex.h2"
+#line 670 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto
     {   // TODO: count_r as out parameter introduces a performance loss.
         auto res {ctx.pass(cur)}; 
@@ -1235,7 +1252,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return res; 
     }
 
-#line 673 "cpp2regex.h2"
+#line 686 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto inner_call {[_0 = (count + 1), _1 = (cur), _2 = (inner), _3 = (reset_func), _4 = (end_func), _5 = (other)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1266,7 +1283,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return r; 
     }
 
-#line 703 "cpp2regex.h2"
+#line 716 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1295,7 +1312,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); 
     }
 
-#line 731 "cpp2regex.h2"
+#line 744 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1323,7 +1340,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); // Upper bound reached.
     }
 
-#line 764 "cpp2regex.h2"
+#line 777 "cpp2regex.h2"
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool
 {
     word_class<CharT> words {}; 
@@ -1348,47 +1365,47 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
     return is_match; 
 }
 
-#line 807 "cpp2regex.h2"
+#line 820 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
             : matched{ matched_ }
             , ctx{ ctx_ }
             , pos{ cpp2::unchecked_narrow<int>(std::distance(ctx_.begin, pos_)) }{
 
-#line 811 "cpp2regex.h2"
+#line 824 "cpp2regex.h2"
         }
 
-#line 813 "cpp2regex.h2"
+#line 826 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
             : matched{ false }
             , ctx{ begin, end }
             , pos{ 0 }{
 
-#line 817 "cpp2regex.h2"
+#line 830 "cpp2regex.h2"
         }
 
-#line 819 "cpp2regex.h2"
+#line 832 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
-#line 820 "cpp2regex.h2"
+#line 833 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
-#line 821 "cpp2regex.h2"
+#line 834 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
-#line 822 "cpp2regex.h2"
+#line 835 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
 
-#line 824 "cpp2regex.h2"
+#line 837 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
-#line 825 "cpp2regex.h2"
+#line 838 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
-#line 826 "cpp2regex.h2"
+#line 839 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
 
-#line 828 "cpp2regex.h2"
+#line 841 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> auto regular_expression<CharT,matcher>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
             matched = r.matched;
             pos     = cpp2::unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
         }
 
-#line 833 "cpp2regex.h2"
+#line 846 "cpp2regex.h2"
         template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
             auto group_id {matcher::get_named_group_index(g)}; 
             if (-1 == group_id) {
@@ -1397,13 +1414,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             return group_id; 
         }
 
-#line 842 "cpp2regex.h2"
+#line 855 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
-#line 843 "cpp2regex.h2"
+#line 856 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
-#line 844 "cpp2regex.h2"
+#line 857 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
-#line 845 "cpp2regex.h2"
+#line 858 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> auto regular_expression<CharT,matcher>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
     {
         auto sr {search_return<Iter>(start, end)}; 
@@ -1432,13 +1449,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 873 "cpp2regex.h2"
+#line 886 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
-#line 874 "cpp2regex.h2"
+#line 887 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
-#line 875 "cpp2regex.h2"
+#line 888 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
-#line 876 "cpp2regex.h2"
+#line 889 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
     {
         context<Iter> ctx {start, end}; 
@@ -1447,20 +1464,20 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return search_return<Iter>(r.matched && r.pos == end, cpp2::move(ctx), r.pos); 
     }
 
-#line 884 "cpp2regex.h2"
+#line 897 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
-#line 885 "cpp2regex.h2"
+#line 898 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
-#line 886 "cpp2regex.h2"
+#line 899 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
-#line 887 "cpp2regex.h2"
+#line 900 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
         context<Iter> ctx {start, end}; 
         auto r {search_with_context(ctx, start)}; 
         return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
     }
 
-#line 893 "cpp2regex.h2"
+#line 906 "cpp2regex.h2"
     template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
     {
         auto r {ctx.fail()}; 
@@ -1484,10 +1501,10 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return r; 
     }
 
-#line 918 "cpp2regex.h2"
+#line 931 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::to_string() const& -> decltype(auto) { return matcher::to_string();  }
 
-#line 922 "cpp2regex.h2"
+#line 935 "cpp2regex.h2"
     template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
@@ -1497,7 +1514,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 932 "cpp2regex.h2"
+#line 945 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -60,17 +60,17 @@ template<typename CharT> class alternative_token_matcher;
 #line 343 "cpp2regex.h2"
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher;
 
-#line 498 "cpp2regex.h2"
+#line 506 "cpp2regex.h2"
 class range_flags;
     
 
-#line 507 "cpp2regex.h2"
+#line 515 "cpp2regex.h2"
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher;
 
-#line 679 "cpp2regex.h2"
+#line 687 "cpp2regex.h2"
 template<typename CharT, typename matcher_wrapper> class regular_expression;
 
-#line 815 "cpp2regex.h2"
+#line 823 "cpp2regex.h2"
 }
 }
 
@@ -483,29 +483,29 @@ template                    <typename CharT,          bool case_insensitive> usi
 //                \k<name_or_number>
 //                \k'name_or_number'
 //
-template<typename CharT, int group, bool case_insensitive> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
+template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 454 "cpp2regex.h2"
+#line 462 "cpp2regex.h2"
 //  Regex syntax: $  Example: aa$
 //
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 470 "cpp2regex.h2"
+#line 478 "cpp2regex.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 479 "cpp2regex.h2"
+#line 487 "cpp2regex.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 494 "cpp2regex.h2"
+#line 502 "cpp2regex.h2"
 // TODO: @enum as template parameter currently not working. See issue https://github.com/hsutter/cppfront/issues/1147
 
-#line 497 "cpp2regex.h2"
+#line 505 "cpp2regex.h2"
 //  Options for range matching.
 class range_flags {
     public: static const int not_greedy;// Try to take as few as possible.
@@ -516,9 +516,9 @@ class range_flags {
     public: range_flags(range_flags const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_flags const&) -> void = delete;
 };
-#line 503 "cpp2regex.h2"
+#line 511 "cpp2regex.h2"
 
-#line 505 "cpp2regex.h2"
+#line 513 "cpp2regex.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher
@@ -526,42 +526,42 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 
     public: template<typename Iter> [[nodiscard]] static auto match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto;
 
-#line 523 "cpp2regex.h2"
+#line 531 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_upper_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 528 "cpp2regex.h2"
+#line 536 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_lower_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 533 "cpp2regex.h2"
+#line 541 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_in_range(cpp2::impl::in<int> count) -> bool;
 
-#line 539 "cpp2regex.h2"
+#line 547 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto;
 
-#line 555 "cpp2regex.h2"
+#line 563 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 585 "cpp2regex.h2"
+#line 593 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 613 "cpp2regex.h2"
+#line 621 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
     public: range_token_matcher() = default;
     public: range_token_matcher(range_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_token_matcher const&) -> void = delete;
 
 
-#line 639 "cpp2regex.h2"
+#line 647 "cpp2regex.h2"
 };
 
-#line 642 "cpp2regex.h2"
+#line 650 "cpp2regex.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 671 "cpp2regex.h2"
+#line 679 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Regular expression implementation.
@@ -583,10 +583,10 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
         public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
-#line 696 "cpp2regex.h2"
+#line 704 "cpp2regex.h2"
         public: explicit search_return(Iter const& begin, Iter const& end);
 
-#line 702 "cpp2regex.h2"
+#line 710 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
         public: [[nodiscard]] auto group(cpp2::impl::in<int> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_start(cpp2::impl::in<int> g) const& -> decltype(auto);
@@ -598,13 +598,13 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
         public: auto update(cpp2::impl::in<match_return<Iter>> r) & -> void;
 
-#line 716 "cpp2regex.h2"
+#line 724 "cpp2regex.h2"
         private: [[nodiscard]] auto get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto;
         public: search_return(search_return const&) = delete; /* No 'that' constructor, suppress copy */
         public: auto operator=(search_return const&) -> void = delete;
 
 
-#line 723 "cpp2regex.h2"
+#line 731 "cpp2regex.h2"
     };
 
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
@@ -612,22 +612,22 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto);
     public: template<typename Iter> auto find_all(auto const& func, Iter const& start, Iter const& end) const& -> void;
 
-#line 756 "cpp2regex.h2"
+#line 764 "cpp2regex.h2"
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto match(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 767 "cpp2regex.h2"
+#line 775 "cpp2regex.h2"
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 776 "cpp2regex.h2"
+#line 784 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] auto search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>;
 
-#line 801 "cpp2regex.h2"
+#line 809 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -638,7 +638,7 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 813 "cpp2regex.h2"
+#line 821 "cpp2regex.h2"
 };
 
 }
@@ -896,15 +896,23 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
     }
 
 #line 423 "cpp2regex.h2"
-template<typename CharT, int group, bool case_insensitive> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
+template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
 {
     auto g {ctx.get_group(group)}; 
 
-    auto group_pos {cpp2::move(g).start}; 
+    auto group_pos {g.start}; 
+    auto group_end {g.end}; 
+    int group_inc {1}; 
+    if (reverse) {
+        group_pos = g.end;
+        group_end = cpp2::move(g).start;
+        group_inc = -1;
+    }
+
     for( ; 
-        group_pos != g.end 
+        group_pos != group_end 
         && cur != ctx.end; 
-    (++group_pos, ++cur) ) 
+    (group_pos += group_inc, ++cur) ) 
     {
         if constexpr (case_insensitive) {
             if (string_util::safe_tolower(*cpp2::impl::assert_not_null(group_pos)) != string_util::safe_tolower(*cpp2::impl::assert_not_null(cur))) {
@@ -918,7 +926,7 @@ template<typename CharT, int group, bool case_insensitive> [[nodiscard]] auto gr
         }
     }
 
-    if (cpp2::move(group_pos) == cpp2::move(g).end) {
+    if (cpp2::move(group_pos) == cpp2::move(group_end)) {
         return true; 
     }
     else {
@@ -926,7 +934,7 @@ template<typename CharT, int group, bool case_insensitive> [[nodiscard]] auto gr
     }
 }
 
-#line 456 "cpp2regex.h2"
+#line 464 "cpp2regex.h2"
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     if (cur == ctx.end || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
@@ -940,14 +948,14 @@ template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[
     }}
 }
 
-#line 472 "cpp2regex.h2"
+#line 480 "cpp2regex.h2"
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     return cur == ctx.begin || // Start of string
            (match_new_line && *cpp2::impl::assert_not_null((cur - 1)) == '\n'); // Start of new line
 }
 
-#line 483 "cpp2regex.h2"
+#line 491 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(cur, ctx, true_end_func())}; 
@@ -958,12 +966,12 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
     return cpp2::move(r).matched; 
 }
 
-#line 499 "cpp2regex.h2"
+#line 507 "cpp2regex.h2"
     inline CPP2_CONSTEXPR int range_flags::not_greedy{ 1 };
     inline CPP2_CONSTEXPR int range_flags::greedy{ 2 };
     inline CPP2_CONSTEXPR int range_flags::possessive{ 3 };
 
-#line 510 "cpp2regex.h2"
+#line 518 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto
     {
         if (range_flags::possessive == kind) {
@@ -977,26 +985,26 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         }}
     }
 
-#line 523 "cpp2regex.h2"
+#line 531 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_upper_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == max_count) {return true; }
         else {return cpp2::impl::cmp_less(count,max_count); }
     }
 
-#line 528 "cpp2regex.h2"
+#line 536 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_lower_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == min_count) {return false; }
         else {return cpp2::impl::cmp_less(count,min_count); }
     }
 
-#line 533 "cpp2regex.h2"
+#line 541 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_in_range(cpp2::impl::in<int> count) -> bool{
         if (-1 != min_count && cpp2::impl::cmp_less(count,min_count)) {return false; }
         if (-1 != max_count && cpp2::impl::cmp_greater(count,max_count)) {return false; }
         return true; 
     }
 
-#line 539 "cpp2regex.h2"
+#line 547 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto
     {   // TODO: count_r as out parameter introduces a performance loss.
         auto res {ctx.pass(cur)}; 
@@ -1013,7 +1021,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return res; 
     }
 
-#line 555 "cpp2regex.h2"
+#line 563 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto inner_call {[_0 = (count + 1), _1 = (cur), _2 = (inner), _3 = (reset_func), _4 = (end_func), _5 = (other)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1044,7 +1052,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return r; 
     }
 
-#line 585 "cpp2regex.h2"
+#line 593 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1073,7 +1081,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return other(cpp2::move(pos), ctx, end_func); 
     }
 
-#line 613 "cpp2regex.h2"
+#line 621 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1101,7 +1109,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
         return other(cpp2::move(pos), ctx, end_func); // Upper bound reached.
     }
 
-#line 646 "cpp2regex.h2"
+#line 654 "cpp2regex.h2"
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool
 {
     word_class<CharT> words {}; 
@@ -1126,47 +1134,47 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
     return is_match; 
 }
 
-#line 690 "cpp2regex.h2"
+#line 698 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
             : matched{ matched_ }
             , ctx{ ctx_ }
             , pos{ cpp2::unchecked_narrow<int>(std::distance(ctx_.begin, pos_)) }{
 
-#line 694 "cpp2regex.h2"
+#line 702 "cpp2regex.h2"
         }
 
-#line 696 "cpp2regex.h2"
+#line 704 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
             : matched{ false }
             , ctx{ begin, end }
             , pos{ 0 }{
 
-#line 700 "cpp2regex.h2"
+#line 708 "cpp2regex.h2"
         }
 
-#line 702 "cpp2regex.h2"
+#line 710 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
-#line 703 "cpp2regex.h2"
+#line 711 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
-#line 704 "cpp2regex.h2"
+#line 712 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
-#line 705 "cpp2regex.h2"
+#line 713 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
 
-#line 707 "cpp2regex.h2"
+#line 715 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
-#line 708 "cpp2regex.h2"
+#line 716 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
-#line 709 "cpp2regex.h2"
+#line 717 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
 
-#line 711 "cpp2regex.h2"
+#line 719 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
             matched = r.matched;
             pos     = cpp2::unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
         }
 
-#line 716 "cpp2regex.h2"
+#line 724 "cpp2regex.h2"
         template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
             auto group_id {matcher<Iter>::get_named_group_index(g)}; 
             if (-1 == group_id) {
@@ -1175,13 +1183,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
             return group_id; 
         }
 
-#line 725 "cpp2regex.h2"
+#line 733 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
-#line 726 "cpp2regex.h2"
+#line 734 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
-#line 727 "cpp2regex.h2"
+#line 735 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
-#line 728 "cpp2regex.h2"
+#line 736 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> auto regular_expression<CharT,matcher_wrapper>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
     {
         auto sr {search_return<Iter>(start, end)}; 
@@ -1210,13 +1218,13 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 756 "cpp2regex.h2"
+#line 764 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
-#line 757 "cpp2regex.h2"
+#line 765 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
-#line 758 "cpp2regex.h2"
+#line 766 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
-#line 759 "cpp2regex.h2"
+#line 767 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
     {
         context<Iter> ctx {start, end}; 
@@ -1225,20 +1233,20 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return search_return<Iter>(r.matched && r.pos == end, cpp2::move(ctx), r.pos); 
     }
 
-#line 767 "cpp2regex.h2"
+#line 775 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
-#line 768 "cpp2regex.h2"
+#line 776 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
-#line 769 "cpp2regex.h2"
+#line 777 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
-#line 770 "cpp2regex.h2"
+#line 778 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
         context<Iter> ctx {start, end}; 
         auto r {search_with_context(ctx, start)}; 
         return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
     }
 
-#line 776 "cpp2regex.h2"
+#line 784 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
     {
         auto r {ctx.fail()}; 
@@ -1262,10 +1270,10 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return r; 
     }
 
-#line 801 "cpp2regex.h2"
+#line 809 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::to_string() const& -> decltype(auto) { return matcher_wrapper::to_string();  }
 
-#line 805 "cpp2regex.h2"
+#line 813 "cpp2regex.h2"
     template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
@@ -1275,7 +1283,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 815 "cpp2regex.h2"
+#line 823 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h
+++ b/include/cpp2regex.h
@@ -10,70 +10,70 @@
 
 #line 1 "cpp2regex.h2"
 
-#line 22 "cpp2regex.h2"
+#line 20 "cpp2regex.h2"
 namespace cpp2 {
 
 namespace regex {
 
-#line 38 "cpp2regex.h2"
+#line 36 "cpp2regex.h2"
 template<typename Iter> class match_group;
 
-#line 48 "cpp2regex.h2"
+#line 46 "cpp2regex.h2"
 template<typename Iter> class match_return;
 
-#line 56 "cpp2regex.h2"
+#line 54 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> class match_context;
 
-#line 122 "cpp2regex.h2"
+#line 120 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> class reverse_match_context;
 
-#line 195 "cpp2regex.h2"
+#line 193 "cpp2regex.h2"
 class true_end_func;
 
-#line 203 "cpp2regex.h2"
+#line 201 "cpp2regex.h2"
 class no_reset;
 
-#line 210 "cpp2regex.h2"
+#line 208 "cpp2regex.h2"
 template<typename Func> class on_return;
 
-#line 237 "cpp2regex.h2"
+#line 235 "cpp2regex.h2"
 template<typename CharT, CharT C> class single_class_entry;
 
-#line 246 "cpp2regex.h2"
+#line 244 "cpp2regex.h2"
 template<typename CharT, CharT Start, CharT End> class range_class_entry;
 
-#line 255 "cpp2regex.h2"
+#line 253 "cpp2regex.h2"
 template<typename CharT, typename ...List> class combined_class_entry;
 
-#line 264 "cpp2regex.h2"
+#line 262 "cpp2regex.h2"
 template<typename CharT, CharT ...List> class list_class_entry;
 
-#line 273 "cpp2regex.h2"
+#line 271 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry;
 
-#line 280 "cpp2regex.h2"
+#line 278 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry;
 
-#line 289 "cpp2regex.h2"
+#line 287 "cpp2regex.h2"
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry;
 
-#line 337 "cpp2regex.h2"
+#line 335 "cpp2regex.h2"
 template<typename CharT> class alternative_token_matcher;
 
-#line 415 "cpp2regex.h2"
+#line 413 "cpp2regex.h2"
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher;
 
-#line 590 "cpp2regex.h2"
+#line 588 "cpp2regex.h2"
 class range_flags;
     
 
-#line 599 "cpp2regex.h2"
+#line 597 "cpp2regex.h2"
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher;
 
-#line 771 "cpp2regex.h2"
-template<typename CharT, typename matcher_wrapper> class regular_expression;
+#line 769 "cpp2regex.h2"
+template<typename CharT, typename matcher> class regular_expression;
 
-#line 907 "cpp2regex.h2"
+#line 904 "cpp2regex.h2"
 }
 }
 
@@ -96,13 +96,11 @@ template<typename CharT, typename matcher_wrapper> class regular_expression;
 #ifndef CPP2_CPP2REGEX_H
 #define CPP2_CPP2REGEX_H
 
-template<typename matcher_wrapper, typename Iter, typename CharT>
-using matcher_wrapper_type = typename matcher_wrapper::template wrap<CharT>;
 
 template<typename matcher, typename Iter>
 using matcher_context_type = typename matcher::template context<Iter>;
 
-#line 22 "cpp2regex.h2"
+#line 20 "cpp2regex.h2"
 namespace cpp2 {
 
 namespace regex {
@@ -128,7 +126,7 @@ template<typename Iter> class match_group
     public: match_group(auto const& start_, auto const& end_, auto const& matched_);
 public: match_group();
 
-#line 44 "cpp2regex.h2"
+#line 42 "cpp2regex.h2"
 };
 
 //  Return value for every matcher.
@@ -140,7 +138,7 @@ template<typename Iter> class match_return
     public: match_return(auto const& matched_, auto const& pos_);
 public: match_return();
 
-#line 52 "cpp2regex.h2"
+#line 50 "cpp2regex.h2"
 };
 
 //  Modifiable state during matching.
@@ -154,13 +152,13 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 
     public: explicit match_context(Iter const& begin_, Iter const& end_);
 
-#line 68 "cpp2regex.h2"
+#line 66 "cpp2regex.h2"
     public: match_context(match_context const& that);
-#line 68 "cpp2regex.h2"
+#line 66 "cpp2regex.h2"
     public: auto operator=(match_context const& that) -> match_context& ;
-#line 68 "cpp2regex.h2"
+#line 66 "cpp2regex.h2"
     public: match_context(match_context&& that) noexcept;
-#line 68 "cpp2regex.h2"
+#line 66 "cpp2regex.h2"
     public: auto operator=(match_context&& that) noexcept -> match_context& ;
 
     //  Getter and setter for groups
@@ -169,22 +167,22 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 
     public: [[nodiscard]] auto get_group_end(auto const& group) const& -> int;
 
-#line 80 "cpp2regex.h2"
+#line 78 "cpp2regex.h2"
     public: [[nodiscard]] auto get_group_start(auto const& group) const& -> int;
 
-#line 86 "cpp2regex.h2"
+#line 84 "cpp2regex.h2"
     public: [[nodiscard]] auto get_group_string(auto const& group) const& -> std::string;
 
-#line 93 "cpp2regex.h2"
+#line 91 "cpp2regex.h2"
     public: auto set_group_end(auto const& group, auto const& pos) & -> void;
 
-#line 98 "cpp2regex.h2"
+#line 96 "cpp2regex.h2"
     public: auto set_group_invalid(auto const& group) & -> void;
 
-#line 102 "cpp2regex.h2"
+#line 100 "cpp2regex.h2"
     public: auto set_group_start(auto const& group, auto const& pos) & -> void;
 
-#line 106 "cpp2regex.h2"
+#line 104 "cpp2regex.h2"
     public: [[nodiscard]] auto size() const& -> decltype(auto);
 
     //  Misc functions
@@ -194,7 +192,7 @@ template<typename CharT, typename Iter, int max_groups> class match_context
 
     public: auto reset() & -> void;
 
-#line 118 "cpp2regex.h2"
+#line 116 "cpp2regex.h2"
 };
 
 //  Modifiable state during matching.
@@ -208,16 +206,16 @@ template<typename CharT, typename Iter, int max_groups> class reverse_match_cont
             public: ReverseIter end; 
 
     public: explicit reverse_match_context(auto const& forward_context_);
-#line 130 "cpp2regex.h2"
+#line 128 "cpp2regex.h2"
     public: auto operator=(auto const& forward_context_) -> reverse_match_context& ;
 
-#line 136 "cpp2regex.h2"
+#line 134 "cpp2regex.h2"
     public: reverse_match_context(reverse_match_context const& that);
-#line 136 "cpp2regex.h2"
+#line 134 "cpp2regex.h2"
     public: auto operator=(reverse_match_context const& that) -> reverse_match_context& ;
-#line 136 "cpp2regex.h2"
+#line 134 "cpp2regex.h2"
     public: reverse_match_context(reverse_match_context&& that) noexcept;
-#line 136 "cpp2regex.h2"
+#line 134 "cpp2regex.h2"
     public: auto operator=(reverse_match_context&& that) noexcept -> reverse_match_context& ;
 
     //  Getter and setter for groups
@@ -272,7 +270,7 @@ template<typename CharT, typename Iter, int max_groups> class reverse_match_cont
 
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto;
 
-#line 193 "cpp2regex.h2"
+#line 191 "cpp2regex.h2"
 //  End function that returns a valid match.
 //
 class true_end_func
@@ -280,7 +278,7 @@ class true_end_func
     public: [[nodiscard]] auto operator()(auto const& cur, auto& ctx) const& -> decltype(auto);
 };
 
-#line 201 "cpp2regex.h2"
+#line 199 "cpp2regex.h2"
 //  Empty group reset function.
 //
 class no_reset
@@ -288,30 +286,30 @@ class no_reset
     public: auto operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void;
 };
 
-#line 209 "cpp2regex.h2"
+#line 207 "cpp2regex.h2"
 //  Evaluate func on destruction of the handle.
 template<typename Func> class on_return
  {
     private: Func func; 
 
     public: explicit on_return(Func const& f);
-#line 214 "cpp2regex.h2"
+#line 212 "cpp2regex.h2"
     public: auto operator=(Func const& f) -> on_return& ;
 
-#line 218 "cpp2regex.h2"
+#line 216 "cpp2regex.h2"
     public: ~on_return() noexcept;
     public: on_return(on_return const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(on_return const&) -> void = delete;
 
 
-#line 221 "cpp2regex.h2"
+#line 219 "cpp2regex.h2"
 };
 
-#line 224 "cpp2regex.h2"
+#line 222 "cpp2regex.h2"
 //  Helper for auto deduction of the Func type.
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto);
 
-#line 228 "cpp2regex.h2"
+#line 226 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Character classes for regular expressions.
@@ -329,10 +327,10 @@ template<typename CharT, CharT C> class single_class_entry
     public: single_class_entry(single_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(single_class_entry const&) -> void = delete;
 
-#line 241 "cpp2regex.h2"
+#line 239 "cpp2regex.h2"
 };
 
-#line 244 "cpp2regex.h2"
+#line 242 "cpp2regex.h2"
 //  Class syntax: - Example: a-c
 //
 template<typename CharT, CharT Start, CharT End> class range_class_entry
@@ -343,10 +341,10 @@ template<typename CharT, CharT Start, CharT End> class range_class_entry
     public: range_class_entry(range_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_class_entry const&) -> void = delete;
 
-#line 250 "cpp2regex.h2"
+#line 248 "cpp2regex.h2"
 };
 
-#line 253 "cpp2regex.h2"
+#line 251 "cpp2regex.h2"
 //  Helper for combining two character classes
 //
 template<typename CharT, typename ...List> class combined_class_entry
@@ -357,10 +355,10 @@ template<typename CharT, typename ...List> class combined_class_entry
     public: combined_class_entry(combined_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(combined_class_entry const&) -> void = delete;
 
-#line 259 "cpp2regex.h2"
+#line 257 "cpp2regex.h2"
 };
 
-#line 262 "cpp2regex.h2"
+#line 260 "cpp2regex.h2"
 //  Class syntax: <list of characters>  Example: abcd
 //
 template<typename CharT, CharT ...List> class list_class_entry
@@ -371,10 +369,10 @@ template<typename CharT, CharT ...List> class list_class_entry
     public: list_class_entry(list_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(list_class_entry const&) -> void = delete;
 
-#line 268 "cpp2regex.h2"
+#line 266 "cpp2regex.h2"
 };
 
-#line 271 "cpp2regex.h2"
+#line 269 "cpp2regex.h2"
 //  Class syntax: [:<class name:]  Example: [:alnum:]
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class named_class_entry
@@ -385,10 +383,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class n
     public: named_class_entry(named_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(named_class_entry const&) -> void = delete;
 
-#line 277 "cpp2regex.h2"
+#line 275 "cpp2regex.h2"
 };
 
-#line 280 "cpp2regex.h2"
+#line 278 "cpp2regex.h2"
 template<typename CharT, typename Inner> class negated_class_entry
 : public Inner {
 
@@ -397,10 +395,10 @@ template<typename CharT, typename Inner> class negated_class_entry
     public: negated_class_entry(negated_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(negated_class_entry const&) -> void = delete;
 
-#line 284 "cpp2regex.h2"
+#line 282 "cpp2regex.h2"
 };
 
-#line 287 "cpp2regex.h2"
+#line 285 "cpp2regex.h2"
 //  Short class syntax: \<character>  Example: \w
 //
 template<typename CharT, string_util::fixed_string Name, typename Inner> class shorthand_class_entry
@@ -411,10 +409,10 @@ template<typename CharT, string_util::fixed_string Name, typename Inner> class s
     public: shorthand_class_entry(shorthand_class_entry const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(shorthand_class_entry const&) -> void = delete;
 
-#line 293 "cpp2regex.h2"
+#line 291 "cpp2regex.h2"
 };
 
-#line 296 "cpp2regex.h2"
+#line 294 "cpp2regex.h2"
 //  Named basic character classes
 //
 template        <typename CharT> using digits_class = named_class_entry<CharT,"digits",range_class_entry<CharT,'0','9'>>;
@@ -451,7 +449,7 @@ template                     <typename CharT> using short_not_space_class = nega
 template<typename CharT> using short_not_vert_space_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\V",ver_space_class<CharT>>>;
 template                     <typename CharT> using short_not_word_class = negated_class_entry<CharT,shorthand_class_entry<CharT,"\\W",word_class<CharT>>>;
 
-#line 333 "cpp2regex.h2"
+#line 331 "cpp2regex.h2"
 //  Regex syntax: |  Example: ab|ba
 //
 //  Non greedy implementation. First alternative that matches is chosen.
@@ -460,22 +458,22 @@ template<typename CharT> class alternative_token_matcher
  {
     public: [[nodiscard]] static auto match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto;
 
-#line 343 "cpp2regex.h2"
+#line 341 "cpp2regex.h2"
     private: template<typename ...Other> [[nodiscard]] static auto match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto;
     public: alternative_token_matcher() = default;
     public: alternative_token_matcher(alternative_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(alternative_token_matcher const&) -> void = delete;
 
 
-#line 361 "cpp2regex.h2"
+#line 359 "cpp2regex.h2"
 };
 
-#line 364 "cpp2regex.h2"
+#line 362 "cpp2regex.h2"
 //  Regex syntax: .
 //
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 379 "cpp2regex.h2"
+#line 377 "cpp2regex.h2"
 // TODO: Check if vectorization works at some point with this implementation.
 // char_token_matcher: <tokens: string_util::fixed_string> (inout cur, inout ctx) -> bool = {
 //     if !(std::distance(cur, ctx.end) < tokens..size()) {
@@ -509,21 +507,21 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
 //     return matched;
 // }
 
-#line 413 "cpp2regex.h2"
+#line 411 "cpp2regex.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 template<typename CharT, bool negate, bool case_insensitive, typename ...List> class class_token_matcher
  {
     public: [[nodiscard]] static auto match(auto& cur, auto& ctx) -> bool;
 
-#line 446 "cpp2regex.h2"
+#line 444 "cpp2regex.h2"
     private: template<typename First, typename ...Other> [[nodiscard]] static auto match_any(cpp2::impl::in<CharT> c) -> bool;
     public: class_token_matcher() = default;
     public: class_token_matcher(class_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(class_token_matcher const&) -> void = delete;
 
 
-#line 459 "cpp2regex.h2"
+#line 457 "cpp2regex.h2"
     // TODO: Implement proper to string
     // to_string: () -> bstring<CharT> = {
     //     r: bstring<CharT> = "[";
@@ -535,10 +533,10 @@ template<typename CharT, bool negate, bool case_insensitive, typename ...List> c
 
     //     return r;
     // }
-#line 470 "cpp2regex.h2"
+#line 468 "cpp2regex.h2"
 };
 
-#line 473 "cpp2regex.h2"
+#line 471 "cpp2regex.h2"
 // Named short classes
 //
 template                    <typename CharT,          bool case_insensitive> using named_class_no_new_line = class_token_matcher<CharT,true,case_insensitive,single_class_entry<CharT,'\n'>>;
@@ -554,7 +552,7 @@ template                    <typename CharT,          bool case_insensitive> usi
 template                    <typename CharT,          bool case_insensitive> using named_class_not_ver_space = class_token_matcher<CharT,true,case_insensitive,ver_space_class<CharT>>;
 template                    <typename CharT,          bool case_insensitive> using named_class_not_word = class_token_matcher<CharT,true,case_insensitive,word_class<CharT>>;
 
-#line 489 "cpp2regex.h2"
+#line 487 "cpp2regex.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -563,30 +561,30 @@ template                    <typename CharT,          bool case_insensitive> usi
 //
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 534 "cpp2regex.h2"
+#line 532 "cpp2regex.h2"
 //  Regex syntax: $  Example: aa$
 //
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 550 "cpp2regex.h2"
+#line 548 "cpp2regex.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool;
 
-#line 559 "cpp2regex.h2"
+#line 557 "cpp2regex.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 573 "cpp2regex.h2"
+#line 571 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool;
 
-#line 586 "cpp2regex.h2"
+#line 584 "cpp2regex.h2"
 // TODO: @enum as template parameter currently not working. See issue https://github.com/hsutter/cppfront/issues/1147
 
-#line 589 "cpp2regex.h2"
+#line 587 "cpp2regex.h2"
 //  Options for range matching.
 class range_flags {
     public: static const int not_greedy;// Try to take as few as possible.
@@ -597,9 +595,9 @@ class range_flags {
     public: range_flags(range_flags const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_flags const&) -> void = delete;
 };
-#line 595 "cpp2regex.h2"
+#line 593 "cpp2regex.h2"
 
-#line 597 "cpp2regex.h2"
+#line 595 "cpp2regex.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 template<typename CharT, int min_count, int max_count, int kind> class range_token_matcher
@@ -607,42 +605,42 @@ template<typename CharT, int min_count, int max_count, int kind> class range_tok
 
     public: template<typename Iter> [[nodiscard]] static auto match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto;
 
-#line 615 "cpp2regex.h2"
+#line 613 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_upper_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 620 "cpp2regex.h2"
+#line 618 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_below_lower_bound(cpp2::impl::in<int> count) -> bool;
 
-#line 625 "cpp2regex.h2"
+#line 623 "cpp2regex.h2"
     private: [[nodiscard]] static auto is_in_range(cpp2::impl::in<int> count) -> bool;
 
-#line 631 "cpp2regex.h2"
+#line 629 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto;
 
-#line 647 "cpp2regex.h2"
+#line 645 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 677 "cpp2regex.h2"
+#line 675 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
 
-#line 705 "cpp2regex.h2"
+#line 703 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] static auto match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>;
     public: range_token_matcher() = default;
     public: range_token_matcher(range_token_matcher const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(range_token_matcher const&) -> void = delete;
 
 
-#line 731 "cpp2regex.h2"
+#line 729 "cpp2regex.h2"
 };
 
-#line 734 "cpp2regex.h2"
+#line 732 "cpp2regex.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool;
 
-#line 763 "cpp2regex.h2"
+#line 761 "cpp2regex.h2"
 //-----------------------------------------------------------------------
 //
 //  Regular expression implementation.
@@ -651,10 +649,9 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
 //
 
 //  Regular expression implementation
-template<typename CharT, typename matcher_wrapper> class regular_expression
+template<typename CharT, typename matcher> class regular_expression
  {
-    public: template<typename Iter> using matcher = matcher_wrapper_type<matcher_wrapper,Iter,CharT>;// TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
-    public: template<typename Iter> using context = matcher_context_type<matcher<Iter>,Iter>;// TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
+    public: template<typename Iter> using context = matcher_context_type<matcher,Iter>;// TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
 
     public: template<typename Iter> class search_return
      {
@@ -664,10 +661,10 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
         public: explicit search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_);
 
-#line 788 "cpp2regex.h2"
+#line 785 "cpp2regex.h2"
         public: explicit search_return(Iter const& begin, Iter const& end);
 
-#line 794 "cpp2regex.h2"
+#line 791 "cpp2regex.h2"
         public: [[nodiscard]] auto group_number() const& -> decltype(auto);
         public: [[nodiscard]] auto group(cpp2::impl::in<int> g) const& -> decltype(auto);
         public: [[nodiscard]] auto group_start(cpp2::impl::in<int> g) const& -> decltype(auto);
@@ -679,13 +676,13 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
         public: auto update(cpp2::impl::in<match_return<Iter>> r) & -> void;
 
-#line 808 "cpp2regex.h2"
+#line 805 "cpp2regex.h2"
         private: [[nodiscard]] auto get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto;
         public: search_return(search_return const&) = delete; /* No 'that' constructor, suppress copy */
         public: auto operator=(search_return const&) -> void = delete;
 
 
-#line 815 "cpp2regex.h2"
+#line 812 "cpp2regex.h2"
     };
 
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
@@ -693,22 +690,22 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: [[nodiscard]] auto find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto);
     public: template<typename Iter> auto find_all(auto const& func, Iter const& start, Iter const& end) const& -> void;
 
-#line 848 "cpp2regex.h2"
+#line 845 "cpp2regex.h2"
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto match(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 859 "cpp2regex.h2"
+#line 856 "cpp2regex.h2"
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto);
     public: [[nodiscard]] auto search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto);
     public: template<typename Iter> [[nodiscard]] auto search(Iter const& start, Iter const& end) const& -> search_return<Iter>;
 
-#line 868 "cpp2regex.h2"
+#line 865 "cpp2regex.h2"
     private: template<typename Iter> [[nodiscard]] auto search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>;
 
-#line 893 "cpp2regex.h2"
+#line 890 "cpp2regex.h2"
     public: [[nodiscard]] auto to_string() const& -> decltype(auto);
 
     //  Helper functions
@@ -719,7 +716,7 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
     public: auto operator=(regular_expression const&) -> void = delete;
 
 
-#line 905 "cpp2regex.h2"
+#line 902 "cpp2regex.h2"
 };
 
 }
@@ -731,7 +728,7 @@ template<typename CharT, typename matcher_wrapper> class regular_expression
 
 #line 1 "cpp2regex.h2"
 
-#line 22 "cpp2regex.h2"
+#line 20 "cpp2regex.h2"
 namespace cpp2 {
 
 namespace regex {
@@ -746,55 +743,55 @@ template <typename Iter> match_return<Iter>::match_return(auto const& matched_, 
                                                          , pos{ pos_ }{}
 template <typename Iter> match_return<Iter>::match_return(){}
 
-#line 63 "cpp2regex.h2"
+#line 61 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> match_context<CharT,Iter,max_groups>::match_context(Iter const& begin_, Iter const& end_)
         : begin{ begin_ }
         , end{ end_ }{
 
-#line 66 "cpp2regex.h2"
+#line 64 "cpp2regex.h2"
     }
 
-#line 68 "cpp2regex.h2"
+#line 66 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> match_context<CharT,Iter,max_groups>::match_context(match_context const& that)
                                    : begin{ that.begin }
                                    , end{ that.end }
                                    , groups{ that.groups }{}
-#line 68 "cpp2regex.h2"
+#line 66 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::operator=(match_context const& that) -> match_context& {
                                    begin = that.begin;
                                    end = that.end;
                                    groups = that.groups;
                                    return *this; }
-#line 68 "cpp2regex.h2"
+#line 66 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> match_context<CharT,Iter,max_groups>::match_context(match_context&& that) noexcept
                                    : begin{ std::move(that).begin }
                                    , end{ std::move(that).end }
                                    , groups{ std::move(that).groups }{}
-#line 68 "cpp2regex.h2"
+#line 66 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::operator=(match_context&& that) noexcept -> match_context& {
                                    begin = std::move(that).begin;
                                    end = std::move(that).end;
                                    groups = std::move(that).groups;
                                    return *this; }
 
-#line 72 "cpp2regex.h2"
+#line 70 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group(auto const& group) const& -> decltype(auto) { return CPP2_ASSERT_IN_BOUNDS(groups, group);  }
 
-#line 74 "cpp2regex.h2"
+#line 72 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_end(auto const& group) const& -> int{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return 0; 
         }
         return cpp2::unchecked_narrow<int>(std::distance(begin, CPP2_ASSERT_IN_BOUNDS(groups, group).end)); 
     }
-#line 80 "cpp2regex.h2"
+#line 78 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_start(auto const& group) const& -> int{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return 0; 
         }
         return cpp2::unchecked_narrow<int>(std::distance(begin, CPP2_ASSERT_IN_BOUNDS(groups, group).start)); 
     }
-#line 86 "cpp2regex.h2"
+#line 84 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::get_group_string(auto const& group) const& -> std::string{
         if (cpp2::impl::cmp_greater_eq(group,max_groups) || !(CPP2_ASSERT_IN_BOUNDS(groups, group).matched)) {
             return ""; 
@@ -802,155 +799,155 @@ template <typename Iter> match_return<Iter>::match_return(){}
         return std::string(CPP2_ASSERT_IN_BOUNDS(groups, group).start, CPP2_ASSERT_IN_BOUNDS(groups, group).end); 
     }
 
-#line 93 "cpp2regex.h2"
+#line 91 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_end(auto const& group, auto const& pos) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).end = pos;
         CPP2_ASSERT_IN_BOUNDS(groups, group).matched = true;
     }
 
-#line 98 "cpp2regex.h2"
+#line 96 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_invalid(auto const& group) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).matched = false;
     }
 
-#line 102 "cpp2regex.h2"
+#line 100 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::set_group_start(auto const& group, auto const& pos) & -> void{
         CPP2_ASSERT_IN_BOUNDS(groups, group).start = pos;
     }
 
-#line 106 "cpp2regex.h2"
+#line 104 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::size() const& -> decltype(auto) { return max_groups;  }
 
-#line 110 "cpp2regex.h2"
+#line 108 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::fail() const& -> decltype(auto) { return match_return<Iter>(false, end); }
-#line 111 "cpp2regex.h2"
+#line 109 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<Iter> cur) const& -> decltype(auto) { return match_return<Iter>(true, cur);  }
 
-#line 113 "cpp2regex.h2"
+#line 111 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto match_context<CharT,Iter,max_groups>::reset() & -> void{
         for ( auto& g : groups ) {
             g.matched = false;
         }
     }
 
-#line 130 "cpp2regex.h2"
+#line 128 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> reverse_match_context<CharT,Iter,max_groups>::reverse_match_context(auto const& forward_context_)
         : forward_context{ forward_context_ }
         , begin{ std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).end) }
         , end{ std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).begin) }{
 
-#line 134 "cpp2regex.h2"
+#line 132 "cpp2regex.h2"
     }
-#line 130 "cpp2regex.h2"
+#line 128 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::operator=(auto const& forward_context_) -> reverse_match_context& {
         forward_context = forward_context_;
         begin = std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).end);
         end = std::make_reverse_iterator((*cpp2::impl::assert_not_null(forward_context)).begin);
         return *this;
 
-#line 134 "cpp2regex.h2"
+#line 132 "cpp2regex.h2"
     }
 
-#line 136 "cpp2regex.h2"
+#line 134 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> reverse_match_context<CharT,Iter,max_groups>::reverse_match_context(reverse_match_context const& that)
                                    : forward_context{ that.forward_context }
                                    , begin{ that.begin }
                                    , end{ that.end }{}
-#line 136 "cpp2regex.h2"
+#line 134 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::operator=(reverse_match_context const& that) -> reverse_match_context& {
                                    forward_context = that.forward_context;
                                    begin = that.begin;
                                    end = that.end;
                                    return *this; }
-#line 136 "cpp2regex.h2"
+#line 134 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> reverse_match_context<CharT,Iter,max_groups>::reverse_match_context(reverse_match_context&& that) noexcept
                                    : forward_context{ std::move(that).forward_context }
                                    , begin{ std::move(that).begin }
                                    , end{ std::move(that).end }{}
-#line 136 "cpp2regex.h2"
+#line 134 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> auto reverse_match_context<CharT,Iter,max_groups>::operator=(reverse_match_context&& that) noexcept -> reverse_match_context& {
                                    forward_context = std::move(that).forward_context;
                                    begin = std::move(that).begin;
                                    end = std::move(that).end;
                                    return *this; }
 
-#line 178 "cpp2regex.h2"
+#line 176 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::fail() const& -> decltype(auto) { return match_return<ReverseIter>(false, end); }
-#line 179 "cpp2regex.h2"
+#line 177 "cpp2regex.h2"
     template <typename CharT, typename Iter, int max_groups> [[nodiscard]] auto reverse_match_context<CharT,Iter,max_groups>::pass(cpp2::impl::in<ReverseIter> cur) const& -> decltype(auto) { return match_return<ReverseIter>(true, cur);  }
 
-#line 188 "cpp2regex.h2"
+#line 186 "cpp2regex.h2"
 template<typename CharT, typename Iter, int max_groups> [[nodiscard]] auto make_reverse_match_context(match_context<CharT,Iter,max_groups>& ctx) -> auto{
     return reverse_match_context<CharT,Iter,max_groups>(&ctx); 
 }
 
-#line 197 "cpp2regex.h2"
+#line 195 "cpp2regex.h2"
     [[nodiscard]] auto true_end_func::operator()(auto const& cur, auto& ctx) const& -> decltype(auto) { return ctx.pass(cur);  }
 
-#line 205 "cpp2regex.h2"
+#line 203 "cpp2regex.h2"
     auto no_reset::operator()([[maybe_unused]] auto& unnamed_param_2) const& -> void{}
 
-#line 214 "cpp2regex.h2"
+#line 212 "cpp2regex.h2"
     template <typename Func> on_return<Func>::on_return(Func const& f)
         : func{ f }{
 
-#line 216 "cpp2regex.h2"
-    }
 #line 214 "cpp2regex.h2"
+    }
+#line 212 "cpp2regex.h2"
     template <typename Func> auto on_return<Func>::operator=(Func const& f) -> on_return& {
         func = f;
         return *this;
 
-#line 216 "cpp2regex.h2"
+#line 214 "cpp2regex.h2"
     }
 
-#line 218 "cpp2regex.h2"
+#line 216 "cpp2regex.h2"
     template <typename Func> on_return<Func>::~on_return() noexcept{
         cpp2::move(*this).func();
     }
 
-#line 225 "cpp2regex.h2"
+#line 223 "cpp2regex.h2"
 template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> decltype(auto) { return on_return<Func>(func);  }
 
-#line 239 "cpp2regex.h2"
+#line 237 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return c == C;  }
-#line 240 "cpp2regex.h2"
+#line 238 "cpp2regex.h2"
     template <typename CharT, CharT C> [[nodiscard]] auto single_class_entry<CharT,C>::to_string() -> decltype(auto) { return bstring<CharT>(1, C); }
 
-#line 248 "cpp2regex.h2"
+#line 246 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return [_0 = Start, _1 = c, _2 = End]{ return cpp2::impl::cmp_less_eq(_0,_1) && cpp2::impl::cmp_less_eq(_1,_2); }();  }
-#line 249 "cpp2regex.h2"
+#line 247 "cpp2regex.h2"
     template <typename CharT, CharT Start, CharT End> [[nodiscard]] auto range_class_entry<CharT,Start,End>::to_string() -> decltype(auto) { return "" + cpp2::to_string(Start) + "-" + cpp2::to_string(End) + ""; }
 
-#line 257 "cpp2regex.h2"
+#line 255 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || List::includes(c));  }
-#line 258 "cpp2regex.h2"
+#line 256 "cpp2regex.h2"
     template <typename CharT, typename ...List> [[nodiscard]] auto combined_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List::to_string()); }
 
-#line 266 "cpp2regex.h2"
+#line 264 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return (false || ... || (List == c));  }
-#line 267 "cpp2regex.h2"
+#line 265 "cpp2regex.h2"
     template <typename CharT, CharT ...List> [[nodiscard]] auto list_class_entry<CharT,List...>::to_string() -> decltype(auto) { return (bstring<CharT>() + ... + List); }
 
-#line 275 "cpp2regex.h2"
+#line 273 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 276 "cpp2regex.h2"
+#line 274 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto named_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return "[:" + cpp2::to_string(Name.data()) + ":]"; }
 
-#line 283 "cpp2regex.h2"
+#line 281 "cpp2regex.h2"
     template <typename CharT, typename Inner> [[nodiscard]] auto negated_class_entry<CharT,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return !(Inner::includes(c));  }
 
-#line 291 "cpp2regex.h2"
+#line 289 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::includes(cpp2::impl::in<CharT> c) -> decltype(auto) { return Inner::includes(c);  }
-#line 292 "cpp2regex.h2"
+#line 290 "cpp2regex.h2"
     template <typename CharT, string_util::fixed_string Name, typename Inner> [[nodiscard]] auto shorthand_class_entry<CharT,Name,Inner>::to_string() -> decltype(auto) { return Name.str(); }
 
-#line 339 "cpp2regex.h2"
+#line 337 "cpp2regex.h2"
     template <typename CharT> [[nodiscard]] auto alternative_token_matcher<CharT>::match(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& ...functions) -> auto{
         return match_first(cur, ctx, end_func, tail, functions...); 
     }
 
-#line 343 "cpp2regex.h2"
+#line 341 "cpp2regex.h2"
     template <typename CharT> template<typename ...Other> [[nodiscard]] auto alternative_token_matcher<CharT>::match_first(auto const& cur, auto& ctx, auto const& end_func, auto const& tail, auto const& cur_func, auto const& cur_reset, Other const& ...other) -> auto
     {
         auto inner_call {[_0 = (tail), _1 = (end_func)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -970,7 +967,7 @@ template<typename Func> [[nodiscard]] auto make_on_return(Func const& func) -> d
         }
     }
 
-#line 366 "cpp2regex.h2"
+#line 364 "cpp2regex.h2"
 template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(auto& cur, auto& ctx) -> bool
 {
     if ( cur != ctx.end                     // any char except the end
@@ -983,7 +980,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
     return false; 
 }
 
-#line 417 "cpp2regex.h2"
+#line 415 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match(auto& cur, auto& ctx) -> bool
     {
         if constexpr (case_insensitive) 
@@ -1013,7 +1010,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         }
     }
 
-#line 446 "cpp2regex.h2"
+#line 444 "cpp2regex.h2"
     template <typename CharT, bool negate, bool case_insensitive, typename ...List> template<typename First, typename ...Other> [[nodiscard]] auto class_token_matcher<CharT,negate,case_insensitive,List...>::match_any(cpp2::impl::in<CharT> c) -> bool
     {
         bool r {First::includes(c)}; 
@@ -1027,7 +1024,7 @@ template<typename CharT, bool single_line> [[nodiscard]] auto any_token_matcher(
         return r; 
     }
 
-#line 495 "cpp2regex.h2"
+#line 493 "cpp2regex.h2"
 template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodiscard]] auto group_ref_token_matcher(auto& cur, auto& ctx) -> bool
 {
     auto g {ctx.get_group(group)}; 
@@ -1066,7 +1063,7 @@ template<typename CharT, int group, bool case_insensitive, bool reverse> [[nodis
     }
 }
 
-#line 536 "cpp2regex.h2"
+#line 534 "cpp2regex.h2"
 template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[nodiscard]] auto line_end_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     if (cur == ctx.end || (match_new_line && *cpp2::impl::assert_not_null(cur) == '\n')) {
@@ -1080,14 +1077,14 @@ template<typename CharT, bool match_new_line, bool match_new_line_before_end> [[
     }}
 }
 
-#line 552 "cpp2regex.h2"
+#line 550 "cpp2regex.h2"
 template<typename CharT, bool match_new_line> [[nodiscard]] auto line_start_token_matcher(auto const& cur, auto& ctx) -> bool
 {
     return cur == ctx.begin || // Start of string
            (match_new_line && *cpp2::impl::assert_not_null((cur - 1)) == '\n'); // Start of new line
 }
 
-#line 563 "cpp2regex.h2"
+#line 561 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto r {func(cur, ctx, true_end_func())}; 
@@ -1098,7 +1095,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookahead_token_match
     return cpp2::move(r).matched; 
 }
 
-#line 573 "cpp2regex.h2"
+#line 571 "cpp2regex.h2"
 template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matcher(auto const& cur, auto& ctx, auto const& func) -> bool
 {
     auto reverse_ctx {make_reverse_match_context(ctx)}; 
@@ -1111,12 +1108,12 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
     return cpp2::move(r).matched; 
 }
 
-#line 591 "cpp2regex.h2"
+#line 589 "cpp2regex.h2"
     inline CPP2_CONSTEXPR int range_flags::not_greedy{ 1 };
     inline CPP2_CONSTEXPR int range_flags::greedy{ 2 };
     inline CPP2_CONSTEXPR int range_flags::possessive{ 3 };
 
-#line 602 "cpp2regex.h2"
+#line 600 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match(Iter const& cur, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& tail) -> auto
     {
         if (range_flags::possessive == kind) {
@@ -1130,26 +1127,26 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         }}
     }
 
-#line 615 "cpp2regex.h2"
+#line 613 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_upper_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == max_count) {return true; }
         else {return cpp2::impl::cmp_less(count,max_count); }
     }
 
-#line 620 "cpp2regex.h2"
+#line 618 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_below_lower_bound(cpp2::impl::in<int> count) -> bool{
         if (-1 == min_count) {return false; }
         else {return cpp2::impl::cmp_less(count,min_count); }
     }
 
-#line 625 "cpp2regex.h2"
+#line 623 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::is_in_range(cpp2::impl::in<int> count) -> bool{
         if (-1 != min_count && cpp2::impl::cmp_less(count,min_count)) {return false; }
         if (-1 != max_count && cpp2::impl::cmp_greater(count,max_count)) {return false; }
         return true; 
     }
 
-#line 631 "cpp2regex.h2"
+#line 629 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_min_count(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, int& count_r) -> auto
     {   // TODO: count_r as out parameter introduces a performance loss.
         auto res {ctx.pass(cur)}; 
@@ -1166,7 +1163,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return res; 
     }
 
-#line 647 "cpp2regex.h2"
+#line 645 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_greedy(cpp2::impl::in<int> count, Iter const& cur, Iter const& last_valid, auto& ctx, auto const& inner, auto const& reset_func, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto inner_call {[_0 = (count + 1), _1 = (cur), _2 = (inner), _3 = (reset_func), _4 = (end_func), _5 = (other)](auto const& tail_cur, auto& tail_ctx) -> auto{
@@ -1197,7 +1194,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return r; 
     }
 
-#line 677 "cpp2regex.h2"
+#line 675 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_possessive(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1226,7 +1223,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); 
     }
 
-#line 705 "cpp2regex.h2"
+#line 703 "cpp2regex.h2"
     template <typename CharT, int min_count, int max_count, int kind> template<typename Iter> [[nodiscard]] auto range_token_matcher<CharT,min_count,max_count,kind>::match_not_greedy(Iter const& cur, auto& ctx, auto const& inner, auto const& end_func, auto const& other) -> match_return<Iter>
     {
         auto count {0}; 
@@ -1254,7 +1251,7 @@ template<typename CharT, bool positive> [[nodiscard]] auto lookbehind_token_matc
         return other(cpp2::move(pos), ctx, end_func); // Upper bound reached.
     }
 
-#line 738 "cpp2regex.h2"
+#line 736 "cpp2regex.h2"
 template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_matcher(auto& cur, auto& ctx) -> bool
 {
     word_class<CharT> words {}; 
@@ -1279,63 +1276,63 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
     return is_match; 
 }
 
-#line 782 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
+#line 779 "cpp2regex.h2"
+        template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(cpp2::impl::in<bool> matched_, context<Iter> const& ctx_, Iter const& pos_)
             : matched{ matched_ }
             , ctx{ ctx_ }
             , pos{ cpp2::unchecked_narrow<int>(std::distance(ctx_.begin, pos_)) }{
 
-#line 786 "cpp2regex.h2"
+#line 783 "cpp2regex.h2"
         }
 
-#line 788 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> regular_expression<CharT,matcher_wrapper>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
+#line 785 "cpp2regex.h2"
+        template <typename CharT, typename matcher> template <typename Iter> regular_expression<CharT,matcher>::search_return<Iter>::search_return(Iter const& begin, Iter const& end)
             : matched{ false }
             , ctx{ begin, end }
             , pos{ 0 }{
 
-#line 792 "cpp2regex.h2"
+#line 789 "cpp2regex.h2"
         }
 
+#line 791 "cpp2regex.h2"
+        template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
+#line 792 "cpp2regex.h2"
+        template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
+#line 793 "cpp2regex.h2"
+        template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
 #line 794 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_number() const& -> decltype(auto) { return ctx.size(); }
-#line 795 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_string(g); }
+        template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
+
 #line 796 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_start(g); }
+        template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
 #line 797 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<int> g) const& -> decltype(auto) { return ctx.get_group_end(g); }
+        template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
+#line 798 "cpp2regex.h2"
+        template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
 
-#line 799 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group(get_group_id(g)); }
 #line 800 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_start(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_start(get_group_id(g)); }
-#line 801 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::group_end(cpp2::impl::in<bstring<CharT>> g) const& -> decltype(auto) { return group_end(get_group_id(g)); }
-
-#line 803 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
+        template <typename CharT, typename matcher> template <typename Iter> auto regular_expression<CharT,matcher>::search_return<Iter>::update(cpp2::impl::in<match_return<Iter>> r) & -> void{
             matched = r.matched;
             pos     = cpp2::unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
         }
 
-#line 808 "cpp2regex.h2"
-        template <typename CharT, typename matcher_wrapper> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
-            auto group_id {matcher<Iter>::get_named_group_index(g)}; 
+#line 805 "cpp2regex.h2"
+        template <typename CharT, typename matcher> template <typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_return<Iter>::get_group_id(cpp2::impl::in<bstring<CharT>> g) const& -> auto{
+            auto group_id {matcher::get_named_group_index(g)}; 
             if (-1 == group_id) {
                 // TODO: Throw error.
             }
             return group_id; 
         }
 
+#line 814 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
+#line 815 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
+#line 816 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
 #line 817 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), str.begin(), str.end()); }
-#line 818 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), str.end()); }
-#line 819 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::find_all(auto&& func, cpp2::impl::in<bview<CharT>> str, cpp2::impl::in<int> start, cpp2::impl::in<int> length) const& -> decltype(auto) { return find_all(CPP2_FORWARD(func), get_iter(str, start), get_iter(str, start + length));  }
-#line 820 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> template<typename Iter> auto regular_expression<CharT,matcher_wrapper>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
+    template <typename CharT, typename matcher> template<typename Iter> auto regular_expression<CharT,matcher>::find_all(auto const& func, Iter const& start, Iter const& end) const& -> void
     {
         auto sr {search_return<Iter>(start, end)}; 
         auto cont {true}; 
@@ -1363,42 +1360,42 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
+#line 845 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
+#line 846 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
+#line 847 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
 #line 848 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return match(str.begin(), str.end()); }
-#line 849 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return match(get_iter(str, start), str.end()); }
-#line 850 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return match(get_iter(str, start), get_iter(str, start + length));  }
-#line 851 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
+    template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::match(Iter const& start, Iter const& end) const& -> search_return<Iter>
     {
         context<Iter> ctx {start, end}; 
 
-        auto r {matcher<Iter>::entry(start, ctx)}; 
+        auto r {matcher::entry(start, ctx)}; 
         return search_return<Iter>(r.matched && r.pos == end, cpp2::move(ctx), r.pos); 
     }
 
+#line 856 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
+#line 857 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
+#line 858 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
 #line 859 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str) const& -> decltype(auto) { return search(str.begin(), str.end()); }
-#line 860 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start) const& -> decltype(auto) { return search(get_iter(str, start), str.end()); }
-#line 861 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(cpp2::impl::in<bview<CharT>> str, auto const& start, auto const& length) const& -> decltype(auto) { return search(get_iter(str, start), get_iter(str, start + length));  }
-#line 862 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
+    template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search(Iter const& start, Iter const& end) const& -> search_return<Iter>{
         context<Iter> ctx {start, end}; 
         auto r {search_with_context(ctx, start)}; 
         return search_return<Iter>(r.matched, cpp2::move(ctx), cpp2::move(r).pos); 
     }
 
-#line 868 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
+#line 865 "cpp2regex.h2"
+    template <typename CharT, typename matcher> template<typename Iter> [[nodiscard]] auto regular_expression<CharT,matcher>::search_with_context(context<Iter>& ctx, Iter const& start) const& -> match_return<Iter>
     {
         auto r {ctx.fail()}; 
 
         auto cur {start}; 
         for( ; true; (++cur) ) {
-            r = matcher<Iter>::entry(cur, ctx);
+            r = matcher::entry(cur, ctx);
             if (r.matched) {
                 break;
             }
@@ -1407,7 +1404,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
                 break;
             }
 
-            if (matcher<Iter>::is_start_match()) {
+            if (matcher::is_start_match()) {
                 break; // Always break with \G option.
             }
         }
@@ -1415,11 +1412,11 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         return r; 
     }
 
-#line 893 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::to_string() const& -> decltype(auto) { return matcher_wrapper::to_string();  }
+#line 890 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::to_string() const& -> decltype(auto) { return matcher::to_string();  }
 
-#line 897 "cpp2regex.h2"
-    template <typename CharT, typename matcher_wrapper> [[nodiscard]] auto regular_expression<CharT,matcher_wrapper>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
+#line 894 "cpp2regex.h2"
+    template <typename CharT, typename matcher> [[nodiscard]] auto regular_expression<CharT,matcher>::get_iter(cpp2::impl::in<bview<CharT>> str, auto const& pos) -> auto{
         if (cpp2::impl::cmp_less(pos,str.size())) {
             return str.begin() + pos; 
         }
@@ -1428,7 +1425,7 @@ template<typename CharT, bool negate> [[nodiscard]] auto word_boundary_token_mat
         }
     }
 
-#line 907 "cpp2regex.h2"
+#line 904 "cpp2regex.h2"
 }
 }
 

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -67,9 +67,6 @@ match_context: <CharT, Iter, max_groups: int> type =
 
     operator=: (out this, that) = {}
 
-    // Helper functions
-    reverse: (inout this) = { std::swap(begin, end); }
-
     //  Getter and setter for groups
     //
     get_group: (in this, group) = groups[group];
@@ -118,6 +115,78 @@ match_context: <CharT, Iter, max_groups: int> type =
             g.matched = false;
         }
     }
+}
+
+//  Modifiable state during matching.
+//
+reverse_match_context: <CharT, Iter, max_groups: int> type =
+{
+    public ReverseIter : type == std::reverse_iterator<Iter>;
+    public forward_context : *match_context<CharT, Iter, max_groups>;
+
+    public  begin : ReverseIter;
+    public  end   : ReverseIter;
+
+    operator=: (out this, forward_context_) = {
+        forward_context = forward_context_;
+        begin = std::make_reverse_iterator(forward_context*.end);
+        end = std::make_reverse_iterator(forward_context*.begin);
+    }
+
+    operator=: (out this, that) = {}
+
+    //  Getter and setter for groups
+    //
+    //get_group: (in this, group) = groups[group];
+
+    // get_group_end:    (in this, group) -> int = {
+    //     if group >= max_groups || !groups[group].matched {
+    //         return 0;
+    //     }
+    //     return cpp2::unchecked_narrow<int>( std::distance(begin, groups[group].end) );
+    // }
+    // get_group_start:  (in this, group) -> int = {
+    //     if group >= max_groups || !groups[group].matched {
+    //         return 0;
+    //     }
+    //     return cpp2::unchecked_narrow<int>( std::distance(begin, groups[group].start) );
+    // }
+    // get_group_string: (in this, group) -> std::string = {
+    //     if group >= max_groups || !groups[group].matched {
+    //         return "";
+    //     }
+    //     return std::string(groups[group].start, groups[group].end);
+    // }
+
+    // set_group_end: (inout this, group, pos) = {
+    //     groups[group].end = pos;
+    //     groups[group].matched = true;
+    // }
+
+    // set_group_invalid: (inout this, group) = {
+    //     groups[group].matched = false;
+    // }
+
+    // set_group_start: (inout this, group, pos) = {
+    //     groups[group].start = pos;
+    // }
+
+    // size: (in this) = max_groups;
+
+    //  Misc functions
+    //
+    fail: (in this)            = match_return<ReverseIter>(false, end);
+    pass: (in this, cur: ReverseIter) = match_return<ReverseIter>(true, cur);
+
+    // reset: (inout this) = {
+    //     for groups do (inout g) {
+    //         g.matched = false;
+    //     }
+    // }
+}
+
+make_reverse_match_context: <CharT, Iter, max_groups: int> (inout ctx: match_context<CharT, Iter, max_groups>) -> _ = {
+    return reverse_match_context<CharT, Iter, max_groups>(ctx&);
 }
 
 
@@ -503,12 +572,12 @@ lookahead_token_matcher: <CharT, positive: bool> (cur, inout ctx, func) -> bool 
 
 lookbehind_token_matcher: <CharT, positive: bool> (cur, inout ctx, func) -> bool =
 {
-    ctx..reverse();
-    r := func(std::make_reverse_iterator(cur), ctx, true_end_func());
+    reverse_ctx := make_reverse_match_context(ctx);
+    r := func(std::make_reverse_iterator(cur), reverse_ctx, true_end_func());
+    _ = reverse_ctx;
     if !positive {
         r.matched = !r.matched;
     }
-    ctx..reverse();
 
     return r.matched;
 }

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -734,6 +734,10 @@ regular_expression: <CharT, matcher_wrapper> type =
             if cur == ctx.end {
                 break;
             }
+
+            if matcher<Iter>::is_start_match() {
+                break; // Always break with \G option.
+            }
         }
 
         return search_return<Iter>(r.matched, ctx, r.pos);

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -67,6 +67,9 @@ match_context: <CharT, Iter, max_groups: int> type =
 
     operator=: (out this, that) = {}
 
+    // Helper functions
+    reverse: (inout this) = { std::swap(begin, end); }
+
     //  Getter and setter for groups
     //
     get_group: (in this, group) = groups[group];
@@ -494,6 +497,18 @@ lookahead_token_matcher: <CharT, positive: bool> (cur, inout ctx, func) -> bool 
     if !positive {
         r.matched = !r.matched;
     }
+
+    return r.matched;
+}
+
+lookbehind_token_matcher: <CharT, positive: bool> (cur, inout ctx, func) -> bool =
+{
+    ctx..reverse();
+    r := func(std::make_reverse_iterator(cur), ctx, true_end_func());
+    if !positive {
+        r.matched = !r.matched;
+    }
+    ctx..reverse();
 
     return r.matched;
 }

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -420,15 +420,23 @@ named_class_not_word      : <CharT, case_insensitive: bool> type == class_token_
 //                \k<name_or_number>
 //                \k'name_or_number'
 //
-group_ref_token_matcher: <CharT, group: int, case_insensitive: bool> (inout cur, inout ctx) -> bool =
+group_ref_token_matcher: <CharT, group: int, case_insensitive: bool, reverse: bool> (inout cur, inout ctx) -> bool =
 {
     g := ctx..get_group(group);
 
     group_pos := g.start;
+    group_end := g.end;
+    group_inc : int = 1;
+    if reverse {
+        group_pos = g.end;
+        group_end = g.start;
+        group_inc = -1;
+    }
+
     while
-        group_pos != g.end
+        group_pos != group_end
         && cur != ctx.end
-    next (group_pos++, cur++)
+    next (group_pos += group_inc, cur++)
     {
         if constexpr case_insensitive {
             if string_util::safe_tolower(group_pos*) != string_util::safe_tolower(cur*) {
@@ -442,7 +450,7 @@ group_ref_token_matcher: <CharT, group: int, case_insensitive: bool> (inout cur,
         }
     }
 
-    if group_pos == g.end {
+    if group_pos == group_end {
         return true;
     }
     else {

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -399,6 +399,19 @@ any_token_matcher: <CharT, single_line: bool> (inout cur, inout ctx) -> bool =
     return false;
 }
 
+//  Regex syntax: (?><matcher>)  Example: a(?>bc|c)c
+//
+atomic_group_matcher: <CharT, Iter> (cur: Iter, inout ctx, inner, end_func, other) -> _ =
+{
+    r := inner(cur, ctx, true_end_func());
+
+    if r.matched {
+        r = other(r.pos, ctx, end_func);
+    }
+
+    return r;
+}
+
 
 // TODO: Check if vectorization works at some point with this implementation.
 // char_token_matcher: <tokens: string_util::fixed_string> (inout cur, inout ctx) -> bool = {

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -13,8 +13,6 @@
 #ifndef CPP2_CPP2REGEX_H
 #define CPP2_CPP2REGEX_H
 
-template<typename matcher_wrapper, typename Iter, typename CharT>
-using matcher_wrapper_type = typename matcher_wrapper::template wrap<CharT>;
 
 template<typename matcher, typename Iter>
 using matcher_context_type = typename matcher::template context<Iter>;
@@ -768,10 +766,9 @@ word_boundary_token_matcher: <CharT, negate: bool> (inout cur, inout ctx) -> boo
 //
 
 //  Regular expression implementation
-regular_expression: <CharT, matcher_wrapper> type = 
+regular_expression: <CharT, matcher> type =
 {
-    matcher: <Iter> type == matcher_wrapper_type<matcher_wrapper, Iter, CharT>; // TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
-    context: <Iter> type == matcher_context_type<matcher<Iter>, Iter>;                      // TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
+    context: <Iter> type == matcher_context_type<matcher, Iter>;                      // TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
 
     search_return: <Iter> type = 
     {
@@ -806,7 +803,7 @@ regular_expression: <CharT, matcher_wrapper> type =
         }
 
         private get_group_id: (this, g: bstring<CharT>) -> _ = {
-            group_id := matcher<Iter>::get_named_group_index(g);
+            group_id := matcher::get_named_group_index(g);
             if -1 == group_id {
                 // TODO: Throw error.
             }
@@ -852,7 +849,7 @@ regular_expression: <CharT, matcher_wrapper> type =
     {
         ctx: context<Iter> = (start, end);
 
-        r := matcher<Iter>::entry(start, ctx);
+        r := matcher::entry(start, ctx);
         return search_return<Iter>(r.matched && r.pos == end, ctx, r.pos);
     }
 
@@ -871,7 +868,7 @@ regular_expression: <CharT, matcher_wrapper> type =
 
         cur:= start;
         while true next (cur++) {
-            r = matcher<Iter>::entry(cur, ctx);
+            r = matcher::entry(cur, ctx);
             if r.matched {
                 break;
             }
@@ -880,7 +877,7 @@ regular_expression: <CharT, matcher_wrapper> type =
                 break;
             }
 
-            if matcher<Iter>::is_start_match() {
+            if matcher::is_start_match() {
                 break; // Always break with \G option.
             }
         }
@@ -890,7 +887,7 @@ regular_expression: <CharT, matcher_wrapper> type =
 
 
 
-    to_string: (in this) = matcher_wrapper::to_string();
+    to_string: (in this) = matcher::to_string();
 
     //  Helper functions
     //

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -14,10 +14,10 @@
 #define CPP2_CPP2REGEX_H
 
 template<typename matcher_wrapper, typename Iter, typename CharT>
-using matcher_wrapper_type = typename matcher_wrapper::template wrap<Iter, CharT>;
+using matcher_wrapper_type = typename matcher_wrapper::template wrap<CharT>;
 
-template<typename matcher>
-using matcher_context_type = typename matcher::context;
+template<typename matcher, typename Iter>
+using matcher_context_type = typename matcher::template context<Iter>;
 
 cpp2: namespace = {
 
@@ -771,7 +771,7 @@ word_boundary_token_matcher: <CharT, negate: bool> (inout cur, inout ctx) -> boo
 regular_expression: <CharT, matcher_wrapper> type = 
 {
     matcher: <Iter> type == matcher_wrapper_type<matcher_wrapper, Iter, CharT>; // TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
-    context: <Iter> type == matcher_context_type<matcher<Iter>>;                      // TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
+    context: <Iter> type == matcher_context_type<matcher<Iter>, Iter>;                      // TODO: Remove when nested types are allowed: https://github.com/hsutter/cppfront/issues/727
 
     search_return: <Iter> type = 
     {

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -109,6 +109,12 @@ match_context: <CharT, Iter, max_groups: int> type =
     //
     fail: (in this)            = match_return<Iter>(false, end);
     pass: (in this, cur: Iter) = match_return<Iter>(true, cur);
+
+    reset: (inout this) = {
+        for groups do (inout g) {
+            g.matched = false;
+        }
+    }
 }
 
 
@@ -687,6 +693,12 @@ regular_expression: <CharT, matcher_wrapper> type =
             pos = unchecked_narrow<int>(std::distance(ctx_.begin, pos_));
         }
 
+        operator=:(out this, begin: Iter, end: Iter) = {
+            matched = false;
+            ctx = (begin, end);
+            pos = 0;
+        }
+
         group_number: (this)         = ctx..size();
         group:        (this, g: int) = ctx..get_group_string(g);
         group_start:  (this, g: int) = ctx..get_group_start(g);
@@ -696,12 +708,48 @@ regular_expression: <CharT, matcher_wrapper> type =
         group_start:  (this, g: bstring<CharT>) = group_start(get_group_id(g));
         group_end:    (this, g: bstring<CharT>) = group_end(get_group_id(g));
 
+        update:       (inout this, r: match_return<Iter>) = {
+            matched = r.matched;
+            pos     = unchecked_narrow<int>(std::distance(ctx.begin, r.pos));
+        }
+
         private get_group_id: (this, g: bstring<CharT>) -> _ = {
             group_id := matcher<Iter>::get_named_group_index(g);
             if -1 == group_id {
                 // TODO: Throw error.
             }
             return group_id;
+        }
+    }
+
+    find_all: (in this, forward func, str: bview<CharT>)                           = find_all(func, str..begin(), str..end());
+    find_all: (in this, forward func, str: bview<CharT>, start: int)               = find_all(func, get_iter(str, start), str..end());
+    find_all: (in this, forward func, str: bview<CharT>, start: int, length : int) = find_all(func, get_iter(str, start), get_iter(str, start + length));
+    find_all: <Iter> (in this, func, start: Iter, end: Iter) =
+    {
+        sr := search_return<Iter>(start, end);
+        cont := true;
+        cur := start;
+
+        while cont {
+            r := search_with_context(sr.ctx, cur);
+            cont = r.matched; // First update the continue so that the user can override it.
+
+            if r.matched {
+                sr..update(r);
+                cont = func(sr);
+            }
+
+            if cont {
+                // Prevent infinity loop for zero length match.
+                cont = 0 != sr.ctx..get_group_end(0) - sr.ctx..get_group_start(0);
+            }
+
+            // Check now if to continue, user may override
+            if cont {
+                cur = start + sr.ctx..get_group_end(0);
+                sr.ctx.reset();
+            }
         }
     }
 
@@ -719,9 +767,14 @@ regular_expression: <CharT, matcher_wrapper> type =
     search: (in this, str: bview<CharT>)                = search(str..begin(), str..end());
     search: (in this, str: bview<CharT>, start)         = search(get_iter(str, start), str..end());
     search: (in this, str: bview<CharT>, start, length) = search(get_iter(str, start), get_iter(str, start + length));
-    search: <Iter> (in this, start: Iter, end: Iter) -> search_return<Iter> = 
-    {
+    search: <Iter> (in this, start: Iter, end: Iter) -> search_return<Iter> = {
         ctx: context<Iter> = (start, end);
+        r := search_with_context(ctx, start);
+        return search_return<Iter>(r.matched, ctx, r.pos);
+    }
+
+    private search_with_context: <Iter> (in this, inout ctx: context<Iter>, start: Iter) -> match_return<Iter> =
+    {
         r := ctx..fail();
 
         cur:= start;
@@ -740,8 +793,10 @@ regular_expression: <CharT, matcher_wrapper> type =
             }
         }
 
-        return search_return<Iter>(r.matched, ctx, r.pos);
+        return r;
     }
+
+
 
     to_string: (in this) = matcher_wrapper::to_string();
 

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -65,6 +65,11 @@ match_context: <CharT, Iter, max_groups: int> type =
 
     operator=: (out this, that) = {}
 
+    // String end and start positions
+    //
+    get_string_start: (in this) = begin;
+    get_string_end: (in this) = end;
+
     //  Getter and setter for groups
     //
     get_group: (in this, group) = groups[group];
@@ -133,6 +138,11 @@ reverse_match_context: <CharT, Iter, max_groups: int> type =
 
     operator=: (out this, that) = {}
 
+    // String end and start positions
+    //
+    get_string_start: (in this) = end;
+    get_string_end: (in this) = begin;
+
     //  Getter and setter for groups
     //
     //get_group: (in this, group) = groups[group];
@@ -156,18 +166,17 @@ reverse_match_context: <CharT, Iter, max_groups: int> type =
     //     return std::string(groups[group].start, groups[group].end);
     // }
 
-    // set_group_end: (inout this, group, pos) = {
-    //     groups[group].end = pos;
-    //     groups[group].matched = true;
-    // }
+    set_group_end: (inout this, group, pos) = {
+        forward_context*..set_group_end(group, (pos).base());
+    }
 
-    // set_group_invalid: (inout this, group) = {
-    //     groups[group].matched = false;
-    // }
+    set_group_invalid: (inout this, group) = {
+        forward_context*..set_group_invalid(group);
+    }
 
-    // set_group_start: (inout this, group, pos) = {
-    //     groups[group].start = pos;
-    // }
+    set_group_start: (inout this, group, pos) = {
+        forward_context*..set_group_start(group, (pos).base());
+    }
 
     // size: (in this) = max_groups;
 
@@ -533,10 +542,10 @@ group_ref_token_matcher: <CharT, group: int, case_insensitive: bool, reverse: bo
 //
 line_end_token_matcher: <CharT, match_new_line: bool, match_new_line_before_end: bool> (cur, inout ctx) -> bool = 
 {
-    if cur == ctx.end || (match_new_line && cur* == '\n') {
+    if cur == ctx.get_string_end() || (match_new_line && cur* == '\n') {
         return true;
     }
-    else if match_new_line_before_end && (cur* == '\n' && (cur + 1) == ctx.end) { // Special case for new line at end.
+    else if match_new_line_before_end && (cur* == '\n' && (cur + 1) == ctx.get_string_end()) { // Special case for new line at end.
         return true;
     }
     else {
@@ -549,7 +558,7 @@ line_end_token_matcher: <CharT, match_new_line: bool, match_new_line_before_end:
 //
 line_start_token_matcher: <CharT, match_new_line: bool> (cur, inout ctx) -> bool = 
 {
-    return cur == ctx.begin || // Start of string
+    return cur == ctx.get_string_start() || // Start of string
            (match_new_line && (cur - 1)* == '\n'); // Start of new line
 }
 
@@ -737,15 +746,15 @@ word_boundary_token_matcher: <CharT, negate: bool> (inout cur, inout ctx) -> boo
 {
     words : word_class<CharT> = ();
     is_match := false;
-    if cur == ctx.begin { // String start
+    if cur == ctx.begin { // Iteration start
         if cur != ctx.end { // No empty string
             is_match = words..includes(cur*);
         }
     }
-    else if cur == ctx.end { // String end
+    else if cur == ctx.end { // Iteration end
         is_match = words..includes((cur - 1)*);
     }
-    else { // Middle of string
+    else { // Middle of iteration
         is_match =
                 (words..includes((cur - 1)*) && !words..includes(cur*))  // End of word: \w\W
             || (!words..includes((cur - 1)*) && words..includes(cur*)); // Start of word: \W\w

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -192,9 +192,26 @@ reverse_match_context: <CharT, Iter, max_groups: int> type =
     // }
 }
 
+make_forward_match_context: <CharT, Iter, max_groups: int> (inout ctx: match_context<CharT, Iter, max_groups>) -> forward _ = {
+    return ctx;
+}
+
+make_forward_match_context: <CharT, Iter, max_groups: int> (inout ctx: reverse_match_context<CharT, Iter, max_groups>) -> forward _ = {
+    return ctx.forward_context*;
+}
+
 make_reverse_match_context: <CharT, Iter, max_groups: int> (inout ctx: match_context<CharT, Iter, max_groups>) -> _ = {
     return reverse_match_context<CharT, Iter, max_groups>(ctx&);
 }
+
+make_reverse_match_context: <CharT, Iter, max_groups: int> (inout ctx: reverse_match_context<CharT, Iter, max_groups>) -> forward _ = {
+    return ctx;
+}
+
+make_forward_iterator: <Iter> (pos: Iter)                        -> _ = pos;
+make_forward_iterator: <Iter> (pos: std::reverse_iterator<Iter>) -> _  = pos.base();
+make_reverse_iterator: <Iter> (pos: Iter)                        -> _ = std::make_reverse_iterator(pos);
+make_reverse_iterator: <Iter> (pos: std::reverse_iterator<Iter>) -> _ = pos;
 
 
 //  End function that returns a valid match.
@@ -540,7 +557,7 @@ group_ref_token_matcher: <CharT, group: int, case_insensitive: bool, reverse: bo
 
 //  Regex syntax: $  Example: aa$
 //
-line_end_token_matcher: <CharT, match_new_line: bool, match_new_line_before_end: bool> (cur, inout ctx) -> bool = 
+line_end_token_matcher: <CharT, match_new_line: bool, match_new_line_before_end: bool> (cur, inout ctx) -> bool =
 {
     if cur == ctx.get_string_end() || (match_new_line && cur* == '\n') {
         return true;
@@ -556,7 +573,7 @@ line_end_token_matcher: <CharT, match_new_line: bool, match_new_line_before_end:
 
 //  Regex syntax: ^  Example: ^aa
 //
-line_start_token_matcher: <CharT, match_new_line: bool> (cur, inout ctx) -> bool = 
+line_start_token_matcher: <CharT, match_new_line: bool> (cur, inout ctx) -> bool =
 {
     return cur == ctx.get_string_start() || // Start of string
            (match_new_line && (cur - 1)* == '\n'); // Start of new line
@@ -567,9 +584,9 @@ line_start_token_matcher: <CharT, match_new_line: bool> (cur, inout ctx) -> bool
 //
 //  Parsed in group_token.
 //
-lookahead_token_matcher: <CharT, positive: bool> (cur, inout ctx, func) -> bool = 
+lookahead_token_matcher: <CharT, positive: bool> (cur, inout ctx, func) -> bool =
 {
-    r := func(cur, ctx, true_end_func());
+    r := func(make_forward_iterator(cur), make_forward_match_context(ctx), true_end_func());
     if !positive {
         r.matched = !r.matched;
     }
@@ -577,11 +594,13 @@ lookahead_token_matcher: <CharT, positive: bool> (cur, inout ctx, func) -> bool 
     return r.matched;
 }
 
+//  Regex syntax: (?<=) or (?<!) or (*plb), etc.  Example: (?<=AA)
+//
+//  Parsed in group_token.
+//
 lookbehind_token_matcher: <CharT, positive: bool> (cur, inout ctx, func) -> bool =
 {
-    reverse_ctx := make_reverse_match_context(ctx);
-    r := func(std::make_reverse_iterator(cur), reverse_ctx, true_end_func());
-    _ = reverse_ctx;
+    r := func(make_reverse_iterator(cur), make_reverse_match_context(ctx), true_end_func());
     if !positive {
         r.matched = !r.matched;
     }
@@ -603,10 +622,10 @@ range_flags: type = {
 
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
-range_token_matcher: <CharT, min_count: int, max_count: int, kind: int> type = 
+range_token_matcher: <CharT, min_count: int, max_count: int, kind: int> type =
 {
 
-    match: <Iter> (cur: Iter, inout ctx, inner, reset_func, end_func, tail) -> _ = 
+    match: <Iter> (cur: Iter, inout ctx, inner, reset_func, end_func, tail) -> _ =
     {
         if range_flags::possessive == kind {
             return match_possessive(cur, ctx, inner, end_func, tail);

--- a/include/cpp2regex.h2
+++ b/include/cpp2regex.h2
@@ -120,7 +120,7 @@ match_context: <CharT, Iter, max_groups: int> type =
     }
 }
 
-//  Modifiable state during matching.
+//  Wrapper of context for reverse matches. Implements only the minimal interface for matching.
 //
 reverse_match_context: <CharT, Iter, max_groups: int> type =
 {
@@ -145,27 +145,6 @@ reverse_match_context: <CharT, Iter, max_groups: int> type =
 
     //  Getter and setter for groups
     //
-    //get_group: (in this, group) = groups[group];
-
-    // get_group_end:    (in this, group) -> int = {
-    //     if group >= max_groups || !groups[group].matched {
-    //         return 0;
-    //     }
-    //     return cpp2::unchecked_narrow<int>( std::distance(begin, groups[group].end) );
-    // }
-    // get_group_start:  (in this, group) -> int = {
-    //     if group >= max_groups || !groups[group].matched {
-    //         return 0;
-    //     }
-    //     return cpp2::unchecked_narrow<int>( std::distance(begin, groups[group].start) );
-    // }
-    // get_group_string: (in this, group) -> std::string = {
-    //     if group >= max_groups || !groups[group].matched {
-    //         return "";
-    //     }
-    //     return std::string(groups[group].start, groups[group].end);
-    // }
-
     set_group_end: (inout this, group, pos) = {
         forward_context*..set_group_end(group, (pos).base());
     }
@@ -178,20 +157,14 @@ reverse_match_context: <CharT, Iter, max_groups: int> type =
         forward_context*..set_group_start(group, (pos).base());
     }
 
-    // size: (in this) = max_groups;
-
     //  Misc functions
     //
     fail: (in this)            = match_return<ReverseIter>(false, end);
     pass: (in this, cur: ReverseIter) = match_return<ReverseIter>(true, cur);
-
-    // reset: (inout this) = {
-    //     for groups do (inout g) {
-    //         g.matched = false;
-    //     }
-    // }
 }
 
+//  Helpers for creating wrappers of the match context.
+//
 make_forward_match_context: <CharT, Iter, max_groups: int> (inout ctx: match_context<CharT, Iter, max_groups>) -> forward _ = {
     return ctx;
 }
@@ -208,6 +181,8 @@ make_reverse_match_context: <CharT, Iter, max_groups: int> (inout ctx: reverse_m
     return ctx;
 }
 
+//  Helpers for creating wrappers of the iterators.
+//
 make_forward_iterator: <Iter> (pos: Iter)                        -> _ = pos;
 make_forward_iterator: <Iter> (pos: std::reverse_iterator<Iter>) -> _  = pos.base();
 make_reverse_iterator: <Iter> (pos: Iter)                        -> _ = std::make_reverse_iterator(pos);
@@ -857,9 +832,9 @@ regular_expression: <CharT, matcher> type =
     find_all: (in this, forward func, str: bview<CharT>, start: int, length : int) = find_all(func, get_iter(str, start), get_iter(str, start + length));
     find_all: <Iter> (in this, func, start: Iter, end: Iter) =
     {
-        sr := search_return<Iter>(start, end);
+        sr   := search_return<Iter>(start, end);
         cont := true;
-        cur := start;
+        cur  := start;
 
         while cont {
             r := search_with_context(sr.ctx, cur);
@@ -897,7 +872,8 @@ regular_expression: <CharT, matcher> type =
     search: (in this, str: bview<CharT>)                = search(str..begin(), str..end());
     search: (in this, str: bview<CharT>, start)         = search(get_iter(str, start), str..end());
     search: (in this, str: bview<CharT>, start, length) = search(get_iter(str, start), get_iter(str, start + length));
-    search: <Iter> (in this, start: Iter, end: Iter) -> search_return<Iter> = {
+    search: <Iter> (in this, start: Iter, end: Iter) -> search_return<Iter> =
+    {
         ctx: context<Iter> = (start, end);
         r := search_with_context(ctx, start);
         return search_return<Iter>(r.matched, ctx, r.pos);

--- a/regression-tests/pure2-regex-general.cpp2
+++ b/regression-tests/pure2-regex-general.cpp2
@@ -1,0 +1,32 @@
+general_regex_test: @regex type = {
+  regex_01 := R"(AA)";
+  regex_02 := R"((?=aa))";
+  run: (this) = {
+    std::cout << "Running tests_01_char_matcher:"<< std::endl;
+
+    std::cout << "Not full match fails: " << regex_01.match("AAaa").matched << std::endl;
+    std::cout << "Full match is ok:     " << regex_01.match("AA").matched << std::endl;
+    std::cout << "Search finds at position 1: " << regex_01.search("aAAaa").group_start(0) << std::endl;
+    std::cout << "Search finds at position 3: " << regex_01.search("aaaAAaa").group_start(0) << std::endl;
+
+    count := 0;
+    func := :(r) -> bool == {
+      count&$* += 1;
+      std::cout << "Find all finds at position: " << r.group_start(0) << std::endl;
+      return true;
+    };
+
+    str : std::string = "aAAaAAaAAa";
+    regex_01..find_all(func, str);
+    std::cout << "Find all found 3 matched: " << count << std::endl;
+
+    count = 0;
+    str = "bbaabb";
+    regex_02..find_all(func, str);
+    std::cout << "Find all found 1 match: " << count << std::endl;
+  }
+}
+
+main: () = {
+    general_regex_test().run();
+}

--- a/regression-tests/pure2-regex_02_ranges.cpp2
+++ b/regression-tests/pure2-regex_02_ranges.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_03_wildcard.cpp2
+++ b/regression-tests/pure2-regex_03_wildcard.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_04_start_end.cpp2
+++ b/regression-tests/pure2-regex_04_start_end.cpp2
@@ -172,6 +172,7 @@ test_tests_04_start_end: @regex type = {
   regex_07 := R"(^)";
   regex_08 := R"($)";
   regex_09 := R"($b)";
+  regex_10 := R"(\GX.*X)";
   run: (this) = {
     std::cout << "Running tests_04_start_end:"<< std::endl;
     test(regex_01, "01", R"(^abc$)", "abc", "y", R"($&)", "abc");
@@ -183,6 +184,7 @@ test_tests_04_start_end: @regex type = {
     test(regex_07, "07", R"(^)", "abc", "y", R"($&)", "");
     test(regex_08, "08", R"($)", "abc", "y", R"($&)", "");
     test(regex_09, "09", R"($b)", "b", "n", R"(-)", "-");
+    test(regex_10, "10", R"(\GX.*X)", "aaaXbX", "n", R"(-)", "-");
     std::cout << std::endl;
   }
 }

--- a/regression-tests/pure2-regex_04_start_end.cpp2
+++ b/regression-tests/pure2-regex_04_start_end.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_05_classes.cpp2
+++ b/regression-tests/pure2-regex_05_classes.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_06_boundaries.cpp2
+++ b/regression-tests/pure2-regex_06_boundaries.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_07_short_classes.cpp2
+++ b/regression-tests/pure2-regex_07_short_classes.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_08_alternatives.cpp2
+++ b/regression-tests/pure2-regex_08_alternatives.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_09_groups.cpp2
+++ b/regression-tests/pure2-regex_09_groups.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_10_escapes.cpp2
+++ b/regression-tests/pure2-regex_10_escapes.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_11_group_references.cpp2
+++ b/regression-tests/pure2-regex_11_group_references.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_12_case_insensitive.cpp2
+++ b/regression-tests/pure2-regex_12_case_insensitive.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_13_possessive_modifier.cpp2
+++ b/regression-tests/pure2-regex_13_possessive_modifier.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_14_multiline_modifier.cpp2
+++ b/regression-tests/pure2-regex_14_multiline_modifier.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_15_group_modifiers.cpp2
+++ b/regression-tests/pure2-regex_15_group_modifiers.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_16_perl_syntax_modifier.cpp2
+++ b/regression-tests/pure2-regex_16_perl_syntax_modifier.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_17_comments.cpp2
+++ b/regression-tests/pure2-regex_17_comments.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_18_branch_reset.cpp2
+++ b/regression-tests/pure2-regex_18_branch_reset.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";

--- a/regression-tests/pure2-regex_19_lookahead.cpp2
+++ b/regression-tests/pure2-regex_19_lookahead.cpp2
@@ -94,6 +94,7 @@ create_result: (resultExpr: std::string, r) -> std::string = {
             }
             result +=  std::to_string(pos);
           }
+          next++;
         }
         else {
           std::cerr << "Not implemented";
@@ -191,6 +192,14 @@ test_tests_19_lookahead: @regex type = {
   regex_26 := R"(^(a*?)(?!(aa|aaaa)*$)(?=a\z))";
   regex_27 := R"(a(?!b(?!c))(..))";
   regex_28 := R"(a(?!b(?=a))(..))";
+  regex_29 := R"((?=foo))";
+  regex_30 := R"((?=foo))";
+  regex_31 := R"(.*(?=foo))";
+  regex_32 := R"((?=.*P)P)";
+  regex_33 := R"(X(?=foo)f)";
+  regex_34 := R"(X(?=foo))";
+  regex_35 := R"((?=XY*foo))";
+  regex_36 := R"(^(?=XY*foo))";
   regex_37 := R"(X(\w+)(?=\s)|X(\w+))";
   regex_38 := R"(^a*(?=b)b)";
   regex_39 := R"('(?!\A)x'm)";
@@ -208,6 +217,8 @@ test_tests_19_lookahead: @regex type = {
   regex_51 := R"(((?s)b.)c(?!\N))";
   regex_52 := R"('(b.)c(?!\N)'s)";
   regex_53 := R"(a*(?!))";
+  regex_54 := R"((?<bar>)foo)";
+  regex_55 := R"((?<bar>ABC)foo)";
   run: (this) = {
     std::cout << "Running tests_19_lookahead:"<< std::endl;
     test(regex_01, "01", R"(a(?!b).)", "abad", "y", R"($&)", "ad");
@@ -238,6 +249,14 @@ test_tests_19_lookahead: @regex type = {
     test(regex_26, "26", R"(^(a*?)(?!(aa|aaaa)*$)(?=a\z))", "aaaaaaaa", "y", R"($1)", "aaaaaaa");
     test(regex_27, "27", R"(a(?!b(?!c))(..))", "abababc", "y", R"($1)", "bc");
     test(regex_28, "28", R"(a(?!b(?=a))(..))", "abababc", "y", R"($1)", "bc");
+    test(regex_29, "29", R"((?=foo))", "foo", "y", R"(@+)", "0");
+    test(regex_30, "30", R"((?=foo))", "XfooY", "y", R"(@+)", "1");
+    test(regex_31, "31", R"(.*(?=foo))", "XfooY", "y", R"(@+)", "1");
+    test(regex_32, "32", R"((?=.*P)P)", "aP", "y", R"(@+)", "2");
+    test(regex_33, "33", R"(X(?=foo)f)", "..XfooY..", "y", R"(@+)", "4");
+    test(regex_34, "34", R"(X(?=foo))", "..XfooY..", "y", R"(@+)", "3");
+    test(regex_35, "35", R"((?=XY*foo))", "Xfoo", "y", R"(@+)", "0");
+    test(regex_36, "36", R"(^(?=XY*foo))", "Xfoo", "y", R"(@+)", "0");
     test(regex_37, "37", R"(X(\w+)(?=\s)|X(\w+))", "Xab", "y", R"([$1-$2])", "[-ab]");
     test(regex_38, "38", R"(^a*(?=b)b)", "ab", "y", R"($&)", "ab");
     test(regex_39, "39", R"('(?!\A)x'm)", "a\nxb\n", "y", R"(-)", "-");
@@ -255,6 +274,8 @@ test_tests_19_lookahead: @regex type = {
     test(regex_51, "51", R"(((?s)b.)c(?!\N))", "a\nb\nc\n", "y", R"($1:$&)", "b\n:b\nc");
     test(regex_52, "52", R"('(b.)c(?!\N)'s)", "a\nb\nc\n", "y", R"($1:$&)", "b\n:b\nc");
     test(regex_53, "53", R"(a*(?!))", "aaaab", "n", R"(-)", "-");
+    test(regex_54, "54", R"((?<bar>)foo)", "bar>ABCfoo", "y", R"($&)", "foo");
+    test(regex_55, "55", R"((?<bar>ABC)foo)", "bar>ABCfoo", "y", R"($&)", "ABCfoo");
     std::cout << std::endl;
   }
 }

--- a/regression-tests/pure2-regex_20_lookbehind.cpp
+++ b/regression-tests/pure2-regex_20_lookbehind.cpp
@@ -1,0 +1,8989 @@
+
+#include "cpp2regex.h"
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "build/20_lookbehind.cpp2"
+
+#line 166 "build/20_lookbehind.cpp2"
+class test_tests_20_lookbehind;
+  
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "build/20_lookbehind.cpp2"
+[[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
+
+#line 113 "build/20_lookbehind.cpp2"
+[[nodiscard]] auto sanitize(std::string str) -> std::string;
+
+#line 125 "build/20_lookbehind.cpp2"
+template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
+           cpp2::impl::in<std::string> resultExpected) -> void;
+
+#line 166 "build/20_lookbehind.cpp2"
+class test_tests_20_lookbehind {
+
+#line 223 "build/20_lookbehind.cpp2"
+  public: auto run() const& -> void;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_01_matcher() = default;
+        public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_01_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_02_matcher() = default;
+        public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_02_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_03_matcher() = default;
+        public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_03_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_04_matcher() = default;
+        public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_04_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_05_matcher() = default;
+        public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_05_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_06_matcher() = default;
+        public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_06_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_07_matcher() = default;
+        public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_07_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_08_matcher() = default;
+        public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_08_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_09_matcher() = default;
+        public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_09_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_10_matcher() = default;
+        public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_10_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_11_matcher() = default;
+        public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_11_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_12_matcher() = default;
+        public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_12_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_13_matcher() = default;
+        public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_13_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_14_matcher() = default;
+        public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_14_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_15_matcher() = default;
+        public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_15_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_16_matcher() = default;
+        public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_16_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_17_matcher() = default;
+        public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_17_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_18_matcher() = default;
+        public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_18_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_19_matcher() = default;
+        public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_19_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_20_matcher() = default;
+        public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_20_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_21_matcher() = default;
+        public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_21_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_22_matcher() = default;
+        public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_22_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_23_matcher() = default;
+        public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_23_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_24_matcher() = default;
+        public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_24_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; public: template<typename CharT> class regex_25_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_25_matcher() = default;
+        public: regex_25_matcher(regex_25_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_25_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_25_matcher<char>> regex_25 {}; public: template<typename CharT> class regex_26_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_26_matcher() = default;
+        public: regex_26_matcher(regex_26_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_26_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_26_matcher<char>> regex_26 {}; public: template<typename CharT> class regex_27_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_27_matcher() = default;
+        public: regex_27_matcher(regex_27_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_27_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_27_matcher<char>> regex_27 {}; public: template<typename CharT> class regex_28_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_28_matcher() = default;
+        public: regex_28_matcher(regex_28_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_28_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_28_matcher<char>> regex_28 {}; public: template<typename CharT> class regex_29_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_29_matcher() = default;
+        public: regex_29_matcher(regex_29_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_29_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_29_matcher<char>> regex_29 {}; public: template<typename CharT> class regex_30_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_30_matcher() = default;
+        public: regex_30_matcher(regex_30_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_30_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_30_matcher<char>> regex_30 {}; public: template<typename CharT> class regex_31_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_31_matcher() = default;
+        public: regex_31_matcher(regex_31_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_31_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_31_matcher<char>> regex_31 {}; public: template<typename CharT> class regex_32_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_32_matcher() = default;
+        public: regex_32_matcher(regex_32_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_32_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_32_matcher<char>> regex_32 {}; public: template<typename CharT> class regex_33_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_33_matcher() = default;
+        public: regex_33_matcher(regex_33_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_33_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_33_matcher<char>> regex_33 {}; public: template<typename CharT> class regex_34_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_34_matcher() = default;
+        public: regex_34_matcher(regex_34_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_34_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_34_matcher<char>> regex_34 {}; public: template<typename CharT> class regex_35_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_35_matcher() = default;
+        public: regex_35_matcher(regex_35_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_35_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_35_matcher<char>> regex_35 {}; public: template<typename CharT> class regex_36_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_36_matcher() = default;
+        public: regex_36_matcher(regex_36_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_36_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_36_matcher<char>> regex_36 {}; public: template<typename CharT> class regex_37_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_37_matcher() = default;
+        public: regex_37_matcher(regex_37_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_37_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_37_matcher<char>> regex_37 {}; public: template<typename CharT> class regex_38_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_38_matcher() = default;
+        public: regex_38_matcher(regex_38_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_38_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_38_matcher<char>> regex_38 {}; public: template<typename CharT> class regex_39_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_39_matcher() = default;
+        public: regex_39_matcher(regex_39_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_39_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_39_matcher<char>> regex_39 {}; public: template<typename CharT> class regex_40_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_40_matcher() = default;
+        public: regex_40_matcher(regex_40_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_40_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_40_matcher<char>> regex_40 {}; public: template<typename CharT> class regex_41_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_41_matcher() = default;
+        public: regex_41_matcher(regex_41_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_41_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_41_matcher<char>> regex_41 {}; public: template<typename CharT> class regex_42_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_42_matcher() = default;
+        public: regex_42_matcher(regex_42_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_42_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_42_matcher<char>> regex_42 {}; public: template<typename CharT> class regex_43_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_43_matcher() = default;
+        public: regex_43_matcher(regex_43_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_43_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_43_matcher<char>> regex_43 {}; public: template<typename CharT> class regex_44_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_44_matcher() = default;
+        public: regex_44_matcher(regex_44_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_44_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_44_matcher<char>> regex_44 {}; public: template<typename CharT> class regex_45_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_45_matcher() = default;
+        public: regex_45_matcher(regex_45_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_45_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_45_matcher<char>> regex_45 {}; public: template<typename CharT> class regex_46_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_46_matcher() = default;
+        public: regex_46_matcher(regex_46_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_46_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_46_matcher<char>> regex_46 {}; public: template<typename CharT> class regex_47_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_47_matcher() = default;
+        public: regex_47_matcher(regex_47_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_47_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_47_matcher<char>> regex_47 {}; public: template<typename CharT> class regex_48_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_48_matcher() = default;
+        public: regex_48_matcher(regex_48_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_48_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_48_matcher<char>> regex_48 {}; public: template<typename CharT> class regex_49_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_49_matcher() = default;
+        public: regex_49_matcher(regex_49_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_49_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_49_matcher<char>> regex_49 {}; public: template<typename CharT> class regex_50_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_50_matcher() = default;
+        public: regex_50_matcher(regex_50_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_50_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_50_matcher<char>> regex_50 {}; public: template<typename CharT> class regex_51_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_51_matcher() = default;
+        public: regex_51_matcher(regex_51_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_51_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_51_matcher<char>> regex_51 {}; public: template<typename CharT> class regex_52_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_52_matcher() = default;
+        public: regex_52_matcher(regex_52_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_52_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_52_matcher<char>> regex_52 {}; public: template<typename CharT> class regex_53_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_53_matcher() = default;
+        public: regex_53_matcher(regex_53_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_53_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_53_matcher<char>> regex_53 {}; public: template<typename CharT> class regex_54_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_54_matcher() = default;
+        public: regex_54_matcher(regex_54_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_54_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_54_matcher<char>> regex_54 {}; public: template<typename CharT> class regex_55_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_55_matcher() = default;
+        public: regex_55_matcher(regex_55_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_55_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_55_matcher<char>> regex_55 {}; public: template<typename CharT> class regex_56_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_56_matcher() = default;
+        public: regex_56_matcher(regex_56_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_56_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_56_matcher<char>> regex_56 {}; 
+  public: test_tests_20_lookbehind() = default;
+  public: test_tests_20_lookbehind(test_tests_20_lookbehind const&) = delete; /* No 'that' constructor, suppress copy */
+  public: auto operator=(test_tests_20_lookbehind const&) -> void = delete;
+
+
+#line 283 "build/20_lookbehind.cpp2"
+};
+auto main() -> int;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "build/20_lookbehind.cpp2"
+[[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string{
+#line 2 "build/20_lookbehind.cpp2"
+  std::string result {""}; 
+
+  auto get_next {[_0 = (&resultExpr)](auto const& iter) mutable -> auto{
+  auto start {std::distance(CPP2_UFCS(cbegin)((*cpp2::impl::assert_not_null(_0))), iter)}; 
+    auto firstDollar {CPP2_UFCS(find)((*cpp2::impl::assert_not_null(_0)), "$", start)}; 
+    auto firstAt {CPP2_UFCS(find)((*cpp2::impl::assert_not_null(_0)), "@", cpp2::move(start))}; 
+
+  auto end {std::min(cpp2::move(firstDollar), cpp2::move(firstAt))}; 
+  if (end != std::string::npos) {
+   return CPP2_UFCS(cbegin)((*cpp2::impl::assert_not_null(_0))) + cpp2::move(end); 
+  }
+  else {
+   return CPP2_UFCS(cend)((*cpp2::impl::assert_not_null(_0))); 
+  }
+  }}; 
+  auto extract_group_and_advance {[](auto& iter) -> auto{
+    auto start {iter}; 
+
+    for( ; std::isdigit(*cpp2::impl::assert_not_null(iter)); ++iter ) {}
+
+    return std::stoi(std::string(cpp2::move(start), iter)); 
+  }}; 
+  auto extract_until {[](auto& iter, cpp2::impl::in<char> to) -> auto{
+    auto start {iter}; 
+
+    for( ; (to != *cpp2::impl::assert_not_null(iter)); ++iter ) {}// TODO: Without bracket: error: postfix unary * (dereference) cannot be immediately followed by a (, identifier, or literal - add whitespace before * here if you meant binary * (multiplication)
+
+    return std::string(cpp2::move(start), iter); 
+  }}; 
+
+  auto iter {CPP2_UFCS(begin)(resultExpr)}; 
+
+  while( iter != CPP2_UFCS(end)(resultExpr) ) {
+    auto next {get_next(iter)}; 
+
+    if (next != iter) {
+      result += std::string(iter, next);
+    }
+    if (next != CPP2_UFCS(end)(resultExpr)) {
+      if (*cpp2::impl::assert_not_null(next) == '$') {
+        ++next;
+
+        if (*cpp2::impl::assert_not_null(next) == '&') {
+          ++next;
+          result += CPP2_UFCS(group)(r, 0);
+        }
+        else {if (*cpp2::impl::assert_not_null(next) == '-' || *cpp2::impl::assert_not_null(next) == '+') {
+          auto is_start {*cpp2::impl::assert_not_null(next) == '-'}; 
+          ++next;
+          if (*cpp2::impl::assert_not_null(next) == '{') {
+            ++next; // Skip {
+            auto group {extract_until(next, '}')}; 
+            ++next; // Skip }
+            result += CPP2_UFCS(group)(r, cpp2::move(group));
+          }
+          else {if (*cpp2::impl::assert_not_null(next) == '[') {
+            ++next; // Skip [
+            auto group {extract_group_and_advance(next)}; 
+            ++next; // Skip ]
+
+            if (cpp2::move(is_start)) {
+              result += std::to_string(CPP2_UFCS(group_start)(r, cpp2::move(group)));
+            }
+            else {
+              result += std::to_string(CPP2_UFCS(group_end)(r, cpp2::move(group)));
+            }
+          }
+          else {
+            // Return max group
+            result += CPP2_UFCS(group)(r, CPP2_UFCS(group_number)(r) - 1);
+          }}
+        }
+        else {if (std::isdigit(*cpp2::impl::assert_not_null(next))) {
+          auto group {extract_group_and_advance(next)}; 
+          result += CPP2_UFCS(group)(r, cpp2::move(group));
+        }
+        else {
+          std::cerr << "Not implemented";
+        }}}
+      }
+      else {if (*cpp2::impl::assert_not_null(next) == '@') {
+        ++next;
+
+        if (*cpp2::impl::assert_not_null(next) == '-' || *cpp2::impl::assert_not_null(next) == '+') {
+          auto i {0}; 
+          for( ; cpp2::impl::cmp_less(i,cpp2::unchecked_narrow<int>(CPP2_UFCS(group_number)(r))); ++i ) {
+            auto pos {0}; 
+            if (*cpp2::impl::assert_not_null(next) == '-') {
+              pos = CPP2_UFCS(group_start)(r, i);
+            }
+            else {
+              pos = CPP2_UFCS(group_end)(r, i);
+            }
+            result +=  std::to_string(cpp2::move(pos));
+          }
+          ++next;
+        }
+        else {
+          std::cerr << "Not implemented";
+        }
+      }
+      else {
+        std::cerr << "Not implemented.";
+      }}
+    }
+    iter = cpp2::move(next);
+  }
+
+  return result; 
+}
+
+#line 113 "build/20_lookbehind.cpp2"
+[[nodiscard]] auto sanitize(std::string str) -> std::string
+{
+  str = cpp2::string_util::replace_all(str, "\a", "\\a");
+  str = cpp2::string_util::replace_all(str, "\f", "\\f");
+  str = cpp2::string_util::replace_all(str, "\x1b", "\\e");
+  str = cpp2::string_util::replace_all(str, "\n", "\\n");
+  str = cpp2::string_util::replace_all(str, "\r", "\\r");
+  str = cpp2::string_util::replace_all(str, "\t", "\\t");
+
+  return cpp2::move(str); 
+}
+
+#line 125 "build/20_lookbehind.cpp2"
+template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
+           cpp2::impl::in<std::string> resultExpected) -> void{
+
+  std::string warning {""}; 
+  if (CPP2_UFCS(to_string)(regex) != regex_str) {
+    warning = "Warning: Parsed regex does not match.";
+  }
+
+  std::string status {"OK"}; 
+
+  auto r {CPP2_UFCS(search)(regex, str)}; 
+
+  if ("y" == kind || "yM" == kind || "yS" == kind || "yB" == kind) {
+    if (!(r.matched)) {
+      status = "Failure: Regex should apply.";
+    }
+    else {
+      // Have a match check the result
+
+      auto result {create_result(resultExpr, cpp2::move(r))}; 
+
+      if (result != resultExpected) {
+        status = "Failure: Result is wrong. (is: " + cpp2::to_string(sanitize(cpp2::move(result))) + ")";
+      }
+    }
+  }
+  else {if ("n" == kind) {
+    if (r.matched) {
+      status = "Failure: Regex should not apply. Result is '" + cpp2::to_string(CPP2_UFCS(group)(cpp2::move(r), 0)) + "'";
+    }
+  }else {
+    status = "Unknown kind '" + cpp2::to_string(kind) + "'";
+  }}
+
+  if (!(CPP2_UFCS(empty)(warning))) {
+    warning += " ";
+  }
+  std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
+}
+
+#line 223 "build/20_lookbehind.cpp2"
+  auto test_tests_20_lookbehind::run() const& -> void{
+    std::cout << "Running tests_20_lookbehind:" << std::endl;
+    test(regex_01, "01", R"((?<=a)b)", "ab", "y", R"($&)", "b");
+    test(regex_02, "02", R"((?<=af?)b)", "ab", "y", R"($&)", "b");
+    test(regex_03, "03", R"((?<=a)b)", "cb", "n", R"(-)", "-");
+    test(regex_04, "04", R"((?<=a(?:fo)?)b)", "cb", "n", R"(-)", "-");
+    test(regex_05, "05", R"((?<=a)b)", "b", "n", R"(-)", "-");
+    test(regex_06, "06", R"((?<=a(?:foo)?)b)", "b", "n", R"(-)", "-");
+    test(regex_07, "07", R"((?<!c)b)", "ab", "y", R"($&)", "b");
+    test(regex_08, "08", R"((?<!c(?:foob)?)b)", "ab", "y", R"($&)", "b");
+    test(regex_09, "09", R"((?<!c)b)", "cb", "n", R"(-)", "-");
+    test(regex_10, "10", R"((?<!c(?:fooba)?)b)", "cb", "n", R"(-)", "-");
+    test(regex_11, "11", R"((?<!c)b)", "b", "y", R"(-)", "-");
+    test(regex_12, "12", R"((?<!c(?:foobar)?)b)", "b", "y", R"(-)", "-");
+    test(regex_13, "13", R"((?<!c)b)", "b", "y", R"($&)", "b");
+    test(regex_14, "14", R"((?<!c(?:foobarb)?)b)", "b", "y", R"($&)", "b");
+    test(regex_15, "15", R"((?<![cd])b)", "dbcb", "n", R"(-)", "-");
+    test(regex_16, "16", R"((?<![cd]e{0,254})b)", "dbcb", "n", R"(-)", "-");
+    test(regex_17, "17", R"((?<![cd])[ab])", "dbaacb", "y", R"($&)", "a");
+    test(regex_18, "18", R"((?<![cd]{1,2})[ab])", "dbaacb", "y", R"($&)", "a");
+    test(regex_19, "19", R"((?<![cd]{1,3})[ab])", "dbaacb", "y", R"($&)", "a");
+    test(regex_20, "20", R"((?<!(c|d))b)", "dbcb", "n", R"(-)", "-");
+    test(regex_21, "21", R"((?<!(c|d))[ab])", "dbaacb", "y", R"($&)", "a");
+    test(regex_22, "22", R"((?<!cd)[ab])", "cdaccb", "y", R"($&)", "b");
+    test(regex_23, "23", R"($(?<=^(a)))", "a", "y", R"($1)", "a");
+    test(regex_24, "24", R"((.*)c)", "abcd", "y", R"($1)", "ab");
+    test(regex_25, "25", R"((.*)(?<=b))", "abcd", "y", R"($1)", "ab");
+    test(regex_26, "26", R"((.*)(?<=b)c)", "abcd", "y", R"($1)", "ab");
+    test(regex_27, "27", R"((.*)(?<=b|c))", "abcd", "y", R"($1)", "abc");
+    test(regex_28, "28", R"((.*)(?<=b|c)c)", "abcd", "y", R"($1)", "ab");
+    test(regex_29, "29", R"((.*)(?<=c|b))", "abcd", "y", R"($1)", "abc");
+    test(regex_30, "30", R"((.*)(?<=c|b)c)", "abcd", "y", R"($1)", "ab");
+    test(regex_31, "31", R"((.*)(?<=[bc]))", "abcd", "y", R"($1)", "abc");
+    test(regex_32, "32", R"((.*)(?<=[bc])c)", "abcd", "y", R"($1)", "ab");
+    test(regex_33, "33", R"((.*?)c)", "abcd", "y", R"($1)", "ab");
+    test(regex_34, "34", R"((.*?)(?<=b))", "abcd", "y", R"($1)", "ab");
+    test(regex_35, "35", R"((.*?)(?<=b)c)", "abcd", "y", R"($1)", "ab");
+    test(regex_36, "36", R"((.*?)(?<=b|c))", "abcd", "y", R"($1)", "ab");
+    test(regex_37, "37", R"((.*?)(?<=b|c)c)", "abcd", "y", R"($1)", "ab");
+    test(regex_38, "38", R"((.*?)(?<=c|b))", "abcd", "y", R"($1)", "ab");
+    test(regex_39, "39", R"((.*?)(?<=c|b)c)", "abcd", "y", R"($1)", "ab");
+    test(regex_40, "40", R"((.*?)(?<=[bc]))", "abcd", "y", R"($1)", "ab");
+    test(regex_41, "41", R"((.*?)(?<=[bc])c)", "abcd", "y", R"($1)", "ab");
+    test(regex_42, "42", R"((?<=foo))", "foo", "y", R"(@+)", "3");
+    test(regex_43, "43", R"((?<=foo))", "XfooY", "y", R"(@+)", "4");
+    test(regex_44, "44", R"(.*(?<=foo))", "foo", "y", R"(@+)", "3");
+    test(regex_45, "45", R"(.*(?<=foo))", "XfooY", "y", R"(@+)", "4");
+    test(regex_46, "46", R"((?<=foo)Y)", "XfooY", "y", R"(@+)", "5");
+    test(regex_47, "47", R"(o(?<=foo)Y)", "..XfooY..", "y", R"(@+)", "7");
+    test(regex_48, "48", R"(X(?<=foo.)[YZ])", "..XfooXY..", "y", R"(@+)", "8");
+    test(regex_49, "49", R"((?<=bar>)foo)", "bar>foo", "y", R"($&)", "foo");
+    test(regex_50, "50", R"((?<!bar>)foo)", "bar>foo", "n", R"(-)", "-");
+    test(regex_51, "51", R"((?<=bar>ABC)foo)", "bar>ABCfoo", "y", R"($&)", "foo");
+    test(regex_52, "52", R"((?<!bar>ABC)foo)", "bar>ABCfoo", "n", R"(-)", "-");
+    test(regex_53, "53", R"((?<=abcd(?<=(aaaabcd))))", "..aaaabcd..", "y", R"($1)", "aaaabcd");
+    test(regex_54, "54", R"((?=xy(?<=(aaxy))))", "..aaxy..", "y", R"($1)", "aaxy");
+    test(regex_55, "55", R"((?=xy(?<=(aaxyz?))))", "..aaxy..", "y", R"($1)", "aaxy");
+    test(regex_56, "56", R"((?<=(?=(aaxy))aa))", "..aaxy..", "y", R"($1)", "aaxy");
+    std::cout << std::endl;
+  }
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_01_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_01_matcher<CharT>::to_string() -> std::string{return R"((?<=a)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"f"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_02_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_02_matcher<CharT>::to_string() -> std::string{return R"((?<=af?)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_03_matcher<CharT>::to_string() -> std::string{return R"((?<=a)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_04_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"of"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_04_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_04_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_04_matcher<CharT>::to_string() -> std::string{return R"((?<=a(?:fo)?)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_05_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_05_matcher<CharT>::to_string() -> std::string{return R"((?<=a)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_06_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"oof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_06_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_06_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_06_matcher<CharT>::to_string() -> std::string{return R"((?<=a(?:foo)?)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_07_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_07_matcher<CharT>::to_string() -> std::string{return R"((?<!c)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_08_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,4 + 1> str_tmp_0 {"boof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),4)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,4); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 4;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_08_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_08_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_08_matcher<CharT>::to_string() -> std::string{return R"((?<!c(?:foob)?)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_09_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_09_matcher<CharT>::to_string() -> std::string{return R"((?<!c)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_10_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,5 + 1> str_tmp_0 {"aboof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),5)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,5); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 5;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_10_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_10_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_10_matcher<CharT>::to_string() -> std::string{return R"((?<!c(?:fooba)?)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_11_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_11_matcher<CharT>::to_string() -> std::string{return R"((?<!c)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_12_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,6 + 1> str_tmp_0 {"raboof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),6)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,6); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 6;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_12_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_12_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_12_matcher<CharT>::to_string() -> std::string{return R"((?<!c(?:foobar)?)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_13_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_13_matcher<CharT>::to_string() -> std::string{return R"((?<!c)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_14_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,7 + 1> str_tmp_0 {"braboof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),7)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,7); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 7;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_14_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_14_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_14_matcher<CharT>::to_string() -> std::string{return R"((?<!c(?:foobarb)?)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_15_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'c'>,::cpp2::regex::single_class_entry<char,'d'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_0 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_15_matcher<CharT>::to_string() -> std::string{return R"((?<![cd])b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_16_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"e"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_16_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,254,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_16_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'c'>,::cpp2::regex::single_class_entry<char,'d'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_16_matcher<CharT>::to_string() -> std::string{return R"((?<![cd]e{0,254})b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_17_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'c'>,::cpp2::regex::single_class_entry<char,'d'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'a'>,::cpp2::regex::single_class_entry<char,'b'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_17_matcher<CharT>::to_string() -> std::string{return R"((?<![cd])[ab])"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_18_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'c'>,::cpp2::regex::single_class_entry<char,'d'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_18_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,2,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_18_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'a'>,::cpp2::regex::single_class_entry<char,'b'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_18_matcher<CharT>::to_string() -> std::string{return R"((?<![cd]{1,2})[ab])"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_19_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'c'>,::cpp2::regex::single_class_entry<char,'d'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_19_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,3,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_19_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'a'>,::cpp2::regex::single_class_entry<char,'b'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_19_matcher<CharT>::to_string() -> std::string{return R"((?<![cd]{1,3})[ab])"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_20_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_20_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"d"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_20_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_20_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_3 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_20_matcher<CharT>::to_string() -> std::string{return R"((?<!(c|d))b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_21_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_21_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"d"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_21_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_21_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'a'>,::cpp2::regex::single_class_entry<char,'b'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_21_matcher<CharT>::to_string() -> std::string{return R"((?<!(c|d))[ab])"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_22_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"dc"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'a'>,::cpp2::regex::single_class_entry<char,'b'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_22_matcher<CharT>::to_string() -> std::string{return R"((?<!cd)[ab])"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_23_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  ctx.set_group_start(1, r.pos);
+
+  auto tmp_1_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
+  static_cast<void>(cpp2::move(tmp_1));
+  if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_23_matcher<CharT>::to_string() -> std::string{return R"($(?<=^(a)))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_24_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_24_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_24_matcher<CharT>::to_string() -> std::string{return R"((.*)c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_25_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_25_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_25_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_25_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_25_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_25_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_25_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_25_matcher<CharT>::to_string() -> std::string{return R"((.*)(?<=b))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_26_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_26_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_26_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_26_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_26_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_26_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_26_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_26_matcher<CharT>::to_string() -> std::string{return R"((.*)(?<=b)c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_2 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_6(), func_4(), cpp2::regex::no_reset(), func_5(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_27_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_27_matcher<CharT>::to_string() -> std::string{return R"((.*)(?<=b|c))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_2 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_6(), func_4(), cpp2::regex::no_reset(), func_5(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_3 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_28_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_28_matcher<CharT>::to_string() -> std::string{return R"((.*)(?<=b|c)c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_6(), func_4(), cpp2::regex::no_reset(), func_5(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_29_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_29_matcher<CharT>::to_string() -> std::string{return R"((.*)(?<=c|b))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_6(), func_4(), cpp2::regex::no_reset(), func_5(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_3 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_30_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_30_matcher<CharT>::to_string() -> std::string{return R"((.*)(?<=c|b)c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_31_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_31_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_31_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'b'>,::cpp2::regex::single_class_entry<char,'c'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_31_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_31_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_31_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_31_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_31_matcher<CharT>::to_string() -> std::string{return R"((.*)(?<=[bc]))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_32_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_32_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_32_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'b'>,::cpp2::regex::single_class_entry<char,'c'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_32_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_32_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_32_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_32_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_32_matcher<CharT>::to_string() -> std::string{return R"((.*)(?<=[bc])c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_33_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_33_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,1>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_33_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_33_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_33_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_33_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_33_matcher<CharT>::to_string() -> std::string{return R"((.*?)c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_34_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_34_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,1>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_34_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_34_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_34_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_34_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_34_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_34_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?<=b))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_35_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_35_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,1>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_35_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_35_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_35_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_35_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_35_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_35_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?<=b)c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,1>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_2 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_6(), func_4(), cpp2::regex::no_reset(), func_5(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_36_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_36_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?<=b|c))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,1>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_2 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_6(), func_4(), cpp2::regex::no_reset(), func_5(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_3 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_37_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_37_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?<=b|c)c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,1>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_6(), func_4(), cpp2::regex::no_reset(), func_5(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_38_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_38_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?<=c|b))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,1>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_6(), func_4(), cpp2::regex::no_reset(), func_5(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_3 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_39_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_39_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?<=c|b)c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_40_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_40_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,1>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_40_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'b'>,::cpp2::regex::single_class_entry<char,'c'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_40_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_40_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_40_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_40_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_40_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?<=[bc]))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_41_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_41_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,1>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_41_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'b'>,::cpp2::regex::single_class_entry<char,'c'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_41_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_41_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_41_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_41_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_41_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?<=[bc])c)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_42_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"oof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_42_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_42_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_42_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_42_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_42_matcher<CharT>::to_string() -> std::string{return R"((?<=foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_43_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"oof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_43_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_43_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_43_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_43_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_43_matcher<CharT>::to_string() -> std::string{return R"((?<=foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_44_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_44_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_44_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"oof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_44_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_44_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_44_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_44_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_44_matcher<CharT>::to_string() -> std::string{return R"(.*(?<=foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_45_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_45_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_45_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"oof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_45_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_45_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_45_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_45_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_45_matcher<CharT>::to_string() -> std::string{return R"(.*(?<=foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_46_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"oof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_46_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"Y"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_46_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_46_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_46_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_46_matcher<CharT>::to_string() -> std::string{return R"((?<=foo)Y)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_47_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_1 {"oof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_47_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"o"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"Y"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_47_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_47_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_47_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_47_matcher<CharT>::to_string() -> std::string{return R"(o(?<=foo)Y)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_48_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+
+  std::array<char,3 + 1> str_tmp_1 {"oof"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_48_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"X"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'Y'>,::cpp2::regex::single_class_entry<char,'Z'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_48_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_48_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_48_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_48_matcher<CharT>::to_string() -> std::string{return R"(X(?<=foo.)[YZ])"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_49_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,4 + 1> str_tmp_0 {">rab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),4)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,4); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 4;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_49_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,3 + 1> str_tmp_1 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_49_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_49_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_49_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_49_matcher<CharT>::to_string() -> std::string{return R"((?<=bar>)foo)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_50_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,4 + 1> str_tmp_0 {">rab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),4)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,4); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 4;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_50_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,3 + 1> str_tmp_1 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_50_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_50_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_50_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_50_matcher<CharT>::to_string() -> std::string{return R"((?<!bar>)foo)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_51_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,7 + 1> str_tmp_0 {"CBA>rab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),7)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,7); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 7;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_51_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,3 + 1> str_tmp_1 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_51_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_51_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_51_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_51_matcher<CharT>::to_string() -> std::string{return R"((?<=bar>ABC)foo)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_52_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,7 + 1> str_tmp_0 {"CBA>rab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),7)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,7); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 7;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_52_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,false>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,3 + 1> str_tmp_1 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_52_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_52_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_52_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_52_matcher<CharT>::to_string() -> std::string{return R"((?<!bar>ABC)foo)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_53_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  std::array<char,7 + 1> str_tmp_0 {"dcbaaaa"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),7)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,7); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 7;}
+  else {break;}
+  ctx.set_group_start(1, r.pos);
+
+  auto tmp_1_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
+  static_cast<void>(cpp2::move(tmp_1));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_53_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_2()))) {r.matched = false;break;}
+
+  std::array<char,4 + 1> str_tmp_2 {"dcba"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),4)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,4); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 4;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_53_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_53_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_53_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_53_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_53_matcher<CharT>::to_string() -> std::string{return R"((?<=abcd(?<=(aaaabcd))))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_54_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  std::array<char,4 + 1> str_tmp_1 {"yxaa"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),4)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,4); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 4;}
+  else {break;}
+  ctx.set_group_start(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_54_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"xy"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_2()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_54_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_54_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_54_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_54_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_54_matcher<CharT>::to_string() -> std::string{return R"((?=xy(?<=(aaxy))))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_55_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"z"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_55_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_3(), cpp2::regex::no_reset(), other, func_4());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_55_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,4 + 1> str_tmp_2 {"yxaa"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),4)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,4); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 4;}
+  else {break;}
+  ctx.set_group_start(1, r.pos);
+
+  auto tmp_3_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_3 {cpp2::regex::make_on_return(cpp2::move(tmp_3_func))}; 
+  static_cast<void>(cpp2::move(tmp_3));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_55_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"xy"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_2()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_55_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_55_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_55_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_55_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_55_matcher<CharT>::to_string() -> std::string{return R"((?=xy(?<=(aaxyz?))))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_56_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  std::array<char,4 + 1> str_tmp_1 {"aaxy"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),4)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,4); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 4;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_56_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"aa"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_2()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_56_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookbehind_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_20_lookbehind::regex_56_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_56_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_20_lookbehind::regex_56_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_20_lookbehind::regex_56_matcher<CharT>::to_string() -> std::string{return R"((?<=(?=(aaxy))aa))"; }
+
+
+#line 284 "build/20_lookbehind.cpp2"
+auto main() -> int{
+    CPP2_UFCS(run)(test_tests_20_lookbehind());
+}
+

--- a/regression-tests/pure2-regex_21_atomic_patterns.cpp2
+++ b/regression-tests/pure2-regex_21_atomic_patterns.cpp2
@@ -163,36 +163,24 @@ test: <M> (regex: M, id: std::string, regex_str: std::string, str: std::string, 
 }
 
 
-test_tests_01_char_matcher: @regex type = {
-  regex_01 := R"(abc)";
-  regex_02 := R"(abc)";
-  regex_03 := R"(abc)";
-  regex_04 := R"(abc)";
-  regex_05 := R"(abc)";
-  regex_06 := R"(abc)";
-  regex_07 := R"(abc)";
-  regex_08 := R"(abc)";
-  regex_09 := R"(abc)";
-  regex_10 := R"(abc)";
-  regex_11 := R"(abc)";
-  regex_12 := R"(abc)";
+test_tests_21_atomic_patterns: @regex type = {
+  regex_01 := R"((?>a+)b)";
+  regex_02 := R"(((?>a+)b))";
+  regex_03 := R"((?>(a+))b)";
+  regex_04 := R"(((?>[^()]+)|\([^()]*\))+)";
+  regex_05 := R"(round\(((?>[^()]+))\))";
+  regex_06 := R"(^((?>(?:aa)?b)?))";
   run: (this) = {
-    std::cout << "Running tests_01_char_matcher:"<< std::endl;
-    test(regex_01, "01", R"(abc)", "abc", "y", R"($&)", "abc");
-    test(regex_02, "02", R"(abc)", "abc", "y", R"($-[0])", "0");
-    test(regex_03, "03", R"(abc)", "abc", "y", R"($+[0])", "3");
-    test(regex_04, "04", R"(abc)", "xbc", "n", R"(-)", "-");
-    test(regex_05, "05", R"(abc)", "axc", "n", R"(-)", "-");
-    test(regex_06, "06", R"(abc)", "abx", "n", R"(-)", "-");
-    test(regex_07, "07", R"(abc)", "xabcy", "y", R"($&)", "abc");
-    test(regex_08, "08", R"(abc)", "xabcy", "y", R"($-[0])", "1");
-    test(regex_09, "09", R"(abc)", "xabcy", "y", R"($+[0])", "4");
-    test(regex_10, "10", R"(abc)", "ababc", "y", R"($&)", "abc");
-    test(regex_11, "11", R"(abc)", "ababc", "y", R"($-[0])", "2");
-    test(regex_12, "12", R"(abc)", "ababc", "y", R"($+[0])", "5");
+    std::cout << "Running tests_21_atomic_patterns:"<< std::endl;
+    test(regex_01, "01", R"((?>a+)b)", "aaab", "y", R"(-)", "-");
+    test(regex_02, "02", R"(((?>a+)b))", "aaab", "y", R"($1)", "aaab");
+    test(regex_03, "03", R"((?>(a+))b)", "aaab", "y", R"($1)", "aaa");
+    test(regex_04, "04", R"(((?>[^()]+)|\([^()]*\))+)", "((abc(ade)ufh()()x", "y", R"($&)", "abc(ade)ufh()()x");
+    test(regex_05, "05", R"(round\(((?>[^()]+))\))", "_I(round(xs * sz),1)", "y", R"($1)", "xs * sz");
+    test(regex_06, "06", R"(^((?>(?:aa)?b)?))", "aab", "y", R"($1)", "aab");
     std::cout << std::endl;
   }
 }
 main: () = {
-    test_tests_01_char_matcher().run();
+    test_tests_21_atomic_patterns().run();
 }

--- a/regression-tests/test-results/apple-clang-14-c++2b/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/apple-clang-14-c++2b/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/apple-clang-14-c++2b/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/apple-clang-14-c++2b/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/clang-12-c++20/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/clang-12-c++20/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/clang-12-c++20/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/clang-12-c++20/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/clang-12-c++20/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/clang-15-c++20-libcpp/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/clang-15-c++20-libcpp/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/clang-15-c++20-libcpp/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/clang-15-c++20-libcpp/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/clang-15-c++20/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/clang-15-c++20/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/clang-15-c++20/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/clang-15-c++20/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/clang-18-c++20/pure2-regex-general.cpp.output
+++ b/regression-tests/test-results/clang-18-c++20/pure2-regex-general.cpp.output
@@ -1,0 +1,78 @@
+PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
+Stack dump:
+0.	Program arguments: /usr/lib/llvm-18/bin/clang -cc1 -triple x86_64-pc-linux-gnu -emit-obj -mrelax-all -dumpdir test.exe- -disable-free -clear-ast-before-backend -disable-llvm-verifier -discard-value-names -main-file-name pure2-regex-general.cpp -mrelocation-model pic -pic-level 2 -pic-is-pie -mframe-pointer=all -fmath-errno -ffp-contract=on -fno-rounding-math -mconstructor-aliases -funwind-tables=2 -target-cpu x86-64 -tune-cpu generic -debugger-tuning=gdb -fdebug-compilation-dir=/home/runner/work/cppfront/cppfront/regression-tests/test-results/clang-18-c++20 -fcoverage-compilation-dir=/home/runner/work/cppfront/cppfront/regression-tests/test-results/clang-18-c++20 -resource-dir /usr/lib/llvm-18/lib/clang/18 -I ../../../include -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14 -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/x86_64-linux-gnu/c++/14 -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/backward -internal-isystem /usr/lib/llvm-18/lib/clang/18/include -internal-isystem /usr/local/include -internal-isystem /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../x86_64-linux-gnu/include -internal-externc-isystem /usr/include/x86_64-linux-gnu -internal-externc-isystem /include -internal-externc-isystem /usr/include -std=c++20 -fdeprecated-macro -ferror-limit 19 -pthread -fgnuc-version=4.2.1 -fno-implicit-modules -fskip-odr-check-in-gmf -fcxx-exceptions -fexceptions -faddrsig -D__GCC_HAVE_DWARF2_CFI_ASM=1 -o /tmp/pure2-regex-general-8173f8.o -x c++ pure2-regex-general.cpp
+1.	<eof> parser at end of file
+2.	cpp2regex.h2:833:113: instantiating function definition 'cpp2::regex::regular_expression<char, general_regex_test::regex_01_matcher<char>>::find_all<const char *, (lambda at pure2-regex-general.cpp2:13:16)>'
+3.	pure2-regex-general.cpp2:13:16: instantiating function definition 'general_regex_test::run()::(anonymous class)::operator()<cpp2::regex::regular_expression<char, general_regex_test::regex_01_matcher<char>>::search_return<const char *>>'
+4.	pure2-regex-general.cpp2:15:54 <Spelling=../../../include/cpp2util.h:10058:66>: instantiating function definition 'general_regex_test::run()::(anonymous class)::operator()(const cpp2::regex::regular_expression<char, general_regex_test::regex_01_matcher<char>>::search_return<const char *> &)::(anonymous class)::operator()<const cpp2::regex::regular_expression<char, general_regex_test::regex_01_matcher<char>>::search_return<const char *> &, int>'
+ #0 0x00007f4a111a63bf llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/usr/lib/llvm-18/bin/../lib/libLLVM.so.18.1+0xda63bf)
+ #1 0x00007f4a111a44f9 llvm::sys::RunSignalHandlers() (/usr/lib/llvm-18/bin/../lib/libLLVM.so.18.1+0xda44f9)
+ #2 0x00007f4a111a6b00 (/usr/lib/llvm-18/bin/../lib/libLLVM.so.18.1+0xda6b00)
+ #3 0x00007f4a0fc45320 (/lib/x86_64-linux-gnu/libc.so.6+0x45320)
+ #4 0x00007f4a19318f6a clang::Sema::tryCaptureVariable(clang::ValueDecl*, clang::SourceLocation, clang::Sema::TryCaptureKind, clang::SourceLocation, bool, clang::QualType&, clang::QualType&, unsigned int const*) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1718f6a)
+ #5 0x00007f4a192e10a6 clang::Sema::BuildDeclRefExpr(clang::ValueDecl*, clang::QualType, clang::ExprValueKind, clang::DeclarationNameInfo const&, clang::NestedNameSpecifierLoc, clang::NamedDecl*, clang::SourceLocation, clang::TemplateArgumentListInfo const*) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x16e10a6)
+ #6 0x00007f4a192e1005 clang::Sema::BuildDeclRefExpr(clang::ValueDecl*, clang::QualType, clang::ExprValueKind, clang::DeclarationNameInfo const&, clang::CXXScopeSpec const*, clang::NamedDecl*, clang::SourceLocation, clang::TemplateArgumentListInfo const*) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x16e1005)
+ #7 0x00007f4a192e533c clang::Sema::BuildDeclarationNameExpr(clang::CXXScopeSpec const&, clang::DeclarationNameInfo const&, clang::NamedDecl*, clang::NamedDecl*, clang::TemplateArgumentListInfo const*, bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x16e533c)
+ #8 0x00007f4a19777871 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b77871)
+ #9 0x00007f4a1977abfb (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b7abfb)
+#10 0x00007f4a197599c4 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b599c4)
+#11 0x00007f4a19770a28 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b70a28)
+#12 0x00007f4a19760341 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b60341)
+#13 0x00007f4a1976681c (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b6681c)
+#14 0x00007f4a1976b4b4 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b6b4b4)
+#15 0x00007f4a1976e08d (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b6e08d)
+#16 0x00007f4a1976b4b4 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b6b4b4)
+#17 0x00007f4a19772670 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b72670)
+#18 0x00007f4a19765c77 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b65c77)
+#19 0x00007f4a1978645a (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b8645a)
+#20 0x00007f4a1978449f (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b8449f)
+#21 0x00007f4a19770669 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b70669)
+#22 0x00007f4a1975fa03 clang::Sema::SubstStmt(clang::Stmt*, clang::MultiLevelTemplateArgumentList const&) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b5fa03)
+#23 0x00007f4a197a1f26 clang::Sema::InstantiateFunctionDefinition(clang::SourceLocation, clang::FunctionDecl*, bool, bool, bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1ba1f26)
+#24 0x00007f4a18fecde0 clang::Sema::runWithSufficientStackSpace(clang::SourceLocation, llvm::function_ref<void ()>) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x13ecde0)
+#25 0x00007f4a1970280e clang::Sema::DeduceReturnType(clang::FunctionDecl*, clang::SourceLocation, bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b0280e)
+#26 0x00007f4a192d6bc9 clang::Sema::DiagnoseUseOfDecl(clang::NamedDecl*, llvm::ArrayRef<clang::SourceLocation>, clang::ObjCInterfaceDecl const*, bool, bool, clang::ObjCInterfaceDecl*, bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x16d6bc9)
+#27 0x00007f4a195de3ce (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x19de3ce)
+#28 0x00007f4a195e5884 clang::Sema::BuildCallToObjectOfClassType(clang::Scope*, clang::Expr*, clang::SourceLocation, llvm::MutableArrayRef<clang::Expr*>, clang::SourceLocation) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x19e5884)
+#29 0x00007f4a192dbb7d clang::Sema::BuildCallExpr(clang::Scope*, clang::Expr*, clang::SourceLocation, llvm::MutableArrayRef<clang::Expr*>, clang::SourceLocation, clang::Expr*, bool, bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x16dbb7d)
+#30 0x00007f4a192f60a1 clang::Sema::ActOnCallExpr(clang::Scope*, clang::Expr*, clang::SourceLocation, llvm::MutableArrayRef<clang::Expr*>, clang::SourceLocation, clang::Expr*) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x16f60a1)
+#31 0x00007f4a1976b65d (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b6b65d)
+#32 0x00007f4a1976f44e (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b6f44e)
+#33 0x00007f4a1976f42d (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b6f42d)
+#34 0x00007f4a1975fa77 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b5fa77)
+#35 0x00007f4a19770669 (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b70669)
+#36 0x00007f4a1975fa03 clang::Sema::SubstStmt(clang::Stmt*, clang::MultiLevelTemplateArgumentList const&) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1b5fa03)
+#37 0x00007f4a197a1f26 clang::Sema::InstantiateFunctionDefinition(clang::SourceLocation, clang::FunctionDecl*, bool, bool, bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1ba1f26)
+#38 0x00007f4a197a4744 clang::Sema::PerformPendingInstantiations(bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1ba4744)
+#39 0x00007f4a197a2029 clang::Sema::InstantiateFunctionDefinition(clang::SourceLocation, clang::FunctionDecl*, bool, bool, bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1ba2029)
+#40 0x00007f4a197a4744 clang::Sema::PerformPendingInstantiations(bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x1ba4744)
+#41 0x00007f4a18fee90b clang::Sema::ActOnEndOfTranslationUnitFragment(clang::Sema::TUFragmentKind) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x13ee90b)
+#42 0x00007f4a18feef7b clang::Sema::ActOnEndOfTranslationUnit() (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x13eef7b)
+#43 0x00007f4a1885fe2e clang::Parser::ParseTopLevelDecl(clang::OpaquePtr<clang::DeclGroupRef>&, clang::Sema::ModuleImportState&) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0xc5fe2e)
+#44 0x00007f4a1879747e clang::ParseAST(clang::Sema&, bool, bool) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0xb9747e)
+#45 0x00007f4a1a60662c clang::FrontendAction::Execute() (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x2a0662c)
+#46 0x00007f4a1a5830b4 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x29830b4)
+#47 0x00007f4a1a68263d clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/usr/lib/llvm-18/bin/../lib/libclang-cpp.so.18.1+0x2a8263d)
+#48 0x000055f3eaf2042e cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/usr/lib/llvm-18/bin/clang+0x1442e)
+#49 0x000055f3eaf1d894 (/usr/lib/llvm-18/bin/clang+0x11894)
+#50 0x000055f3eaf1ca26 clang_main(int, char**, llvm::ToolContext const&) (/usr/lib/llvm-18/bin/clang+0x10a26)
+#51 0x000055f3eaf2a383 main (/usr/lib/llvm-18/bin/clang+0x1e383)
+#52 0x00007f4a0fc2a1ca (/lib/x86_64-linux-gnu/libc.so.6+0x2a1ca)
+#53 0x00007f4a0fc2a28b __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28b)
+#54 0x000055f3eaf1a255 _start (/usr/lib/llvm-18/bin/clang+0xe255)
+clang++-18: error: unable to execute command: Segmentation fault (core dumped)
+clang++-18: error: clang frontend command failed due to signal (use -v to see invocation)
+Ubuntu clang version 18.1.3 (1ubuntu1)
+Target: x86_64-pc-linux-gnu
+Thread model: posix
+InstalledDir: /usr/bin
+clang++-18: note: diagnostic msg: 
+********************
+
+PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
+Preprocessed source(s) and associated run script(s) are located at:
+clang++-18: note: diagnostic msg: /tmp/pure2-regex-general-9097b6.cpp
+clang++-18: note: diagnostic msg: /tmp/pure2-regex-general-9097b6.sh
+clang++-18: note: diagnostic msg: 
+
+********************

--- a/regression-tests/test-results/clang-18-c++20/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++20/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/clang-18-c++20/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++20/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/clang-18-c++20/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++20/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/gcc-10-c++20/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/gcc-10-c++20/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/gcc-10-c++20/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/gcc-10-c++20/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/gcc-10-c++20/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/gcc-13-c++2b/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/gcc-13-c++2b/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/gcc-13-c++2b/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/gcc-13-c++2b/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/gcc-14-c++2b/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/gcc-14-c++2b/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-regex-general.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-regex-general.cpp.output
@@ -1,0 +1,1 @@
+pure2-regex-general.cpp

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-regex_21_atomic_patterns.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-regex_21_atomic_patterns.cpp.output
@@ -1,0 +1,1 @@
+pure2-regex_21_atomic_patterns.cpp

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-regex-general.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-regex-general.cpp.output
@@ -1,0 +1,1 @@
+pure2-regex-general.cpp

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/msvc-2022-c++latest/pure2-regex_21_atomic_patterns.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++latest/pure2-regex_21_atomic_patterns.cpp.output
@@ -1,0 +1,1 @@
+pure2-regex_21_atomic_patterns.cpp

--- a/regression-tests/test-results/pure2-regex-general.cpp
+++ b/regression-tests/test-results/pure2-regex-general.cpp
@@ -19,26 +19,19 @@ class general_regex_test {
 
 #line 4 "pure2-regex-general.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
   public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
-
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-};
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -46,31 +39,24 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
   public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
-
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-};
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -78,7 +64,7 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; 
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; 
   public: general_regex_test() = default;
   public: general_regex_test(general_regex_test const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(general_regex_test const&) -> void = delete;
@@ -122,8 +108,7 @@ auto main() -> int;
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto general_regex_test::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -151,10 +136,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto general_regex_test::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -162,21 +148,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto general_regex_test::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] constexpr auto general_regex_test::regex_01_matcher::wrap<Iter,CharT>::is_start_match() -> bool { return false; }
-
-  [[nodiscard]] auto general_regex_test::regex_01_matcher::to_string() -> std::string{return R"(AA)"; }
-
+  template <typename CharT> [[nodiscard]] constexpr auto general_regex_test::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto general_regex_test::regex_01_matcher<CharT>::to_string() -> std::string{return R"(AA)"; }
 
 
 
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto general_regex_test::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -204,11 +188,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto general_regex_test::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -223,10 +208,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto general_regex_test::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -234,14 +220,13 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] constexpr auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::is_start_match() -> bool { return false; }
-
-  [[nodiscard]] auto general_regex_test::regex_02_matcher::to_string() -> std::string{return R"((?=aa))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto general_regex_test::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher<CharT>::to_string() -> std::string{return R"((?=aa))"; }
 
 
 #line 30 "pure2-regex-general.cpp2"

--- a/regression-tests/test-results/pure2-regex-general.cpp
+++ b/regression-tests/test-results/pure2-regex-general.cpp
@@ -1,0 +1,251 @@
+
+#define CPP2_IMPORT_STD          Yes
+#include "cpp2regex.h"
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "pure2-regex-general.cpp2"
+class general_regex_test;
+#line 2 "pure2-regex-general.cpp2"
+  
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-regex-general.cpp2"
+class general_regex_test {
+
+#line 4 "pure2-regex-general.cpp2"
+  public: auto run() const& -> void;
+  public: class regex_01_matcher {
+  public: template<typename Iter, typename CharT> class wrap {
+  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_0 {
+  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+
+  public: wrap() = default;
+  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
+  public: auto operator=(wrap const&) -> void = delete;
+};
+
+  public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_01_matcher() = default;
+        public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_01_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
+  public: template<typename Iter, typename CharT> class wrap {
+  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+
+  public: wrap() = default;
+  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
+  public: auto operator=(wrap const&) -> void = delete;
+};
+
+  public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_02_matcher() = default;
+        public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_02_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; 
+  public: general_regex_test() = default;
+  public: general_regex_test(general_regex_test const&) = delete; /* No 'that' constructor, suppress copy */
+  public: auto operator=(general_regex_test const&) -> void = delete;
+
+
+#line 28 "pure2-regex-general.cpp2"
+};
+
+auto main() -> int;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-regex-general.cpp2"
+
+#line 4 "pure2-regex-general.cpp2"
+  auto general_regex_test::run() const& -> void{
+    std::cout << "Running tests_01_char_matcher:" << std::endl;
+
+    std::cout << "Not full match fails: " << CPP2_UFCS(match)(regex_01, "AAaa").matched << std::endl;
+    std::cout << "Full match is ok:     " << CPP2_UFCS(match)(regex_01, "AA").matched << std::endl;
+    std::cout << "Search finds at position 1: " << CPP2_UFCS(group_start)(CPP2_UFCS(search)(regex_01, "aAAaa"), 0) << std::endl;
+    std::cout << "Search finds at position 3: " << CPP2_UFCS(group_start)(CPP2_UFCS(search)(regex_01, "aaaAAaa"), 0) << std::endl;
+
+    auto count {0}; 
+    auto func {[&, _1 = (&count)](auto const& r) -> bool{
+      *cpp2::impl::assert_not_null(_1) += 1;
+      std::cout << "Find all finds at position: " << CPP2_UFCS(group_start)(r, 0) << std::endl;
+      return true; 
+    }}; 
+
+    std::string str {"aAAaAAaAAa"}; 
+    regex_01.find_all(func, str);
+    std::cout << "Find all found 3 matched: " << count << std::endl;
+
+    count = 0;
+    str = "bbaabb";
+    regex_02.find_all(cpp2::move(func), cpp2::move(str));
+    std::cout << "Find all found 1 match: " << cpp2::move(count) << std::endl;
+  }
+
+
+
+
+
+  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"AA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  return r; 
+  }
+
+  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename Iter, typename CharT> [[nodiscard]] constexpr auto general_regex_test::regex_01_matcher::wrap<Iter,CharT>::is_start_match() -> bool { return false; }
+
+  [[nodiscard]] auto general_regex_test::regex_01_matcher::to_string() -> std::string{return R"(AA)"; }
+
+
+
+
+
+
+  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"aa"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  return r; 
+  }
+
+
+  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  return r; 
+  }
+
+  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename Iter, typename CharT> [[nodiscard]] auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename Iter, typename CharT> [[nodiscard]] constexpr auto general_regex_test::regex_02_matcher::wrap<Iter,CharT>::is_start_match() -> bool { return false; }
+
+  [[nodiscard]] auto general_regex_test::regex_02_matcher::to_string() -> std::string{return R"((?=aa))"; }
+
+
+#line 30 "pure2-regex-general.cpp2"
+auto main() -> int{
+    CPP2_UFCS(run)(general_regex_test());
+}
+

--- a/regression-tests/test-results/pure2-regex-general.cpp2.output
+++ b/regression-tests/test-results/pure2-regex-general.cpp2.output
@@ -1,0 +1,2 @@
+pure2-regex-general.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/regression-tests/test-results/pure2-regex_01_char_matcher.cpp
+++ b/regression-tests/test-results/pure2-regex_01_char_matcher.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_01_char_matcher.cpp2"
 
-#line 165 "pure2-regex_01_char_matcher.cpp2"
+#line 166 "pure2-regex_01_char_matcher.cpp2"
 class test_tests_01_char_matcher;
   
 
@@ -18,37 +18,31 @@ class test_tests_01_char_matcher;
 #line 1 "pure2-regex_01_char_matcher.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_01_char_matcher.cpp2"
+#line 113 "pure2-regex_01_char_matcher.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_01_char_matcher.cpp2"
+#line 125 "pure2-regex_01_char_matcher.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_01_char_matcher.cpp2"
+#line 166 "pure2-regex_01_char_matcher.cpp2"
 class test_tests_01_char_matcher {
 
-#line 178 "pure2-regex_01_char_matcher.cpp2"
+#line 179 "pure2-regex_01_char_matcher.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,25 +70,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -108,25 +90,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -134,25 +110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -160,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -186,25 +150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -212,25 +170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -238,25 +190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -264,25 +210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -290,25 +230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -316,25 +250,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -342,13 +270,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; 
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; 
   public: test_tests_01_char_matcher() = default;
   public: test_tests_01_char_matcher(test_tests_01_char_matcher const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_01_char_matcher const&) -> void = delete;
 
 
-#line 194 "pure2-regex_01_char_matcher.cpp2"
+#line 195 "pure2-regex_01_char_matcher.cpp2"
 };
 auto main() -> int;
 
@@ -452,6 +380,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -467,7 +396,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_01_char_matcher.cpp2"
+#line 113 "pure2-regex_01_char_matcher.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -480,7 +409,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_01_char_matcher.cpp2"
+#line 125 "pure2-regex_01_char_matcher.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -521,7 +450,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 178 "pure2-regex_01_char_matcher.cpp2"
+#line 179 "pure2-regex_01_char_matcher.cpp2"
   auto test_tests_01_char_matcher::run() const& -> void{
     std::cout << "Running tests_01_char_matcher:" << std::endl;
     test(regex_01, "01", R"(abc)", "abc", "y", R"($&)", "abc");
@@ -542,59 +471,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abc"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_01_matcher::to_string() -> std::string{return R"(abc)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -622,10 +499,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -633,19 +511,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_02_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_01_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -673,10 +551,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -684,19 +563,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_03_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_02_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -724,10 +603,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -735,19 +615,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_04_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_03_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -775,10 +655,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -786,19 +667,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_05_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_04_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -826,10 +707,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -837,19 +719,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_06_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_05_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -877,10 +759,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -888,19 +771,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_07_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_06_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -928,10 +811,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -939,19 +823,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_08_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_07_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -979,10 +863,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -990,19 +875,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_09_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_08_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1030,10 +915,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1041,19 +927,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_10_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_09_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1081,10 +967,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1092,19 +979,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_11_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_10_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1132,10 +1019,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1143,15 +1031,68 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_01_char_matcher::regex_12_matcher::to_string() -> std::string{return R"(abc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_11_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
 
 
-#line 195 "pure2-regex_01_char_matcher.cpp2"
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abc"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_01_char_matcher::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_01_char_matcher::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_01_char_matcher::regex_12_matcher<CharT>::to_string() -> std::string{return R"(abc)"; }
+
+
+#line 196 "pure2-regex_01_char_matcher.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_01_char_matcher());
 }

--- a/regression-tests/test-results/pure2-regex_02_ranges.cpp
+++ b/regression-tests/test-results/pure2-regex_02_ranges.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_02_ranges.cpp2"
 
-#line 165 "pure2-regex_02_ranges.cpp2"
+#line 166 "pure2-regex_02_ranges.cpp2"
 class test_tests_02_ranges;
   
 
@@ -18,47 +18,41 @@ class test_tests_02_ranges;
 #line 1 "pure2-regex_02_ranges.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_02_ranges.cpp2"
+#line 113 "pure2-regex_02_ranges.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_02_ranges.cpp2"
+#line 125 "pure2-regex_02_ranges.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_02_ranges.cpp2"
+#line 166 "pure2-regex_02_ranges.cpp2"
 class test_tests_02_ranges {
 
-#line 206 "pure2-regex_02_ranges.cpp2"
+#line 207 "pure2-regex_02_ranges.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -66,35 +60,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -102,35 +90,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -138,35 +120,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -174,35 +150,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -210,35 +180,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -246,35 +210,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -282,35 +240,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -318,35 +270,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -354,35 +300,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -390,35 +330,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -426,35 +360,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -462,35 +390,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -498,35 +420,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -534,35 +450,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -570,35 +480,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -606,35 +510,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -642,35 +540,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -678,35 +570,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -714,35 +600,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -750,35 +630,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; public: class regex_21_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_21_matcher() = default;
         public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -786,35 +660,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_21_matcher> regex_21 {}; public: class regex_22_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_22_matcher() = default;
         public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -822,35 +690,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_22_matcher> regex_22 {}; public: class regex_23_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_23_matcher() = default;
         public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -858,35 +720,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_23_matcher> regex_23 {}; public: class regex_24_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_24_matcher() = default;
         public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -894,35 +750,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_24_matcher> regex_24 {}; public: class regex_25_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; public: template<typename CharT> class regex_25_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_25_matcher() = default;
         public: regex_25_matcher(regex_25_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -930,35 +780,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_25_matcher> regex_25 {}; public: class regex_26_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_25_matcher<char>> regex_25 {}; public: template<typename CharT> class regex_26_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_26_matcher() = default;
         public: regex_26_matcher(regex_26_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -966,35 +810,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_26_matcher> regex_26 {}; public: class regex_27_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_26_matcher<char>> regex_26 {}; public: template<typename CharT> class regex_27_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_27_matcher() = default;
         public: regex_27_matcher(regex_27_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1002,35 +840,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_27_matcher> regex_27 {}; public: class regex_28_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_27_matcher<char>> regex_27 {}; public: template<typename CharT> class regex_28_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_28_matcher() = default;
         public: regex_28_matcher(regex_28_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1038,35 +870,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_28_matcher> regex_28 {}; public: class regex_29_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_28_matcher<char>> regex_28 {}; public: template<typename CharT> class regex_29_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_29_matcher() = default;
         public: regex_29_matcher(regex_29_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1074,35 +900,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_29_matcher> regex_29 {}; public: class regex_30_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_29_matcher<char>> regex_29 {}; public: template<typename CharT> class regex_30_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_30_matcher() = default;
         public: regex_30_matcher(regex_30_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1110,35 +930,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_30_matcher> regex_30 {}; public: class regex_31_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_30_matcher<char>> regex_30 {}; public: template<typename CharT> class regex_31_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_31_matcher() = default;
         public: regex_31_matcher(regex_31_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1146,35 +960,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_31_matcher> regex_31 {}; public: class regex_32_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_31_matcher<char>> regex_31 {}; public: template<typename CharT> class regex_32_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_32_matcher() = default;
         public: regex_32_matcher(regex_32_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1182,35 +990,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_32_matcher> regex_32 {}; public: class regex_33_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_32_matcher<char>> regex_32 {}; public: template<typename CharT> class regex_33_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_33_matcher() = default;
         public: regex_33_matcher(regex_33_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1218,35 +1020,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_33_matcher> regex_33 {}; public: class regex_34_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_33_matcher<char>> regex_33 {}; public: template<typename CharT> class regex_34_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_34_matcher() = default;
         public: regex_34_matcher(regex_34_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1254,35 +1050,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_34_matcher> regex_34 {}; public: class regex_35_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_34_matcher<char>> regex_34 {}; public: template<typename CharT> class regex_35_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_35_matcher() = default;
         public: regex_35_matcher(regex_35_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1290,35 +1080,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_35_matcher> regex_35 {}; public: class regex_36_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_35_matcher<char>> regex_35 {}; public: template<typename CharT> class regex_36_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_36_matcher() = default;
         public: regex_36_matcher(regex_36_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1326,35 +1110,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_36_matcher> regex_36 {}; public: class regex_37_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_36_matcher<char>> regex_36 {}; public: template<typename CharT> class regex_37_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_37_matcher() = default;
         public: regex_37_matcher(regex_37_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1362,35 +1140,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_37_matcher> regex_37 {}; public: class regex_38_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_37_matcher<char>> regex_37 {}; public: template<typename CharT> class regex_38_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_38_matcher() = default;
         public: regex_38_matcher(regex_38_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1398,35 +1170,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_38_matcher> regex_38 {}; public: class regex_39_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_38_matcher<char>> regex_38 {}; public: template<typename CharT> class regex_39_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_39_matcher() = default;
         public: regex_39_matcher(regex_39_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1434,35 +1200,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_39_matcher> regex_39 {}; public: class regex_40_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_39_matcher<char>> regex_39 {}; public: template<typename CharT> class regex_40_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_40_matcher() = default;
         public: regex_40_matcher(regex_40_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1470,13 +1230,13 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_40_matcher> regex_40 {}; 
+  public: cpp2::regex::regular_expression<char,regex_40_matcher<char>> regex_40 {}; 
   public: test_tests_02_ranges() = default;
   public: test_tests_02_ranges(test_tests_02_ranges const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_02_ranges const&) -> void = delete;
 
 
-#line 250 "pure2-regex_02_ranges.cpp2"
+#line 251 "pure2-regex_02_ranges.cpp2"
 };
 auto main() -> int;
 
@@ -1580,6 +1340,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -1595,7 +1356,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_02_ranges.cpp2"
+#line 113 "pure2-regex_02_ranges.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -1608,7 +1369,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_02_ranges.cpp2"
+#line 125 "pure2-regex_02_ranges.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -1649,7 +1410,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 206 "pure2-regex_02_ranges.cpp2"
+#line 207 "pure2-regex_02_ranges.cpp2"
   auto test_tests_02_ranges::run() const& -> void{
     std::cout << "Running tests_02_ranges:" << std::endl;
     test(regex_01, "01", R"(ab*c)", "abc", "y", R"($&)", "abc");
@@ -1698,8 +1459,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1727,11 +1487,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1759,11 +1520,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1791,10 +1553,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1802,19 +1565,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher::to_string() -> std::string{return R"(ab*c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_01_matcher<CharT>::to_string() -> std::string{return R"(ab*c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1842,11 +1605,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1874,11 +1638,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1906,10 +1671,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1917,19 +1683,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher::to_string() -> std::string{return R"(ab*c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_02_matcher<CharT>::to_string() -> std::string{return R"(ab*c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1957,11 +1723,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1989,11 +1756,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2021,10 +1789,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2032,19 +1801,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher::to_string() -> std::string{return R"(ab*c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_03_matcher<CharT>::to_string() -> std::string{return R"(ab*c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2072,11 +1841,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2104,11 +1874,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2136,10 +1907,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2147,19 +1919,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher::to_string() -> std::string{return R"(ab*bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_04_matcher<CharT>::to_string() -> std::string{return R"(ab*bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2187,11 +1959,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2219,11 +1992,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2251,10 +2025,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2262,19 +2037,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher::to_string() -> std::string{return R"(ab*bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_05_matcher<CharT>::to_string() -> std::string{return R"(ab*bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2302,11 +2077,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2334,11 +2110,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2366,10 +2143,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2377,19 +2155,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher::to_string() -> std::string{return R"(ab*bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_06_matcher<CharT>::to_string() -> std::string{return R"(ab*bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2417,11 +2195,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2449,11 +2228,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2481,10 +2261,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2492,19 +2273,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher::to_string() -> std::string{return R"(ab*bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_07_matcher<CharT>::to_string() -> std::string{return R"(ab*bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2532,11 +2313,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2564,11 +2346,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2596,10 +2379,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2607,19 +2391,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher::to_string() -> std::string{return R"(ab*bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_08_matcher<CharT>::to_string() -> std::string{return R"(ab*bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2647,11 +2431,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2679,11 +2464,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2711,10 +2497,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2722,19 +2509,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher::to_string() -> std::string{return R"(ab*bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_09_matcher<CharT>::to_string() -> std::string{return R"(ab*bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2762,11 +2549,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2794,11 +2582,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2826,10 +2615,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2837,19 +2627,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher::to_string() -> std::string{return R"(ab*bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_10_matcher<CharT>::to_string() -> std::string{return R"(ab*bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2877,11 +2667,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2909,11 +2700,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2941,10 +2733,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2952,19 +2745,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher::to_string() -> std::string{return R"(ab*bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_11_matcher<CharT>::to_string() -> std::string{return R"(ab*bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2992,11 +2785,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3024,11 +2818,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3056,10 +2851,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3067,19 +2863,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher::to_string() -> std::string{return R"(ab*bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_12_matcher<CharT>::to_string() -> std::string{return R"(ab*bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3107,11 +2903,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3139,11 +2936,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3171,10 +2969,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3182,19 +2981,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher::to_string() -> std::string{return R"(ab{0,}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_13_matcher<CharT>::to_string() -> std::string{return R"(ab{0,}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3222,11 +3021,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3254,11 +3054,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3286,10 +3087,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3297,19 +3099,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher::to_string() -> std::string{return R"(ab{0,}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_14_matcher<CharT>::to_string() -> std::string{return R"(ab{0,}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3337,11 +3139,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3369,11 +3172,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3401,10 +3205,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3412,19 +3217,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher::to_string() -> std::string{return R"(ab{0,}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_15_matcher<CharT>::to_string() -> std::string{return R"(ab{0,}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3452,11 +3257,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3484,11 +3290,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3516,10 +3323,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3527,19 +3335,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher::to_string() -> std::string{return R"(ab+bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_16_matcher<CharT>::to_string() -> std::string{return R"(ab+bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3567,11 +3375,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3599,11 +3408,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3631,10 +3441,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3642,19 +3453,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher::to_string() -> std::string{return R"(ab+bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_17_matcher<CharT>::to_string() -> std::string{return R"(ab+bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3682,11 +3493,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3714,11 +3526,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3746,10 +3559,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3757,19 +3571,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher::to_string() -> std::string{return R"(ab+bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_18_matcher<CharT>::to_string() -> std::string{return R"(ab+bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3797,11 +3611,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3829,11 +3644,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3861,10 +3677,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3872,19 +3689,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher::to_string() -> std::string{return R"(ab+bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_19_matcher<CharT>::to_string() -> std::string{return R"(ab+bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3912,11 +3729,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3944,11 +3762,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3976,10 +3795,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3987,19 +3807,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher::to_string() -> std::string{return R"(ab+bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_20_matcher<CharT>::to_string() -> std::string{return R"(ab+bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4027,11 +3847,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4059,11 +3880,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4091,10 +3913,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4102,19 +3925,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher::to_string() -> std::string{return R"(ab{1,}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_21_matcher<CharT>::to_string() -> std::string{return R"(ab{1,}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4142,11 +3965,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4174,11 +3998,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4206,10 +4031,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4217,19 +4043,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher::to_string() -> std::string{return R"(ab+bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_22_matcher<CharT>::to_string() -> std::string{return R"(ab+bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4257,11 +4083,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4289,11 +4116,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4321,10 +4149,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4332,19 +4161,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher::to_string() -> std::string{return R"(ab+bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_23_matcher<CharT>::to_string() -> std::string{return R"(ab+bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4372,11 +4201,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4404,11 +4234,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4436,10 +4267,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4447,19 +4279,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher::to_string() -> std::string{return R"(ab+bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_24_matcher<CharT>::to_string() -> std::string{return R"(ab+bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4487,11 +4319,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4519,11 +4352,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4551,10 +4385,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4562,19 +4397,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher::to_string() -> std::string{return R"(ab{1,}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_25_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_25_matcher<CharT>::to_string() -> std::string{return R"(ab{1,}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4602,11 +4437,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4634,11 +4470,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4666,10 +4503,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4677,19 +4515,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher::to_string() -> std::string{return R"(ab{1,}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_26_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_26_matcher<CharT>::to_string() -> std::string{return R"(ab{1,}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4717,11 +4555,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4749,11 +4588,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4781,10 +4621,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4792,19 +4633,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher::to_string() -> std::string{return R"(ab{1,}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_27_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_27_matcher<CharT>::to_string() -> std::string{return R"(ab{1,}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4832,11 +4673,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4864,11 +4706,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4896,10 +4739,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4907,19 +4751,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher::to_string() -> std::string{return R"(ab{1,3}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_28_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_28_matcher<CharT>::to_string() -> std::string{return R"(ab{1,3}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4947,11 +4791,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4979,11 +4824,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5011,10 +4857,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5022,19 +4869,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher::to_string() -> std::string{return R"(ab{1,3}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_29_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_29_matcher<CharT>::to_string() -> std::string{return R"(ab{1,3}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5062,11 +4909,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5094,11 +4942,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5126,10 +4975,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5137,19 +4987,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher::to_string() -> std::string{return R"(ab{1,3}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_30_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_30_matcher<CharT>::to_string() -> std::string{return R"(ab{1,3}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5177,11 +5027,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5209,11 +5060,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5241,10 +5093,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5252,19 +5105,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher::to_string() -> std::string{return R"(ab{3,4}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_31_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_31_matcher<CharT>::to_string() -> std::string{return R"(ab{3,4}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5292,11 +5145,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5324,11 +5178,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5356,10 +5211,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5367,19 +5223,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher::to_string() -> std::string{return R"(ab{3,4}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_32_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_32_matcher<CharT>::to_string() -> std::string{return R"(ab{3,4}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5407,11 +5263,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5439,11 +5296,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5471,10 +5329,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5482,19 +5341,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher::to_string() -> std::string{return R"(ab{3,4}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_33_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_33_matcher<CharT>::to_string() -> std::string{return R"(ab{3,4}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5522,11 +5381,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5554,11 +5414,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5586,10 +5447,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5597,19 +5459,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher::to_string() -> std::string{return R"(ab{4,5}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_34_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_34_matcher<CharT>::to_string() -> std::string{return R"(ab{4,5}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5637,11 +5499,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5669,11 +5532,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5701,10 +5565,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5712,19 +5577,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher::to_string() -> std::string{return R"(ab?bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_35_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_35_matcher<CharT>::to_string() -> std::string{return R"(ab?bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5752,11 +5617,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5784,11 +5650,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5816,10 +5683,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5827,19 +5695,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher::to_string() -> std::string{return R"(ab?bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_36_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_36_matcher<CharT>::to_string() -> std::string{return R"(ab?bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5867,11 +5735,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5899,11 +5768,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5931,10 +5801,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5942,19 +5813,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher::to_string() -> std::string{return R"(ab{0,1}bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_37_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_37_matcher<CharT>::to_string() -> std::string{return R"(ab{0,1}bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5982,11 +5853,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6014,11 +5886,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6046,10 +5919,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6057,19 +5931,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher::to_string() -> std::string{return R"(ab?bc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_38_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_38_matcher<CharT>::to_string() -> std::string{return R"(ab?bc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6097,11 +5971,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6129,11 +6004,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6161,10 +6037,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6172,19 +6049,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher::to_string() -> std::string{return R"(ab?c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_39_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_39_matcher<CharT>::to_string() -> std::string{return R"(ab?c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6212,11 +6089,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6244,11 +6122,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6276,10 +6155,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6287,15 +6167,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher::to_string() -> std::string{return R"(ab{0,1}c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_02_ranges::regex_40_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_02_ranges::regex_40_matcher<CharT>::to_string() -> std::string{return R"(ab{0,1}c)"; }
 
 
-#line 251 "pure2-regex_02_ranges.cpp2"
+#line 252 "pure2-regex_02_ranges.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_02_ranges());
 }

--- a/regression-tests/test-results/pure2-regex_03_wildcard.cpp
+++ b/regression-tests/test-results/pure2-regex_03_wildcard.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_03_wildcard.cpp2"
 
-#line 165 "pure2-regex_03_wildcard.cpp2"
+#line 166 "pure2-regex_03_wildcard.cpp2"
 class test_tests_03_wildcard;
   
 
@@ -18,47 +18,41 @@ class test_tests_03_wildcard;
 #line 1 "pure2-regex_03_wildcard.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_03_wildcard.cpp2"
+#line 113 "pure2-regex_03_wildcard.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_03_wildcard.cpp2"
+#line 125 "pure2-regex_03_wildcard.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_03_wildcard.cpp2"
+#line 166 "pure2-regex_03_wildcard.cpp2"
 class test_tests_03_wildcard {
 
-#line 186 "pure2-regex_03_wildcard.cpp2"
+#line 187 "pure2-regex_03_wildcard.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -66,35 +60,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -102,35 +90,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -138,35 +120,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -174,35 +150,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -210,35 +180,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -246,35 +210,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -282,35 +240,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -318,35 +270,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -354,35 +300,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -390,35 +330,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -426,35 +360,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -462,35 +390,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -498,25 +420,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -524,25 +440,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -550,25 +460,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -576,35 +480,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -612,35 +510,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -648,35 +540,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -684,35 +570,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -720,13 +600,13 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; 
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; 
   public: test_tests_03_wildcard() = default;
   public: test_tests_03_wildcard(test_tests_03_wildcard const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_03_wildcard const&) -> void = delete;
 
 
-#line 210 "pure2-regex_03_wildcard.cpp2"
+#line 211 "pure2-regex_03_wildcard.cpp2"
 };
 auto main() -> int;
 
@@ -830,6 +710,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -845,7 +726,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_03_wildcard.cpp2"
+#line 113 "pure2-regex_03_wildcard.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -858,7 +739,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_03_wildcard.cpp2"
+#line 125 "pure2-regex_03_wildcard.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -899,7 +780,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 186 "pure2-regex_03_wildcard.cpp2"
+#line 187 "pure2-regex_03_wildcard.cpp2"
   auto test_tests_03_wildcard::run() const& -> void{
     std::cout << "Running tests_03_wildcard:" << std::endl;
     test(regex_01, "01", R"(.{1})", "abbbbc", "y", R"($&)", "a");
@@ -928,82 +809,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,1,1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher::to_string() -> std::string{return R"(.{1})"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1018,11 +824,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1036,11 +843,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1054,10 +862,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1065,19 +874,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher::to_string() -> std::string{return R"(.{1})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_01_matcher<CharT>::to_string() -> std::string{return R"(.{1})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1092,11 +901,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1110,11 +920,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1128,10 +939,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1139,19 +951,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher::to_string() -> std::string{return R"(.{1})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_02_matcher<CharT>::to_string() -> std::string{return R"(.{1})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1166,11 +978,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1179,16 +992,17 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   false
   );
   if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,3,4,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  r = cpp2::regex::range_token_matcher<char,1,1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
   }
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1202,10 +1016,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1213,19 +1028,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher::to_string() -> std::string{return R"(.{3,4})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_03_matcher<CharT>::to_string() -> std::string{return R"(.{1})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1240,11 +1055,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1258,11 +1074,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1276,10 +1093,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1287,19 +1105,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher::to_string() -> std::string{return R"(.{3,4})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_04_matcher<CharT>::to_string() -> std::string{return R"(.{3,4})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1314,11 +1132,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1332,11 +1151,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1350,10 +1170,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1361,19 +1182,96 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher::to_string() -> std::string{return R"(.{3,4})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_05_matcher<CharT>::to_string() -> std::string{return R"(.{3,4})"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,3,4,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_06_matcher<CharT>::to_string() -> std::string{return R"(.{3,4})"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1388,11 +1286,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1406,11 +1305,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1424,10 +1324,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1435,19 +1336,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher::to_string() -> std::string{return R"(\N{1})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_07_matcher<CharT>::to_string() -> std::string{return R"(\N{1})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1462,11 +1363,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1480,11 +1382,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1498,10 +1401,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1509,19 +1413,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher::to_string() -> std::string{return R"(\N{1})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_08_matcher<CharT>::to_string() -> std::string{return R"(\N{1})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1536,11 +1440,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1554,11 +1459,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1572,10 +1478,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1583,19 +1490,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher::to_string() -> std::string{return R"(\N{1})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_09_matcher<CharT>::to_string() -> std::string{return R"(\N{1})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1610,11 +1517,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1628,11 +1536,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1646,10 +1555,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1657,19 +1567,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher::to_string() -> std::string{return R"(\N{3,4})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_10_matcher<CharT>::to_string() -> std::string{return R"(\N{3,4})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1684,11 +1594,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1702,11 +1613,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1720,10 +1632,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1731,19 +1644,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher::to_string() -> std::string{return R"(\N{3,4})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_11_matcher<CharT>::to_string() -> std::string{return R"(\N{3,4})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1758,11 +1671,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1776,11 +1690,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1794,10 +1709,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1805,19 +1721,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher::to_string() -> std::string{return R"(\N{3,4})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_12_matcher<CharT>::to_string() -> std::string{return R"(\N{3,4})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1832,11 +1748,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1850,11 +1767,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1868,10 +1786,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1879,19 +1798,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher::to_string() -> std::string{return R"(\N{3,4})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_13_matcher<CharT>::to_string() -> std::string{return R"(\N{3,4})"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1934,10 +1853,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1945,19 +1865,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_14_matcher::to_string() -> std::string{return R"(a.c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_14_matcher<CharT>::to_string() -> std::string{return R"(a.c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2000,10 +1920,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2011,19 +1932,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_15_matcher::to_string() -> std::string{return R"(a.c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_15_matcher<CharT>::to_string() -> std::string{return R"(a.c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2066,10 +1987,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2077,19 +1999,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_16_matcher::to_string() -> std::string{return R"(a\Nc)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_16_matcher<CharT>::to_string() -> std::string{return R"(a\Nc)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2104,11 +2026,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2136,11 +2059,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2168,10 +2092,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2179,19 +2104,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher::to_string() -> std::string{return R"(a.*c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_17_matcher<CharT>::to_string() -> std::string{return R"(a.*c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2206,11 +2131,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2238,11 +2164,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2270,10 +2197,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2281,19 +2209,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher::to_string() -> std::string{return R"(a\N*c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_18_matcher<CharT>::to_string() -> std::string{return R"(a\N*c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2308,11 +2236,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2340,11 +2269,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2372,10 +2302,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2383,19 +2314,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher::to_string() -> std::string{return R"(a.*c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_19_matcher<CharT>::to_string() -> std::string{return R"(a.*c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2410,11 +2341,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2442,11 +2374,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2474,10 +2407,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2485,15 +2419,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher::to_string() -> std::string{return R"(a\N*c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_03_wildcard::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_03_wildcard::regex_20_matcher<CharT>::to_string() -> std::string{return R"(a\N*c)"; }
 
 
-#line 211 "pure2-regex_03_wildcard.cpp2"
+#line 212 "pure2-regex_03_wildcard.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_03_wildcard());
 }

--- a/regression-tests/test-results/pure2-regex_04_start_end.cpp
+++ b/regression-tests/test-results/pure2-regex_04_start_end.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_04_start_end.cpp2"
 
-#line 165 "pure2-regex_04_start_end.cpp2"
+#line 166 "pure2-regex_04_start_end.cpp2"
 class test_tests_04_start_end;
   
 
@@ -18,37 +18,31 @@ class test_tests_04_start_end;
 #line 1 "pure2-regex_04_start_end.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_04_start_end.cpp2"
+#line 113 "pure2-regex_04_start_end.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_04_start_end.cpp2"
+#line 125 "pure2-regex_04_start_end.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_04_start_end.cpp2"
+#line 166 "pure2-regex_04_start_end.cpp2"
 class test_tests_04_start_end {
 
-#line 175 "pure2-regex_04_start_end.cpp2"
+#line 177 "pure2-regex_04_start_end.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,25 +70,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -108,25 +90,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -134,25 +110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -160,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -186,25 +150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -212,25 +170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -238,25 +190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -264,13 +210,43 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; 
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_10_matcher() = default;
+        public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_10_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; 
   public: test_tests_04_start_end() = default;
   public: test_tests_04_start_end(test_tests_04_start_end const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_04_start_end const&) -> void = delete;
 
 
-#line 188 "pure2-regex_04_start_end.cpp2"
+#line 191 "pure2-regex_04_start_end.cpp2"
 };
 auto main() -> int;
 
@@ -374,6 +350,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -389,7 +366,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_04_start_end.cpp2"
+#line 113 "pure2-regex_04_start_end.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -402,7 +379,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_04_start_end.cpp2"
+#line 125 "pure2-regex_04_start_end.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -443,7 +420,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 175 "pure2-regex_04_start_end.cpp2"
+#line 177 "pure2-regex_04_start_end.cpp2"
   auto test_tests_04_start_end::run() const& -> void{
     std::cout << "Running tests_04_start_end:" << std::endl;
     test(regex_01, "01", R"(^abc$)", "abc", "y", R"($&)", "abc");
@@ -455,67 +432,14 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
     test(regex_07, "07", R"(^)", "abc", "y", R"($&)", "");
     test(regex_08, "08", R"($)", "abc", "y", R"($&)", "");
     test(regex_09, "09", R"($b)", "b", "n", R"(-)", "-");
+    test(regex_10, "10", R"(\GX.*X)", "aaaXbX", "n", R"(-)", "-");
     std::cout << std::endl;
   }
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
-
-  std::array<char,3 + 1> str_tmp_0 {"abc"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_04_start_end::regex_01_matcher::to_string() -> std::string{return R"(^abc$)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -545,10 +469,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -556,71 +481,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_04_start_end::regex_02_matcher::to_string() -> std::string{return R"(^abc$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_01_matcher<CharT>::to_string() -> std::string{return R"(^abc$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
-
-  std::array<char,3 + 1> str_tmp_0 {"abc"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_04_start_end::regex_03_matcher::to_string() -> std::string{return R"(^abc)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -650,10 +523,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -661,19 +535,126 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_04_start_end::regex_04_matcher::to_string() -> std::string{return R"(^abc$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_02_matcher<CharT>::to_string() -> std::string{return R"(^abc$)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+
+  std::array<char,3 + 1> str_tmp_0 {"abc"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_03_matcher<CharT>::to_string() -> std::string{return R"(^abc)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+
+  std::array<char,3 + 1> str_tmp_0 {"abc"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_04_matcher<CharT>::to_string() -> std::string{return R"(^abc$)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -702,10 +683,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -713,19 +695,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_04_start_end::regex_05_matcher::to_string() -> std::string{return R"(abc$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_05_matcher<CharT>::to_string() -> std::string{return R"(abc$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -754,10 +736,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -765,19 +748,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_04_start_end::regex_06_matcher::to_string() -> std::string{return R"(abc$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_06_matcher<CharT>::to_string() -> std::string{return R"(abc$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -792,10 +775,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -803,19 +787,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_04_start_end::regex_07_matcher::to_string() -> std::string{return R"(^)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_07_matcher<CharT>::to_string() -> std::string{return R"(^)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -830,10 +814,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -841,19 +826,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_04_start_end::regex_08_matcher::to_string() -> std::string{return R"($)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_08_matcher<CharT>::to_string() -> std::string{return R"($)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -882,10 +867,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -893,15 +879,121 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_04_start_end::regex_09_matcher::to_string() -> std::string{return R"($b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_09_matcher<CharT>::to_string() -> std::string{return R"($b)"; }
 
 
-#line 189 "pure2-regex_04_start_end.cpp2"
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_10_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"X"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_10_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"X"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_04_start_end::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_04_start_end::regex_10_matcher<CharT>::is_start_match() -> bool { return true; }
+template <typename CharT> [[nodiscard]] auto test_tests_04_start_end::regex_10_matcher<CharT>::to_string() -> std::string{return R"(\GX.*X)"; }
+
+
+#line 192 "pure2-regex_04_start_end.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_04_start_end());
 }

--- a/regression-tests/test-results/pure2-regex_05_classes.cpp
+++ b/regression-tests/test-results/pure2-regex_05_classes.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_05_classes.cpp2"
 
-#line 165 "pure2-regex_05_classes.cpp2"
+#line 166 "pure2-regex_05_classes.cpp2"
 class test_tests_05_classes;
   
 
@@ -18,37 +18,31 @@ class test_tests_05_classes;
 #line 1 "pure2-regex_05_classes.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_05_classes.cpp2"
+#line 113 "pure2-regex_05_classes.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_05_classes.cpp2"
+#line 125 "pure2-regex_05_classes.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_05_classes.cpp2"
+#line 166 "pure2-regex_05_classes.cpp2"
 class test_tests_05_classes {
 
-#line 185 "pure2-regex_05_classes.cpp2"
+#line 186 "pure2-regex_05_classes.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,25 +70,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -108,25 +90,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -134,25 +110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -160,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -186,25 +150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -212,25 +170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -238,25 +190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -264,25 +210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -290,25 +230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -316,25 +250,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -342,25 +270,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -368,25 +290,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -394,25 +310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -420,25 +330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -446,25 +350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -472,25 +370,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -498,25 +390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -524,13 +410,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; 
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; 
   public: test_tests_05_classes() = default;
   public: test_tests_05_classes(test_tests_05_classes const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_05_classes const&) -> void = delete;
 
 
-#line 208 "pure2-regex_05_classes.cpp2"
+#line 209 "pure2-regex_05_classes.cpp2"
 };
 auto main() -> int;
 
@@ -634,6 +520,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -649,7 +536,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_05_classes.cpp2"
+#line 113 "pure2-regex_05_classes.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -662,7 +549,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_05_classes.cpp2"
+#line 125 "pure2-regex_05_classes.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -703,7 +590,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 185 "pure2-regex_05_classes.cpp2"
+#line 186 "pure2-regex_05_classes.cpp2"
   auto test_tests_05_classes::run() const& -> void{
     std::cout << "Running tests_05_classes:" << std::endl;
     test(regex_01, "01", R"(a[bc]d)", "abc", "n", R"(-)", "-");
@@ -731,74 +618,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,1 + 1> str_tmp_0 {"a"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'b'>,::cpp2::regex::single_class_entry<char,'c'>>::match(r.pos, ctx))) {r.matched = false;break;}
-
-  std::array<char,1 + 1> str_tmp_1 {"d"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_05_classes::regex_01_matcher::to_string() -> std::string{return R"(a[bc]d)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -841,10 +661,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -852,19 +673,86 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_02_matcher::to_string() -> std::string{return R"(a[bc]d)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_01_matcher<CharT>::to_string() -> std::string{return R"(a[bc]d)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::class_token_matcher<char,false,false,::cpp2::regex::single_class_entry<char,'b'>,::cpp2::regex::single_class_entry<char,'c'>>::match(r.pos, ctx))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"d"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_02_matcher<CharT>::to_string() -> std::string{return R"(a[bc]d)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -907,10 +795,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -918,19 +807,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_03_matcher::to_string() -> std::string{return R"(a[b]d)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_03_matcher<CharT>::to_string() -> std::string{return R"(a[b]d)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -947,10 +836,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -958,19 +848,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_04_matcher::to_string() -> std::string{return R"([a][b][d])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_04_matcher<CharT>::to_string() -> std::string{return R"([a][b][d])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -987,10 +877,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -998,19 +889,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_05_matcher::to_string() -> std::string{return R"(.[b].)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_05_matcher<CharT>::to_string() -> std::string{return R"(.[b].)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1027,10 +918,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1038,19 +930,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_06_matcher::to_string() -> std::string{return R"(.[b].)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_06_matcher<CharT>::to_string() -> std::string{return R"(.[b].)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1093,10 +985,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1104,19 +997,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_07_matcher::to_string() -> std::string{return R"(a[b-d]e)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_07_matcher<CharT>::to_string() -> std::string{return R"(a[b-d]e)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1159,10 +1052,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1170,19 +1064,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_08_matcher::to_string() -> std::string{return R"(a[b-d]e)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_08_matcher<CharT>::to_string() -> std::string{return R"(a[b-d]e)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1211,10 +1105,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1222,19 +1117,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_09_matcher::to_string() -> std::string{return R"(a[b-d])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_09_matcher<CharT>::to_string() -> std::string{return R"(a[b-d])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1263,10 +1158,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1274,19 +1170,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_10_matcher::to_string() -> std::string{return R"(a[-b])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_10_matcher<CharT>::to_string() -> std::string{return R"(a[-b])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1315,10 +1211,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1326,19 +1223,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_11_matcher::to_string() -> std::string{return R"(a[b-])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_11_matcher<CharT>::to_string() -> std::string{return R"(a[b-])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1366,10 +1263,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1377,19 +1275,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_12_matcher::to_string() -> std::string{return R"(a])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_12_matcher<CharT>::to_string() -> std::string{return R"(a])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1432,10 +1330,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1443,19 +1342,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_13_matcher::to_string() -> std::string{return R"(a[]]b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_13_matcher<CharT>::to_string() -> std::string{return R"(a[]]b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1498,10 +1397,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1509,19 +1409,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_14_matcher::to_string() -> std::string{return R"(a[^bc]d)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_14_matcher<CharT>::to_string() -> std::string{return R"(a[^bc]d)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1564,10 +1464,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1575,19 +1476,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_15_matcher::to_string() -> std::string{return R"(a[^bc]d)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_15_matcher<CharT>::to_string() -> std::string{return R"(a[^bc]d)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1630,10 +1531,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1641,19 +1543,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_16_matcher::to_string() -> std::string{return R"(a[^-b]c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_16_matcher<CharT>::to_string() -> std::string{return R"(a[^-b]c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1696,10 +1598,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1707,19 +1610,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_17_matcher::to_string() -> std::string{return R"(a[^-b]c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_17_matcher<CharT>::to_string() -> std::string{return R"(a[^-b]c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1762,10 +1665,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1773,19 +1677,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_18_matcher::to_string() -> std::string{return R"(a[^]b]c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_18_matcher<CharT>::to_string() -> std::string{return R"(a[^]b]c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1828,10 +1732,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_05_classes::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1839,15 +1744,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_05_classes::regex_19_matcher::to_string() -> std::string{return R"(a[^]b]c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_05_classes::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_05_classes::regex_19_matcher<CharT>::to_string() -> std::string{return R"(a[^]b]c)"; }
 
 
-#line 209 "pure2-regex_05_classes.cpp2"
+#line 210 "pure2-regex_05_classes.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_05_classes());
 }

--- a/regression-tests/test-results/pure2-regex_06_boundaries.cpp
+++ b/regression-tests/test-results/pure2-regex_06_boundaries.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_06_boundaries.cpp2"
 
-#line 165 "pure2-regex_06_boundaries.cpp2"
+#line 166 "pure2-regex_06_boundaries.cpp2"
 class test_tests_06_boundaries;
   
 
@@ -18,37 +18,31 @@ class test_tests_06_boundaries;
 #line 1 "pure2-regex_06_boundaries.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_06_boundaries.cpp2"
+#line 113 "pure2-regex_06_boundaries.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_06_boundaries.cpp2"
+#line 125 "pure2-regex_06_boundaries.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_06_boundaries.cpp2"
+#line 166 "pure2-regex_06_boundaries.cpp2"
 class test_tests_06_boundaries {
 
-#line 183 "pure2-regex_06_boundaries.cpp2"
+#line 184 "pure2-regex_06_boundaries.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,25 +70,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -108,25 +90,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -134,25 +110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -160,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -186,25 +150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -212,25 +170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -238,25 +190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -264,25 +210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -290,25 +230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -316,25 +250,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -342,25 +270,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -368,25 +290,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -394,25 +310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -420,25 +330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -446,25 +350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -472,13 +370,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; 
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; 
   public: test_tests_06_boundaries() = default;
   public: test_tests_06_boundaries(test_tests_06_boundaries const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_06_boundaries const&) -> void = delete;
 
 
-#line 204 "pure2-regex_06_boundaries.cpp2"
+#line 205 "pure2-regex_06_boundaries.cpp2"
 };
 auto main() -> int;
 
@@ -582,6 +480,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -597,7 +496,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_06_boundaries.cpp2"
+#line 113 "pure2-regex_06_boundaries.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -610,7 +509,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_06_boundaries.cpp2"
+#line 125 "pure2-regex_06_boundaries.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -651,7 +550,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 183 "pure2-regex_06_boundaries.cpp2"
+#line 184 "pure2-regex_06_boundaries.cpp2"
   auto test_tests_06_boundaries::run() const& -> void{
     std::cout << "Running tests_06_boundaries:" << std::endl;
     test(regex_01, "01", R"(\ba\b)", "a-", "y", R"(-)", "-");
@@ -677,61 +576,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::word_boundary_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
-
-  std::array<char,1 + 1> str_tmp_0 {"a"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  if (!(cpp2::regex::word_boundary_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_06_boundaries::regex_01_matcher::to_string() -> std::string{return R"(\ba\b)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -761,10 +606,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -772,19 +618,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_02_matcher::to_string() -> std::string{return R"(\ba\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_01_matcher<CharT>::to_string() -> std::string{return R"(\ba\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -814,10 +660,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -825,19 +672,73 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_03_matcher::to_string() -> std::string{return R"(\ba\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_02_matcher<CharT>::to_string() -> std::string{return R"(\ba\b)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::word_boundary_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::word_boundary_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_03_matcher<CharT>::to_string() -> std::string{return R"(\ba\b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -867,10 +768,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -878,19 +780,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_04_matcher::to_string() -> std::string{return R"(\by\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_04_matcher<CharT>::to_string() -> std::string{return R"(\by\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -920,10 +822,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -931,19 +834,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_05_matcher::to_string() -> std::string{return R"(\by\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_05_matcher<CharT>::to_string() -> std::string{return R"(\by\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -973,10 +876,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -984,19 +888,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_06_matcher::to_string() -> std::string{return R"(\by\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_06_matcher<CharT>::to_string() -> std::string{return R"(\by\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1026,10 +930,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1037,19 +942,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_07_matcher::to_string() -> std::string{return R"(\Ba\B)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_07_matcher<CharT>::to_string() -> std::string{return R"(\Ba\B)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1079,10 +984,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1090,19 +996,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_08_matcher::to_string() -> std::string{return R"(\Ba\B)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_08_matcher<CharT>::to_string() -> std::string{return R"(\Ba\B)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1132,10 +1038,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1143,19 +1050,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_09_matcher::to_string() -> std::string{return R"(\Ba\B)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_09_matcher<CharT>::to_string() -> std::string{return R"(\Ba\B)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1185,10 +1092,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1196,19 +1104,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_10_matcher::to_string() -> std::string{return R"(\By\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_10_matcher<CharT>::to_string() -> std::string{return R"(\By\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1238,10 +1146,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1249,19 +1158,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_11_matcher::to_string() -> std::string{return R"(\By\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_11_matcher<CharT>::to_string() -> std::string{return R"(\By\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1291,10 +1200,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1302,19 +1212,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_12_matcher::to_string() -> std::string{return R"(\By\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_12_matcher<CharT>::to_string() -> std::string{return R"(\By\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1344,10 +1254,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1355,19 +1266,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_13_matcher::to_string() -> std::string{return R"(\By\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_13_matcher<CharT>::to_string() -> std::string{return R"(\By\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1397,10 +1308,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1408,19 +1320,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_14_matcher::to_string() -> std::string{return R"(\by\B)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_14_matcher<CharT>::to_string() -> std::string{return R"(\by\B)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1450,10 +1362,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1461,19 +1374,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_15_matcher::to_string() -> std::string{return R"(\By\B)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_15_matcher<CharT>::to_string() -> std::string{return R"(\By\B)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1488,10 +1401,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1499,19 +1413,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_16_matcher::to_string() -> std::string{return R"(\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_16_matcher<CharT>::to_string() -> std::string{return R"(\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1526,10 +1440,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_06_boundaries::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1537,15 +1452,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_06_boundaries::regex_17_matcher::to_string() -> std::string{return R"(\B)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_06_boundaries::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_06_boundaries::regex_17_matcher<CharT>::to_string() -> std::string{return R"(\B)"; }
 
 
-#line 205 "pure2-regex_06_boundaries.cpp2"
+#line 206 "pure2-regex_06_boundaries.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_06_boundaries());
 }

--- a/regression-tests/test-results/pure2-regex_07_short_classes.cpp
+++ b/regression-tests/test-results/pure2-regex_07_short_classes.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_07_short_classes.cpp2"
 
-#line 165 "pure2-regex_07_short_classes.cpp2"
+#line 166 "pure2-regex_07_short_classes.cpp2"
 class test_tests_07_short_classes;
   
 
@@ -18,37 +18,31 @@ class test_tests_07_short_classes;
 #line 1 "pure2-regex_07_short_classes.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_07_short_classes.cpp2"
+#line 113 "pure2-regex_07_short_classes.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_07_short_classes.cpp2"
+#line 125 "pure2-regex_07_short_classes.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_07_short_classes.cpp2"
+#line 166 "pure2-regex_07_short_classes.cpp2"
 class test_tests_07_short_classes {
 
-#line 190 "pure2-regex_07_short_classes.cpp2"
+#line 191 "pure2-regex_07_short_classes.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,25 +70,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -108,25 +90,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -134,25 +110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -160,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -186,25 +150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -212,25 +170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -238,25 +190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -264,25 +210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -290,25 +230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -316,25 +250,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -342,25 +270,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -368,25 +290,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -394,25 +310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -420,25 +330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -446,25 +350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -472,25 +370,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -498,25 +390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -524,25 +410,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -550,25 +430,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; public: class regex_21_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_21_matcher() = default;
         public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -576,25 +450,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_21_matcher> regex_21 {}; public: class regex_22_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_22_matcher() = default;
         public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -602,25 +470,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_22_matcher> regex_22 {}; public: class regex_23_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_23_matcher() = default;
         public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -628,25 +490,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_23_matcher> regex_23 {}; public: class regex_24_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_24_matcher() = default;
         public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -654,13 +510,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_24_matcher> regex_24 {}; 
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; 
   public: test_tests_07_short_classes() = default;
   public: test_tests_07_short_classes(test_tests_07_short_classes const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_07_short_classes const&) -> void = delete;
 
 
-#line 218 "pure2-regex_07_short_classes.cpp2"
+#line 219 "pure2-regex_07_short_classes.cpp2"
 };
 auto main() -> int;
 
@@ -764,6 +620,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -779,7 +636,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_07_short_classes.cpp2"
+#line 113 "pure2-regex_07_short_classes.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -792,7 +649,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_07_short_classes.cpp2"
+#line 125 "pure2-regex_07_short_classes.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -833,7 +690,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 190 "pure2-regex_07_short_classes.cpp2"
+#line 191 "pure2-regex_07_short_classes.cpp2"
   auto test_tests_07_short_classes::run() const& -> void{
     std::cout << "Running tests_07_short_classes:" << std::endl;
     test(regex_01, "01", R"(\w)", "a", "y", R"(-)", "-");
@@ -866,46 +723,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::named_class_word<char,false>::match(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_07_short_classes::regex_01_matcher::to_string() -> std::string{return R"(\w)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -920,10 +738,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -931,19 +750,58 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_02_matcher::to_string() -> std::string{return R"(\w)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_01_matcher<CharT>::to_string() -> std::string{return R"(\w)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::named_class_word<char,false>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_02_matcher<CharT>::to_string() -> std::string{return R"(\w)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -958,10 +816,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -969,19 +828,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_03_matcher::to_string() -> std::string{return R"(\W)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_03_matcher<CharT>::to_string() -> std::string{return R"(\W)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -996,10 +855,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1007,19 +867,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_04_matcher::to_string() -> std::string{return R"(\W)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_04_matcher<CharT>::to_string() -> std::string{return R"(\W)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1062,10 +922,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1073,19 +934,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_05_matcher::to_string() -> std::string{return R"(a\sb)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_05_matcher<CharT>::to_string() -> std::string{return R"(a\sb)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1128,10 +989,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1139,19 +1001,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_06_matcher::to_string() -> std::string{return R"(a\sb)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_06_matcher<CharT>::to_string() -> std::string{return R"(a\sb)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1194,10 +1056,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1205,19 +1068,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_07_matcher::to_string() -> std::string{return R"(a\Sb)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_07_matcher<CharT>::to_string() -> std::string{return R"(a\Sb)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1260,10 +1123,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1271,19 +1135,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_08_matcher::to_string() -> std::string{return R"(a\Sb)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_08_matcher<CharT>::to_string() -> std::string{return R"(a\Sb)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1298,10 +1162,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1309,19 +1174,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_09_matcher::to_string() -> std::string{return R"(\d)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_09_matcher<CharT>::to_string() -> std::string{return R"(\d)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1336,10 +1201,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1347,19 +1213,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_10_matcher::to_string() -> std::string{return R"(\d)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_10_matcher<CharT>::to_string() -> std::string{return R"(\d)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1374,10 +1240,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1385,19 +1252,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_11_matcher::to_string() -> std::string{return R"(\D)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_11_matcher<CharT>::to_string() -> std::string{return R"(\D)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1412,10 +1279,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1423,19 +1291,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_12_matcher::to_string() -> std::string{return R"(\D)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_12_matcher<CharT>::to_string() -> std::string{return R"(\D)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1450,10 +1318,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1461,19 +1330,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_13_matcher::to_string() -> std::string{return R"([\w])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_13_matcher<CharT>::to_string() -> std::string{return R"([\w])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1488,10 +1357,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1499,19 +1369,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_14_matcher::to_string() -> std::string{return R"([\w])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_14_matcher<CharT>::to_string() -> std::string{return R"([\w])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1526,10 +1396,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1537,19 +1408,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_15_matcher::to_string() -> std::string{return R"([\W])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_15_matcher<CharT>::to_string() -> std::string{return R"([\W])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1564,10 +1435,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1575,19 +1447,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_16_matcher::to_string() -> std::string{return R"([\W])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_16_matcher<CharT>::to_string() -> std::string{return R"([\W])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1630,10 +1502,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1641,19 +1514,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_17_matcher::to_string() -> std::string{return R"(a[\s]b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_17_matcher<CharT>::to_string() -> std::string{return R"(a[\s]b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1696,10 +1569,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1707,19 +1581,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_18_matcher::to_string() -> std::string{return R"(a[\s]b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_18_matcher<CharT>::to_string() -> std::string{return R"(a[\s]b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1762,10 +1636,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1773,19 +1648,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_19_matcher::to_string() -> std::string{return R"(a[\S]b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_19_matcher<CharT>::to_string() -> std::string{return R"(a[\S]b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1828,10 +1703,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1839,19 +1715,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_20_matcher::to_string() -> std::string{return R"(a[\S]b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_20_matcher<CharT>::to_string() -> std::string{return R"(a[\S]b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_21_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1866,10 +1742,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_21_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1877,19 +1754,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_21_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_21_matcher::to_string() -> std::string{return R"([\d])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_21_matcher<CharT>::to_string() -> std::string{return R"([\d])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_22_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1904,10 +1781,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_22_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1915,19 +1793,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_22_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_22_matcher::to_string() -> std::string{return R"([\d])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_22_matcher<CharT>::to_string() -> std::string{return R"([\d])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_23_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1942,10 +1820,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_23_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1953,19 +1832,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_23_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_23_matcher::to_string() -> std::string{return R"([\D])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_23_matcher<CharT>::to_string() -> std::string{return R"([\D])"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_24_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1980,10 +1859,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_24_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_07_short_classes::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1991,15 +1871,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_24_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_07_short_classes::regex_24_matcher::to_string() -> std::string{return R"([\D])"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_07_short_classes::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_07_short_classes::regex_24_matcher<CharT>::to_string() -> std::string{return R"([\D])"; }
 
 
-#line 219 "pure2-regex_07_short_classes.cpp2"
+#line 220 "pure2-regex_07_short_classes.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_07_short_classes());
 }

--- a/regression-tests/test-results/pure2-regex_08_alternatives.cpp
+++ b/regression-tests/test-results/pure2-regex_08_alternatives.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_08_alternatives.cpp2"
 
-#line 165 "pure2-regex_08_alternatives.cpp2"
+#line 166 "pure2-regex_08_alternatives.cpp2"
 class test_tests_08_alternatives;
   
 
@@ -18,52 +18,46 @@ class test_tests_08_alternatives;
 #line 1 "pure2-regex_08_alternatives.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_08_alternatives.cpp2"
+#line 113 "pure2-regex_08_alternatives.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_08_alternatives.cpp2"
+#line 125 "pure2-regex_08_alternatives.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_08_alternatives.cpp2"
+#line 166 "pure2-regex_08_alternatives.cpp2"
 class test_tests_08_alternatives {
 
-#line 168 "pure2-regex_08_alternatives.cpp2"
+#line 169 "pure2-regex_08_alternatives.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -71,40 +65,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -112,13 +100,13 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; 
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; 
   public: test_tests_08_alternatives() = default;
   public: test_tests_08_alternatives(test_tests_08_alternatives const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_08_alternatives const&) -> void = delete;
 
 
-#line 174 "pure2-regex_08_alternatives.cpp2"
+#line 175 "pure2-regex_08_alternatives.cpp2"
 };
 auto main() -> int;
 
@@ -222,6 +210,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -237,7 +226,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_08_alternatives.cpp2"
+#line 113 "pure2-regex_08_alternatives.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -250,7 +239,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_08_alternatives.cpp2"
+#line 125 "pure2-regex_08_alternatives.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -291,7 +280,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 168 "pure2-regex_08_alternatives.cpp2"
+#line 169 "pure2-regex_08_alternatives.cpp2"
   auto test_tests_08_alternatives::run() const& -> void{
     std::cout << "Running tests_08_alternatives:" << std::endl;
     test(regex_01, "01", R"(ab|cd)", "abc", "y", R"($&)", "ab");
@@ -302,127 +291,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_1 {"cd"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_3(), func_1(), cpp2::regex::no_reset(), func_2(), cpp2::regex::no_reset());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher::to_string() -> std::string{return R"(ab|cd)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -450,11 +319,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -482,11 +352,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -500,11 +371,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -518,10 +390,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -529,15 +402,139 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher::to_string() -> std::string{return R"(ab|cd)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_08_alternatives::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_01_matcher<CharT>::to_string() -> std::string{return R"(ab|cd)"; }
 
 
-#line 175 "pure2-regex_08_alternatives.cpp2"
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_1 {"cd"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_3(), func_1(), cpp2::regex::no_reset(), func_2(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_08_alternatives::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_08_alternatives::regex_02_matcher<CharT>::to_string() -> std::string{return R"(ab|cd)"; }
+
+
+#line 176 "pure2-regex_08_alternatives.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_08_alternatives());
 }

--- a/regression-tests/test-results/pure2-regex_09_groups.cpp
+++ b/regression-tests/test-results/pure2-regex_09_groups.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_09_groups.cpp2"
 
-#line 165 "pure2-regex_09_groups.cpp2"
+#line 166 "pure2-regex_09_groups.cpp2"
 class test_tests_09_groups;
   
 
@@ -18,37 +18,31 @@ class test_tests_09_groups;
 #line 1 "pure2-regex_09_groups.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_09_groups.cpp2"
+#line 113 "pure2-regex_09_groups.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_09_groups.cpp2"
+#line 125 "pure2-regex_09_groups.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_09_groups.cpp2"
+#line 166 "pure2-regex_09_groups.cpp2"
 class test_tests_09_groups {
 
-#line 177 "pure2-regex_09_groups.cpp2"
+#line 178 "pure2-regex_09_groups.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,25 +70,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -108,25 +90,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -134,25 +110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -160,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -186,25 +150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -212,25 +170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -238,25 +190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -264,25 +210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -290,25 +230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -316,13 +250,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; 
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; 
   public: test_tests_09_groups() = default;
   public: test_tests_09_groups(test_tests_09_groups const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_09_groups const&) -> void = delete;
 
 
-#line 192 "pure2-regex_09_groups.cpp2"
+#line 193 "pure2-regex_09_groups.cpp2"
 };
 auto main() -> int;
 
@@ -426,6 +360,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -441,7 +376,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_09_groups.cpp2"
+#line 113 "pure2-regex_09_groups.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -454,7 +389,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_09_groups.cpp2"
+#line 125 "pure2-regex_09_groups.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -495,7 +430,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 177 "pure2-regex_09_groups.cpp2"
+#line 178 "pure2-regex_09_groups.cpp2"
   auto test_tests_09_groups::run() const& -> void{
     std::cout << "Running tests_09_groups:" << std::endl;
     test(regex_01, "01", R"(()ef)", "def", "y", R"($&-$1)", "ef-");
@@ -515,72 +450,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_0_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
-  static_cast<void>(cpp2::move(tmp_0));
-
-  std::array<char,2 + 1> str_tmp_1 {"ef"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_09_groups::regex_01_matcher::to_string() -> std::string{return R"(()ef)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -621,10 +491,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -632,19 +503,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_02_matcher::to_string() -> std::string{return R"(()ef)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_01_matcher<CharT>::to_string() -> std::string{return R"(()ef)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -685,10 +556,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -696,19 +568,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_03_matcher::to_string() -> std::string{return R"(()ef)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_02_matcher<CharT>::to_string() -> std::string{return R"(()ef)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -749,10 +621,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -760,19 +633,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_04_matcher::to_string() -> std::string{return R"(()ef)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_03_matcher<CharT>::to_string() -> std::string{return R"(()ef)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -813,10 +686,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -824,19 +698,84 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_05_matcher::to_string() -> std::string{return R"(()ef)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_04_matcher<CharT>::to_string() -> std::string{return R"(()ef)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+
+  std::array<char,2 + 1> str_tmp_1 {"ef"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_05_matcher<CharT>::to_string() -> std::string{return R"(()ef)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -890,10 +829,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -901,19 +841,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_06_matcher::to_string() -> std::string{return R"(((a)))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_06_matcher<CharT>::to_string() -> std::string{return R"(((a)))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -967,10 +907,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -978,19 +919,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_07_matcher::to_string() -> std::string{return R"(((a)))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_07_matcher<CharT>::to_string() -> std::string{return R"(((a)))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1044,10 +985,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1055,19 +997,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_08_matcher::to_string() -> std::string{return R"(((a)))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_08_matcher<CharT>::to_string() -> std::string{return R"(((a)))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1149,10 +1091,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1160,19 +1103,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_09_matcher::to_string() -> std::string{return R"((a)b(c))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_09_matcher<CharT>::to_string() -> std::string{return R"((a)b(c))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1254,10 +1197,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1265,19 +1209,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_10_matcher::to_string() -> std::string{return R"((a)b(c))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_10_matcher<CharT>::to_string() -> std::string{return R"((a)b(c))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1359,10 +1303,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_09_groups::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1370,15 +1315,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_09_groups::regex_11_matcher::to_string() -> std::string{return R"((a)b(c))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_09_groups::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_09_groups::regex_11_matcher<CharT>::to_string() -> std::string{return R"((a)b(c))"; }
 
 
-#line 193 "pure2-regex_09_groups.cpp2"
+#line 194 "pure2-regex_09_groups.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_09_groups());
 }

--- a/regression-tests/test-results/pure2-regex_10_escapes.cpp
+++ b/regression-tests/test-results/pure2-regex_10_escapes.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_10_escapes.cpp2"
 
-#line 165 "pure2-regex_10_escapes.cpp2"
+#line 166 "pure2-regex_10_escapes.cpp2"
 class test_tests_10_escapes;
   
 
@@ -18,37 +18,31 @@ class test_tests_10_escapes;
 #line 1 "pure2-regex_10_escapes.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_10_escapes.cpp2"
+#line 113 "pure2-regex_10_escapes.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_10_escapes.cpp2"
+#line 125 "pure2-regex_10_escapes.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_10_escapes.cpp2"
+#line 166 "pure2-regex_10_escapes.cpp2"
 class test_tests_10_escapes {
 
-#line 186 "pure2-regex_10_escapes.cpp2"
+#line 187 "pure2-regex_10_escapes.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,35 +50,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -92,35 +80,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -128,25 +110,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -154,35 +130,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -190,35 +160,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -226,35 +190,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -262,25 +220,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -288,25 +240,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -314,25 +260,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -340,35 +280,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -376,35 +310,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -412,35 +340,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -448,25 +370,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -474,25 +390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -500,25 +410,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -526,25 +430,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -552,25 +450,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -578,25 +470,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -604,25 +490,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -630,13 +510,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; 
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; 
   public: test_tests_10_escapes() = default;
   public: test_tests_10_escapes(test_tests_10_escapes const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_10_escapes const&) -> void = delete;
 
 
-#line 210 "pure2-regex_10_escapes.cpp2"
+#line 211 "pure2-regex_10_escapes.cpp2"
 };
 auto main() -> int;
 
@@ -740,6 +620,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -755,7 +636,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_10_escapes.cpp2"
+#line 113 "pure2-regex_10_escapes.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -768,7 +649,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_10_escapes.cpp2"
+#line 125 "pure2-regex_10_escapes.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -809,7 +690,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 186 "pure2-regex_10_escapes.cpp2"
+#line 187 "pure2-regex_10_escapes.cpp2"
   auto test_tests_10_escapes::run() const& -> void{
     std::cout << "Running tests_10_escapes:" << std::endl;
     test(regex_01, "01", R"(a\(b)", "a(b", "y", R"($&-$1)", "a(b-");
@@ -838,8 +719,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -867,10 +747,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -878,19 +759,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_01_matcher::to_string() -> std::string{return R"(a\(b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_01_matcher<CharT>::to_string() -> std::string{return R"(a\(b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -918,11 +799,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -950,11 +832,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -982,10 +865,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -993,19 +877,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher::to_string() -> std::string{return R"(a\(*b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_02_matcher<CharT>::to_string() -> std::string{return R"(a\(*b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1033,11 +917,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1065,11 +950,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1097,10 +983,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1108,19 +995,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher::to_string() -> std::string{return R"(a\(*b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_03_matcher<CharT>::to_string() -> std::string{return R"(a\(*b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1148,10 +1035,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1159,19 +1047,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_04_matcher::to_string() -> std::string{return R"(a\\b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_04_matcher<CharT>::to_string() -> std::string{return R"(a\\b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1186,11 +1074,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1219,11 +1108,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1263,10 +1153,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1274,19 +1165,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher::to_string() -> std::string{return R"(foo(\h+)bar)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_05_matcher<CharT>::to_string() -> std::string{return R"(foo(\h+)bar)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1301,11 +1192,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1320,11 +1212,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1364,10 +1257,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1375,19 +1269,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher::to_string() -> std::string{return R"((\H+)(\h))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_06_matcher<CharT>::to_string() -> std::string{return R"((\H+)(\h))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1402,11 +1296,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1421,11 +1316,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1465,10 +1361,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1476,19 +1373,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher::to_string() -> std::string{return R"((\h+)(\H))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_07_matcher<CharT>::to_string() -> std::string{return R"((\h+)(\H))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1544,10 +1441,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1555,19 +1453,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_08_matcher::to_string() -> std::string{return R"(foo(\h)bar)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_08_matcher<CharT>::to_string() -> std::string{return R"(foo(\h)bar)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1609,10 +1507,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1620,19 +1519,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_09_matcher::to_string() -> std::string{return R"((\H)(\h))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_09_matcher<CharT>::to_string() -> std::string{return R"((\H)(\h))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1674,10 +1573,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1685,19 +1585,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_10_matcher::to_string() -> std::string{return R"((\h)(\H))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_10_matcher<CharT>::to_string() -> std::string{return R"((\h)(\H))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1712,11 +1612,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1745,11 +1646,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1789,10 +1691,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1800,19 +1703,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher::to_string() -> std::string{return R"(foo(\v+)bar)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_11_matcher<CharT>::to_string() -> std::string{return R"(foo(\v+)bar)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1827,11 +1730,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1846,11 +1750,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1890,10 +1795,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1901,19 +1807,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher::to_string() -> std::string{return R"((\V+)(\v))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_12_matcher<CharT>::to_string() -> std::string{return R"((\V+)(\v))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1928,11 +1834,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1947,11 +1854,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1991,10 +1899,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2002,19 +1911,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher::to_string() -> std::string{return R"((\v+)(\V))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_13_matcher<CharT>::to_string() -> std::string{return R"((\v+)(\V))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2070,10 +1979,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2081,19 +1991,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_14_matcher::to_string() -> std::string{return R"(foo(\v)bar)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_14_matcher<CharT>::to_string() -> std::string{return R"(foo(\v)bar)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2135,10 +2045,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2146,19 +2057,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_15_matcher::to_string() -> std::string{return R"((\V)(\v))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_15_matcher<CharT>::to_string() -> std::string{return R"((\V)(\v))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2200,10 +2111,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2211,19 +2123,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_16_matcher::to_string() -> std::string{return R"((\v)(\V))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_16_matcher<CharT>::to_string() -> std::string{return R"((\v)(\V))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2251,10 +2163,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2262,19 +2175,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_17_matcher::to_string() -> std::string{return R"(foo\t\n\r\f\a\ebar)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_17_matcher<CharT>::to_string() -> std::string{return R"(foo\t\n\r\f\a\ebar)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2317,10 +2230,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2328,19 +2242,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_18_matcher::to_string() -> std::string{return R"(foo\Kbar)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_18_matcher<CharT>::to_string() -> std::string{return R"(foo\Kbar)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2368,10 +2282,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2379,19 +2294,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_19_matcher::to_string() -> std::string{return R"(\x41\x42)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_19_matcher<CharT>::to_string() -> std::string{return R"(\x41\x42)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2419,10 +2334,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_10_escapes::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2430,15 +2346,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_10_escapes::regex_20_matcher::to_string() -> std::string{return R"(\101\o{102})"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_10_escapes::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_10_escapes::regex_20_matcher<CharT>::to_string() -> std::string{return R"(\101\o{102})"; }
 
 
-#line 211 "pure2-regex_10_escapes.cpp2"
+#line 212 "pure2-regex_10_escapes.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_10_escapes());
 }

--- a/regression-tests/test-results/pure2-regex_11_group_references.cpp
+++ b/regression-tests/test-results/pure2-regex_11_group_references.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_11_group_references.cpp2"
 
-#line 165 "pure2-regex_11_group_references.cpp2"
+#line 166 "pure2-regex_11_group_references.cpp2"
 class test_tests_11_group_references;
   
 
@@ -18,37 +18,31 @@ class test_tests_11_group_references;
 #line 1 "pure2-regex_11_group_references.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_11_group_references.cpp2"
+#line 113 "pure2-regex_11_group_references.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_11_group_references.cpp2"
+#line 125 "pure2-regex_11_group_references.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_11_group_references.cpp2"
+#line 166 "pure2-regex_11_group_references.cpp2"
 class test_tests_11_group_references {
 
-#line 190 "pure2-regex_11_group_references.cpp2"
+#line 191 "pure2-regex_11_group_references.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,5>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,5>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,45 +70,39 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,5>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,5>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -128,25 +110,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -154,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -180,25 +150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -206,25 +170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -232,25 +190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -258,25 +210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -284,45 +230,39 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -330,25 +270,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -356,25 +290,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -382,25 +310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -408,25 +330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -434,25 +350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -460,25 +370,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -486,25 +390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -512,25 +410,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -538,25 +430,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -564,25 +450,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -590,45 +470,39 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; public: class regex_21_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_21_matcher() = default;
         public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -636,45 +510,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_21_matcher> regex_21 {}; public: class regex_22_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_22_matcher() = default;
         public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -682,45 +550,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_22_matcher> regex_22 {}; public: class regex_23_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_23_matcher() = default;
         public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -728,45 +590,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_23_matcher> regex_23 {}; public: class regex_24_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_24_matcher() = default;
         public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -774,13 +630,13 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_24_matcher> regex_24 {}; 
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; 
   public: test_tests_11_group_references() = default;
   public: test_tests_11_group_references(test_tests_11_group_references const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_11_group_references const&) -> void = delete;
 
 
-#line 218 "pure2-regex_11_group_references.cpp2"
+#line 219 "pure2-regex_11_group_references.cpp2"
 };
 auto main() -> int;
 
@@ -884,6 +740,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -899,7 +756,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_11_group_references.cpp2"
+#line 113 "pure2-regex_11_group_references.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -912,7 +769,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_11_group_references.cpp2"
+#line 125 "pure2-regex_11_group_references.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -953,7 +810,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 190 "pure2-regex_11_group_references.cpp2"
+#line 191 "pure2-regex_11_group_references.cpp2"
   auto test_tests_11_group_references::run() const& -> void{
     std::cout << "Running tests_11_group_references:" << std::endl;
     test(regex_01, "01", R"((foo)(\g-2))", "foofoo", "y", R"($1-$2)", "foo-foo");
@@ -986,8 +843,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1019,7 +875,7 @@ int i{0};
   auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
   static_cast<void>(cpp2::move(tmp_1));
   ctx.set_group_start(2, r.pos);
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   ctx.set_group_end(2, r.pos);
 
   auto tmp_2_func {
@@ -1042,10 +898,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1053,19 +910,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_01_matcher::to_string() -> std::string{return R"((foo)(\g-2))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_01_matcher<CharT>::to_string() -> std::string{return R"((foo)(\g-2))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1097,7 +954,7 @@ int i{0};
   auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
   static_cast<void>(cpp2::move(tmp_1));
   ctx.set_group_start(2, r.pos);
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   ctx.set_group_end(2, r.pos);
 
   auto tmp_2_func {
@@ -1138,7 +995,7 @@ int i{0};
   auto tmp_4 {cpp2::regex::make_on_return(cpp2::move(tmp_4_func))}; 
   static_cast<void>(cpp2::move(tmp_4));
   ctx.set_group_start(4, r.pos);
-  if (!(cpp2::regex::group_ref_token_matcher<char,3,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,3,false,false>(r.pos, ctx))) {r.matched = false;break;}
   ctx.set_group_end(4, r.pos);
 
   auto tmp_5_func {
@@ -1161,10 +1018,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1172,19 +1030,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_02_matcher::to_string() -> std::string{return R"((foo)(\g-2)(foo)(\g-2))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_02_matcher<CharT>::to_string() -> std::string{return R"((foo)(\g-2)(foo)(\g-2))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1199,11 +1057,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1219,11 +1078,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1238,11 +1098,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1272,7 +1133,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,2,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,2,false,false>(r.pos, ctx))) {r.matched = false;break;}
   ctx.set_group_end(1, r.pos);
 
   auto tmp_2_func {
@@ -1297,11 +1158,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1331,7 +1193,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,4,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,4,false,false>(r.pos, ctx))) {r.matched = false;break;}
   ctx.set_group_end(3, r.pos);
 
   auto tmp_5_func {
@@ -1354,10 +1216,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1365,19 +1228,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher::to_string() -> std::string{return R"((([abc]+) \g-1)(([abc]+) \g{-1}))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_03_matcher<CharT>::to_string() -> std::string{return R"((([abc]+) \g-1)(([abc]+) \g{-1}))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1462,9 +1325,9 @@ int i{0};
 
   auto tmp_5 {cpp2::regex::make_on_return(cpp2::move(tmp_5_func))}; 
   static_cast<void>(cpp2::move(tmp_5));
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,2,false>(r.pos, ctx))) {r.matched = false;break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,3,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,2,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,3,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -1475,10 +1338,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1486,97 +1350,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_04_matcher::to_string() -> std::string{return R"((a)(b)(c)\g1\g2\g3)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_04_matcher<CharT>::to_string() -> std::string{return R"((a)(b)(c)\g1\g2\g3)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_1_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
-  static_cast<void>(cpp2::move(tmp_1));
-
-  std::array<char,1 + 1> str_tmp_2 {" "}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  if (name == "n") {return 1; }else {return -1; }
-  }
-
-  [[nodiscard]] auto test_tests_11_group_references::regex_05_matcher::to_string() -> std::string{return R"(/(?'n'foo) \g{n}/)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1621,7 +1407,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -1632,10 +1418,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1643,18 +1430,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "n") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_06_matcher::to_string() -> std::string{return R"(/(?'n'foo) \g{ n }/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_05_matcher<CharT>::to_string() -> std::string{return R"(/(?'n'foo) \g{n}/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1699,7 +1486,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -1710,10 +1497,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1721,18 +1509,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "n") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_07_matcher::to_string() -> std::string{return R"(/(?'n'foo) \g{n}/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_06_matcher<CharT>::to_string() -> std::string{return R"(/(?'n'foo) \g{ n }/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1777,7 +1565,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -1788,10 +1576,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1799,18 +1588,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "n") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_08_matcher::to_string() -> std::string{return R"(/(?<n>foo) \g{n}/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_07_matcher<CharT>::to_string() -> std::string{return R"(/(?'n'foo) \g{n}/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1855,7 +1644,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -1866,10 +1655,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1877,18 +1667,97 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "n") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_09_matcher::to_string() -> std::string{return R"(/(?<n>foo) \g{n}/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_08_matcher<CharT>::to_string() -> std::string{return R"(/(?<n>foo) \g{n}/)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_1_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
+  static_cast<void>(cpp2::move(tmp_1));
+
+  std::array<char,1 + 1> str_tmp_2 {" "}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  if (name == "n") {return 1; }else {return -1; }
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_09_matcher<CharT>::to_string() -> std::string{return R"(/(?<n>foo) \g{n}/)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1903,11 +1772,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1963,11 +1833,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1982,11 +1853,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2016,7 +1888,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
 
   std::array<char,1 + 1> str_tmp_5 {" "}; 
   if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
@@ -2042,11 +1914,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2072,10 +1945,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2083,18 +1957,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "as") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher::to_string() -> std::string{return R"(/(?<as>as) (\w+) \g{as} (\w+)/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_10_matcher<CharT>::to_string() -> std::string{return R"(/(?<as>as) (\w+) \g{as} (\w+)/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2139,7 +2013,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -2150,10 +2024,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2161,18 +2036,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "n") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_11_matcher::to_string() -> std::string{return R"(/(?'n'foo) \k<n>/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_11_matcher<CharT>::to_string() -> std::string{return R"(/(?'n'foo) \k<n>/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2217,7 +2092,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -2228,10 +2103,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2239,18 +2115,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "n") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_12_matcher::to_string() -> std::string{return R"(/(?'n'foo) \k<n>/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_12_matcher<CharT>::to_string() -> std::string{return R"(/(?'n'foo) \k<n>/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2295,7 +2171,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -2306,10 +2182,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2317,18 +2194,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "n") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_13_matcher::to_string() -> std::string{return R"(/(?<n>foo) \k'n'/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_13_matcher<CharT>::to_string() -> std::string{return R"(/(?<n>foo) \k'n'/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2373,7 +2250,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -2384,10 +2261,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2395,18 +2273,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "n") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_14_matcher::to_string() -> std::string{return R"(/(?<n>foo) \k'n'/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_14_matcher<CharT>::to_string() -> std::string{return R"(/(?<n>foo) \k'n'/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2451,7 +2329,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -2462,10 +2340,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2473,18 +2352,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "a1") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_15_matcher::to_string() -> std::string{return R"(/(?'a1'foo) \k'a1'/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_15_matcher<CharT>::to_string() -> std::string{return R"(/(?'a1'foo) \k'a1'/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2529,7 +2408,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -2540,10 +2419,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2551,18 +2431,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "a1") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_16_matcher::to_string() -> std::string{return R"(/(?<a1>foo) \k<a1>/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_16_matcher<CharT>::to_string() -> std::string{return R"(/(?<a1>foo) \k<a1>/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2607,7 +2487,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -2618,10 +2498,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2629,18 +2510,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "_") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_17_matcher::to_string() -> std::string{return R"(/(?'_'foo) \k'_'/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_17_matcher<CharT>::to_string() -> std::string{return R"(/(?'_'foo) \k'_'/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2685,7 +2566,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -2696,10 +2577,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2707,96 +2589,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "_") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_18_matcher::to_string() -> std::string{return R"(/(?<_>foo) \k<_>/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_18_matcher<CharT>::to_string() -> std::string{return R"(/(?<_>foo) \k<_>/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_1_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
-  static_cast<void>(cpp2::move(tmp_1));
-
-  std::array<char,1 + 1> str_tmp_2 {" "}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  if (name == "_0_") {return 1; }else {return -1; }
-  }
-
-  [[nodiscard]] auto test_tests_11_group_references::regex_19_matcher::to_string() -> std::string{return R"(/(?'_0_'foo) \k'_0_'/)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2841,7 +2645,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -2852,10 +2656,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2863,18 +2668,97 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "_0_") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_20_matcher::to_string() -> std::string{return R"(/(?<_0_>foo) \k<_0_>/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_19_matcher<CharT>::to_string() -> std::string{return R"(/(?'_0_'foo) \k'_0_'/)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_1_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
+  static_cast<void>(cpp2::move(tmp_1));
+
+  std::array<char,1 + 1> str_tmp_2 {" "}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  if (name == "_0_") {return 1; }else {return -1; }
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_20_matcher<CharT>::to_string() -> std::string{return R"(/(?<_0_>foo) \k<_0_>/)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2889,11 +2773,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2949,11 +2834,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2968,11 +2854,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3002,7 +2889,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
 
   std::array<char,1 + 1> str_tmp_5 {" "}; 
   if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
@@ -3028,11 +2915,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3058,10 +2946,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3069,18 +2958,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "as") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher::to_string() -> std::string{return R"(/(?<as>as) (\w+) \k<as> (\w+)/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_21_matcher<CharT>::to_string() -> std::string{return R"(/(?<as>as) (\w+) \k<as> (\w+)/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3095,11 +2984,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3155,11 +3045,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3174,11 +3065,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3208,7 +3100,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
 
   std::array<char,1 + 1> str_tmp_5 {" "}; 
   if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
@@ -3234,11 +3126,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3264,10 +3157,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3275,18 +3169,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "as") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher::to_string() -> std::string{return R"(/(?<as>as) (\w+) \k{as} (\w+)/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_22_matcher<CharT>::to_string() -> std::string{return R"(/(?<as>as) (\w+) \k{as} (\w+)/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3301,11 +3195,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3361,11 +3256,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3380,11 +3276,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3414,7 +3311,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
 
   std::array<char,1 + 1> str_tmp_5 {" "}; 
   if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
@@ -3440,11 +3337,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3470,10 +3368,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3481,18 +3380,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "as") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher::to_string() -> std::string{return R"(/(?<as>as) (\w+) \k'as' (\w+)/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_23_matcher<CharT>::to_string() -> std::string{return R"(/(?<as>as) (\w+) \k'as' (\w+)/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3507,11 +3406,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3567,11 +3467,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3586,11 +3487,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3620,7 +3522,7 @@ int i{0};
 }
   if (r.matched) {r.pos += 1;}
   else {break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
 
   std::array<char,1 + 1> str_tmp_5 {" "}; 
   if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
@@ -3646,11 +3548,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3676,10 +3579,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3687,14 +3591,15 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "as") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher::to_string() -> std::string{return R"(/(?<as>as) (\w+) \k{ as } (\w+)/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_11_group_references::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_11_group_references::regex_24_matcher<CharT>::to_string() -> std::string{return R"(/(?<as>as) (\w+) \k{ as } (\w+)/)"; }
 
 
-#line 219 "pure2-regex_11_group_references.cpp2"
+#line 220 "pure2-regex_11_group_references.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_11_group_references());
 }

--- a/regression-tests/test-results/pure2-regex_12_case_insensitive.cpp
+++ b/regression-tests/test-results/pure2-regex_12_case_insensitive.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_12_case_insensitive.cpp2"
 
-#line 165 "pure2-regex_12_case_insensitive.cpp2"
+#line 166 "pure2-regex_12_case_insensitive.cpp2"
 class test_tests_12_case_insensitive;
   
 
@@ -18,37 +18,31 @@ class test_tests_12_case_insensitive;
 #line 1 "pure2-regex_12_case_insensitive.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_12_case_insensitive.cpp2"
+#line 113 "pure2-regex_12_case_insensitive.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_12_case_insensitive.cpp2"
+#line 125 "pure2-regex_12_case_insensitive.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_12_case_insensitive.cpp2"
+#line 166 "pure2-regex_12_case_insensitive.cpp2"
 class test_tests_12_case_insensitive {
 
-#line 285 "pure2-regex_12_case_insensitive.cpp2"
+#line 286 "pure2-regex_12_case_insensitive.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,25 +70,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -108,25 +90,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -134,25 +110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -160,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -186,35 +150,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -222,35 +180,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -258,35 +210,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -294,35 +240,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -330,35 +270,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_100_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_100_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_100_matcher() = default;
         public: regex_100_matcher(regex_100_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -366,36 +300,35 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_100_matcher> regex_100 {}; public: class regex_101_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_100_matcher<char>> regex_100 {}; public: template<typename CharT> class regex_101_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -405,31 +338,26 @@ public: class func_3 {
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_101_matcher() = default;
         public: regex_101_matcher(regex_101_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -437,66 +365,65 @@ public: class func_3 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_101_matcher> regex_101 {}; public: class regex_102_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_101_matcher<char>> regex_101 {}; public: template<typename CharT> class regex_102_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_10 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_11 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_12 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -506,26 +433,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_13 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_102_matcher() = default;
         public: regex_102_matcher(regex_102_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -533,66 +455,65 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_102_matcher> regex_102 {}; public: class regex_103_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_102_matcher<char>> regex_102 {}; public: template<typename CharT> class regex_103_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_10 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_11 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_12 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -602,26 +523,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_13 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_103_matcher() = default;
         public: regex_103_matcher(regex_103_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -629,66 +545,65 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_103_matcher> regex_103 {}; public: class regex_104_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_103_matcher<char>> regex_103 {}; public: template<typename CharT> class regex_104_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_10 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_11 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_12 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -698,26 +613,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_13 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_104_matcher() = default;
         public: regex_104_matcher(regex_104_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -725,66 +635,65 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_104_matcher> regex_104 {}; public: class regex_105_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_104_matcher<char>> regex_104 {}; public: template<typename CharT> class regex_105_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_10 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_11 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_12 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -794,26 +703,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_13 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_105_matcher() = default;
         public: regex_105_matcher(regex_105_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -821,66 +725,65 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_105_matcher> regex_105 {}; public: class regex_106_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_105_matcher<char>> regex_105 {}; public: template<typename CharT> class regex_106_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_10 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_11 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_12 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -890,26 +793,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_13 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_106_matcher() = default;
         public: regex_106_matcher(regex_106_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -917,25 +815,19 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_106_matcher> regex_106 {}; public: class regex_107_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,11>;
+  public: cpp2::regex::regular_expression<char,regex_106_matcher<char>> regex_106 {}; public: template<typename CharT> class regex_107_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,11>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_107_matcher() = default;
         public: regex_107_matcher(regex_107_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -943,25 +835,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_107_matcher> regex_107 {}; public: class regex_108_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,11>;
+  public: cpp2::regex::regular_expression<char,regex_107_matcher<char>> regex_107 {}; public: template<typename CharT> class regex_108_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,11>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_108_matcher() = default;
         public: regex_108_matcher(regex_108_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -969,25 +855,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_108_matcher> regex_108 {}; public: class regex_109_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,10>;
+  public: cpp2::regex::regular_expression<char,regex_108_matcher<char>> regex_108 {}; public: template<typename CharT> class regex_109_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,10>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_109_matcher() = default;
         public: regex_109_matcher(regex_109_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -995,35 +875,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_109_matcher> regex_109 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_109_matcher<char>> regex_109 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1031,25 +905,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_110_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_110_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_110_matcher() = default;
         public: regex_110_matcher(regex_110_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1057,25 +925,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_110_matcher> regex_110 {}; public: class regex_111_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_110_matcher<char>> regex_110 {}; public: template<typename CharT> class regex_111_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_111_matcher() = default;
         public: regex_111_matcher(regex_111_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1083,45 +945,39 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_111_matcher> regex_111 {}; public: class regex_112_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_111_matcher<char>> regex_111 {}; public: template<typename CharT> class regex_112_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_112_matcher() = default;
         public: regex_112_matcher(regex_112_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1129,45 +985,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_112_matcher> regex_112 {}; public: class regex_113_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_112_matcher<char>> regex_112 {}; public: template<typename CharT> class regex_113_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_113_matcher() = default;
         public: regex_113_matcher(regex_113_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1175,25 +1025,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_113_matcher> regex_113 {}; public: class regex_114_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_113_matcher<char>> regex_113 {}; public: template<typename CharT> class regex_114_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_114_matcher() = default;
         public: regex_114_matcher(regex_114_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1201,25 +1045,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_114_matcher> regex_114 {}; public: class regex_115_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_114_matcher<char>> regex_114 {}; public: template<typename CharT> class regex_115_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_115_matcher() = default;
         public: regex_115_matcher(regex_115_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1227,25 +1065,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_115_matcher> regex_115 {}; public: class regex_116_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_115_matcher<char>> regex_115 {}; public: template<typename CharT> class regex_116_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_116_matcher() = default;
         public: regex_116_matcher(regex_116_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1253,35 +1085,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_116_matcher> regex_116 {}; public: class regex_117_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_116_matcher<char>> regex_116 {}; public: template<typename CharT> class regex_117_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_117_matcher() = default;
         public: regex_117_matcher(regex_117_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1289,25 +1115,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_117_matcher> regex_117 {}; public: class regex_118_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_117_matcher<char>> regex_117 {}; public: template<typename CharT> class regex_118_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_118_matcher() = default;
         public: regex_118_matcher(regex_118_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1315,35 +1135,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_118_matcher> regex_118 {}; public: class regex_119_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_118_matcher<char>> regex_118 {}; public: template<typename CharT> class regex_119_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_119_matcher() = default;
         public: regex_119_matcher(regex_119_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1351,35 +1165,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_119_matcher> regex_119 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_119_matcher<char>> regex_119 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1387,35 +1195,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1423,35 +1225,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1459,35 +1255,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1495,35 +1285,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1531,35 +1315,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1567,35 +1345,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1603,35 +1375,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1639,35 +1405,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1675,35 +1435,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; public: class regex_21_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_21_matcher() = default;
         public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1711,35 +1465,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_21_matcher> regex_21 {}; public: class regex_22_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_22_matcher() = default;
         public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1747,35 +1495,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_22_matcher> regex_22 {}; public: class regex_23_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_23_matcher() = default;
         public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1783,35 +1525,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_23_matcher> regex_23 {}; public: class regex_24_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_24_matcher() = default;
         public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1819,35 +1555,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_24_matcher> regex_24 {}; public: class regex_25_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; public: template<typename CharT> class regex_25_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_25_matcher() = default;
         public: regex_25_matcher(regex_25_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1855,35 +1585,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_25_matcher> regex_25 {}; public: class regex_26_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_25_matcher<char>> regex_25 {}; public: template<typename CharT> class regex_26_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_26_matcher() = default;
         public: regex_26_matcher(regex_26_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1891,25 +1615,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_26_matcher> regex_26 {}; public: class regex_27_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_26_matcher<char>> regex_26 {}; public: template<typename CharT> class regex_27_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_27_matcher() = default;
         public: regex_27_matcher(regex_27_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1917,25 +1635,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_27_matcher> regex_27 {}; public: class regex_28_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_27_matcher<char>> regex_27 {}; public: template<typename CharT> class regex_28_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_28_matcher() = default;
         public: regex_28_matcher(regex_28_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1943,25 +1655,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_28_matcher> regex_28 {}; public: class regex_29_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_28_matcher<char>> regex_28 {}; public: template<typename CharT> class regex_29_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_29_matcher() = default;
         public: regex_29_matcher(regex_29_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1969,25 +1675,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_29_matcher> regex_29 {}; public: class regex_30_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_29_matcher<char>> regex_29 {}; public: template<typename CharT> class regex_30_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_30_matcher() = default;
         public: regex_30_matcher(regex_30_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1995,25 +1695,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_30_matcher> regex_30 {}; public: class regex_31_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_30_matcher<char>> regex_30 {}; public: template<typename CharT> class regex_31_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_31_matcher() = default;
         public: regex_31_matcher(regex_31_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2021,25 +1715,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_31_matcher> regex_31 {}; public: class regex_32_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_31_matcher<char>> regex_31 {}; public: template<typename CharT> class regex_32_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_32_matcher() = default;
         public: regex_32_matcher(regex_32_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2047,25 +1735,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_32_matcher> regex_32 {}; public: class regex_33_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_32_matcher<char>> regex_32 {}; public: template<typename CharT> class regex_33_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_33_matcher() = default;
         public: regex_33_matcher(regex_33_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2073,25 +1755,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_33_matcher> regex_33 {}; public: class regex_34_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_33_matcher<char>> regex_33 {}; public: template<typename CharT> class regex_34_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_34_matcher() = default;
         public: regex_34_matcher(regex_34_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2099,25 +1775,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_34_matcher> regex_34 {}; public: class regex_35_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_34_matcher<char>> regex_34 {}; public: template<typename CharT> class regex_35_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_35_matcher() = default;
         public: regex_35_matcher(regex_35_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2125,25 +1795,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_35_matcher> regex_35 {}; public: class regex_36_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_35_matcher<char>> regex_35 {}; public: template<typename CharT> class regex_36_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_36_matcher() = default;
         public: regex_36_matcher(regex_36_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2151,35 +1815,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_36_matcher> regex_36 {}; public: class regex_37_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_36_matcher<char>> regex_36 {}; public: template<typename CharT> class regex_37_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_37_matcher() = default;
         public: regex_37_matcher(regex_37_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2187,35 +1845,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_37_matcher> regex_37 {}; public: class regex_38_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_37_matcher<char>> regex_37 {}; public: template<typename CharT> class regex_38_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_38_matcher() = default;
         public: regex_38_matcher(regex_38_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2223,25 +1875,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_38_matcher> regex_38 {}; public: class regex_39_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_38_matcher<char>> regex_38 {}; public: template<typename CharT> class regex_39_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_39_matcher() = default;
         public: regex_39_matcher(regex_39_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2249,25 +1895,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_39_matcher> regex_39 {}; public: class regex_40_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_39_matcher<char>> regex_39 {}; public: template<typename CharT> class regex_40_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_40_matcher() = default;
         public: regex_40_matcher(regex_40_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2275,25 +1915,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_40_matcher> regex_40 {}; public: class regex_41_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_40_matcher<char>> regex_40 {}; public: template<typename CharT> class regex_41_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_41_matcher() = default;
         public: regex_41_matcher(regex_41_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2301,25 +1935,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_41_matcher> regex_41 {}; public: class regex_42_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_41_matcher<char>> regex_41 {}; public: template<typename CharT> class regex_42_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_42_matcher() = default;
         public: regex_42_matcher(regex_42_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2327,25 +1955,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_42_matcher> regex_42 {}; public: class regex_43_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_42_matcher<char>> regex_42 {}; public: template<typename CharT> class regex_43_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_43_matcher() = default;
         public: regex_43_matcher(regex_43_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2353,25 +1975,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_43_matcher> regex_43 {}; public: class regex_44_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_43_matcher<char>> regex_43 {}; public: template<typename CharT> class regex_44_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_44_matcher() = default;
         public: regex_44_matcher(regex_44_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2379,25 +1995,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_44_matcher> regex_44 {}; public: class regex_45_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_44_matcher<char>> regex_44 {}; public: template<typename CharT> class regex_45_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_45_matcher() = default;
         public: regex_45_matcher(regex_45_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2405,25 +2015,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_45_matcher> regex_45 {}; public: class regex_46_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_45_matcher<char>> regex_45 {}; public: template<typename CharT> class regex_46_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_46_matcher() = default;
         public: regex_46_matcher(regex_46_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2431,25 +2035,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_46_matcher> regex_46 {}; public: class regex_47_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_46_matcher<char>> regex_46 {}; public: template<typename CharT> class regex_47_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_47_matcher() = default;
         public: regex_47_matcher(regex_47_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2457,25 +2055,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_47_matcher> regex_47 {}; public: class regex_48_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_47_matcher<char>> regex_47 {}; public: template<typename CharT> class regex_48_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_48_matcher() = default;
         public: regex_48_matcher(regex_48_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2483,25 +2075,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_48_matcher> regex_48 {}; public: class regex_49_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_48_matcher<char>> regex_48 {}; public: template<typename CharT> class regex_49_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_49_matcher() = default;
         public: regex_49_matcher(regex_49_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2509,25 +2095,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_49_matcher> regex_49 {}; public: class regex_50_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_49_matcher<char>> regex_49 {}; public: template<typename CharT> class regex_50_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_50_matcher() = default;
         public: regex_50_matcher(regex_50_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2535,25 +2115,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_50_matcher> regex_50 {}; public: class regex_51_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_50_matcher<char>> regex_50 {}; public: template<typename CharT> class regex_51_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_51_matcher() = default;
         public: regex_51_matcher(regex_51_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2561,25 +2135,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_51_matcher> regex_51 {}; public: class regex_52_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_51_matcher<char>> regex_51 {}; public: template<typename CharT> class regex_52_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_52_matcher() = default;
         public: regex_52_matcher(regex_52_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2587,25 +2155,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_52_matcher> regex_52 {}; public: class regex_53_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_52_matcher<char>> regex_52 {}; public: template<typename CharT> class regex_53_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_53_matcher() = default;
         public: regex_53_matcher(regex_53_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2613,40 +2175,34 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_53_matcher> regex_53 {}; public: class regex_54_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_53_matcher<char>> regex_53 {}; public: template<typename CharT> class regex_54_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_54_matcher() = default;
         public: regex_54_matcher(regex_54_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2654,40 +2210,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_54_matcher> regex_54 {}; public: class regex_55_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_54_matcher<char>> regex_54 {}; public: template<typename CharT> class regex_55_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_55_matcher() = default;
         public: regex_55_matcher(regex_55_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2695,25 +2245,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_55_matcher> regex_55 {}; public: class regex_56_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_55_matcher<char>> regex_55 {}; public: template<typename CharT> class regex_56_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_56_matcher() = default;
         public: regex_56_matcher(regex_56_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2721,25 +2265,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_56_matcher> regex_56 {}; public: class regex_57_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_56_matcher<char>> regex_56 {}; public: template<typename CharT> class regex_57_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_57_matcher() = default;
         public: regex_57_matcher(regex_57_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2747,25 +2285,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_57_matcher> regex_57 {}; public: class regex_58_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_57_matcher<char>> regex_57 {}; public: template<typename CharT> class regex_58_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_58_matcher() = default;
         public: regex_58_matcher(regex_58_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2773,35 +2305,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_58_matcher> regex_58 {}; public: class regex_59_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_58_matcher<char>> regex_58 {}; public: template<typename CharT> class regex_59_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_59_matcher() = default;
         public: regex_59_matcher(regex_59_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2809,35 +2335,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_59_matcher> regex_59 {}; public: class regex_60_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_59_matcher<char>> regex_59 {}; public: template<typename CharT> class regex_60_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_60_matcher() = default;
         public: regex_60_matcher(regex_60_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2845,25 +2365,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_60_matcher> regex_60 {}; public: class regex_61_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_60_matcher<char>> regex_60 {}; public: template<typename CharT> class regex_61_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_61_matcher() = default;
         public: regex_61_matcher(regex_61_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2871,25 +2385,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_61_matcher> regex_61 {}; public: class regex_62_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_61_matcher<char>> regex_61 {}; public: template<typename CharT> class regex_62_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_62_matcher() = default;
         public: regex_62_matcher(regex_62_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2897,25 +2405,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_62_matcher> regex_62 {}; public: class regex_63_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_62_matcher<char>> regex_62 {}; public: template<typename CharT> class regex_63_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_63_matcher() = default;
         public: regex_63_matcher(regex_63_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2923,45 +2425,39 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_63_matcher> regex_63 {}; public: class regex_64_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_63_matcher<char>> regex_63 {}; public: template<typename CharT> class regex_64_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_64_matcher() = default;
         public: regex_64_matcher(regex_64_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2969,45 +2465,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_64_matcher> regex_64 {}; public: class regex_65_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_64_matcher<char>> regex_64 {}; public: template<typename CharT> class regex_65_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_65_matcher() = default;
         public: regex_65_matcher(regex_65_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3015,35 +2505,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_65_matcher> regex_65 {}; public: class regex_66_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_65_matcher<char>> regex_65 {}; public: template<typename CharT> class regex_66_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_66_matcher() = default;
         public: regex_66_matcher(regex_66_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3051,35 +2535,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_66_matcher> regex_66 {}; public: class regex_67_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_66_matcher<char>> regex_66 {}; public: template<typename CharT> class regex_67_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_67_matcher() = default;
         public: regex_67_matcher(regex_67_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3087,35 +2565,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_67_matcher> regex_67 {}; public: class regex_68_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_67_matcher<char>> regex_67 {}; public: template<typename CharT> class regex_68_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_68_matcher() = default;
         public: regex_68_matcher(regex_68_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3123,36 +2595,35 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_68_matcher> regex_68 {}; public: class regex_69_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_68_matcher<char>> regex_68 {}; public: template<typename CharT> class regex_69_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -3162,26 +2633,21 @@ public: class func_3 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_69_matcher() = default;
         public: regex_69_matcher(regex_69_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3189,36 +2655,35 @@ public: class func_3 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_69_matcher> regex_69 {}; public: class regex_70_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_69_matcher<char>> regex_69 {}; public: template<typename CharT> class regex_70_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -3228,26 +2693,21 @@ public: class func_3 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_70_matcher() = default;
         public: regex_70_matcher(regex_70_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3255,36 +2715,35 @@ public: class func_3 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_70_matcher> regex_70 {}; public: class regex_71_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_70_matcher<char>> regex_70 {}; public: template<typename CharT> class regex_71_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -3294,26 +2753,21 @@ public: class func_3 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_71_matcher() = default;
         public: regex_71_matcher(regex_71_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3321,36 +2775,35 @@ public: class func_3 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_71_matcher> regex_71 {}; public: class regex_72_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_71_matcher<char>> regex_71 {}; public: template<typename CharT> class regex_72_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -3360,26 +2813,21 @@ public: class func_3 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_72_matcher() = default;
         public: regex_72_matcher(regex_72_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3387,36 +2835,35 @@ public: class func_3 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_72_matcher> regex_72 {}; public: class regex_73_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_72_matcher<char>> regex_72 {}; public: template<typename CharT> class regex_73_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -3426,26 +2873,21 @@ public: class func_3 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_73_matcher() = default;
         public: regex_73_matcher(regex_73_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3453,36 +2895,35 @@ public: class func_3 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_73_matcher> regex_73 {}; public: class regex_74_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_73_matcher<char>> regex_73 {}; public: template<typename CharT> class regex_74_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -3492,26 +2933,21 @@ public: class func_3 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_74_matcher() = default;
         public: regex_74_matcher(regex_74_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3519,36 +2955,35 @@ public: class func_3 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_74_matcher> regex_74 {}; public: class regex_75_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_74_matcher<char>> regex_74 {}; public: template<typename CharT> class regex_75_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -3558,26 +2993,21 @@ public: class func_3 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_75_matcher() = default;
         public: regex_75_matcher(regex_75_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3585,35 +3015,29 @@ public: class func_3 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_75_matcher> regex_75 {}; public: class regex_76_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_75_matcher<char>> regex_75 {}; public: template<typename CharT> class regex_76_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_76_matcher() = default;
         public: regex_76_matcher(regex_76_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3621,25 +3045,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_76_matcher> regex_76 {}; public: class regex_77_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_76_matcher<char>> regex_76 {}; public: template<typename CharT> class regex_77_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_77_matcher() = default;
         public: regex_77_matcher(regex_77_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3647,35 +3065,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_77_matcher> regex_77 {}; public: class regex_78_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_77_matcher<char>> regex_77 {}; public: template<typename CharT> class regex_78_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_78_matcher() = default;
         public: regex_78_matcher(regex_78_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3683,11 +3095,10 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_78_matcher> regex_78 {}; public: class regex_79_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_78_matcher<char>> regex_78 {}; public: template<typename CharT> class regex_79_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -3697,26 +3108,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_79_matcher() = default;
         public: regex_79_matcher(regex_79_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3724,11 +3130,10 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_79_matcher> regex_79 {}; public: class regex_80_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_79_matcher<char>> regex_79 {}; public: template<typename CharT> class regex_80_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -3738,26 +3143,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_80_matcher() = default;
         public: regex_80_matcher(regex_80_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3765,55 +3165,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_80_matcher> regex_80 {}; public: class regex_81_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_80_matcher<char>> regex_80 {}; public: template<typename CharT> class regex_81_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_81_matcher() = default;
         public: regex_81_matcher(regex_81_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3821,55 +3215,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_81_matcher> regex_81 {}; public: class regex_82_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_81_matcher<char>> regex_81 {}; public: template<typename CharT> class regex_82_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_82_matcher() = default;
         public: regex_82_matcher(regex_82_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3877,35 +3265,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_82_matcher> regex_82 {}; public: class regex_83_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_82_matcher<char>> regex_82 {}; public: template<typename CharT> class regex_83_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_83_matcher() = default;
         public: regex_83_matcher(regex_83_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3913,35 +3295,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_83_matcher> regex_83 {}; public: class regex_84_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_83_matcher<char>> regex_83 {}; public: template<typename CharT> class regex_84_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_84_matcher() = default;
         public: regex_84_matcher(regex_84_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3949,35 +3325,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_84_matcher> regex_84 {}; public: class regex_85_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_84_matcher<char>> regex_84 {}; public: template<typename CharT> class regex_85_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_85_matcher() = default;
         public: regex_85_matcher(regex_85_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3985,40 +3355,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_85_matcher> regex_85 {}; public: class regex_86_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_85_matcher<char>> regex_85 {}; public: template<typename CharT> class regex_86_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_86_matcher() = default;
         public: regex_86_matcher(regex_86_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4026,25 +3390,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_86_matcher> regex_86 {}; public: class regex_87_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_86_matcher<char>> regex_86 {}; public: template<typename CharT> class regex_87_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_87_matcher() = default;
         public: regex_87_matcher(regex_87_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4052,40 +3410,34 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_87_matcher> regex_87 {}; public: class regex_88_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_87_matcher<char>> regex_87 {}; public: template<typename CharT> class regex_88_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_88_matcher() = default;
         public: regex_88_matcher(regex_88_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4093,40 +3445,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_88_matcher> regex_88 {}; public: class regex_89_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_88_matcher<char>> regex_88 {}; public: template<typename CharT> class regex_89_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_89_matcher() = default;
         public: regex_89_matcher(regex_89_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4134,50 +3480,44 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_89_matcher> regex_89 {}; public: class regex_90_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_89_matcher<char>> regex_89 {}; public: template<typename CharT> class regex_90_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_90_matcher() = default;
         public: regex_90_matcher(regex_90_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4185,50 +3525,44 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_90_matcher> regex_90 {}; public: class regex_91_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_90_matcher<char>> regex_90 {}; public: template<typename CharT> class regex_91_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_91_matcher() = default;
         public: regex_91_matcher(regex_91_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4236,45 +3570,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_91_matcher> regex_91 {}; public: class regex_92_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_91_matcher<char>> regex_91 {}; public: template<typename CharT> class regex_92_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_92_matcher() = default;
         public: regex_92_matcher(regex_92_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4282,45 +3610,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_92_matcher> regex_92 {}; public: class regex_93_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_92_matcher<char>> regex_92 {}; public: template<typename CharT> class regex_93_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_93_matcher() = default;
         public: regex_93_matcher(regex_93_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4328,45 +3650,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_93_matcher> regex_93 {}; public: class regex_94_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_93_matcher<char>> regex_93 {}; public: template<typename CharT> class regex_94_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_94_matcher() = default;
         public: regex_94_matcher(regex_94_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4374,45 +3690,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_94_matcher> regex_94 {}; public: class regex_95_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_94_matcher<char>> regex_94 {}; public: template<typename CharT> class regex_95_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_95_matcher() = default;
         public: regex_95_matcher(regex_95_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4420,35 +3730,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_95_matcher> regex_95 {}; public: class regex_96_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_95_matcher<char>> regex_95 {}; public: template<typename CharT> class regex_96_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_96_matcher() = default;
         public: regex_96_matcher(regex_96_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4456,35 +3760,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_96_matcher> regex_96 {}; public: class regex_97_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_96_matcher<char>> regex_96 {}; public: template<typename CharT> class regex_97_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_97_matcher() = default;
         public: regex_97_matcher(regex_97_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4492,50 +3790,44 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_97_matcher> regex_97 {}; public: class regex_98_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_97_matcher<char>> regex_97 {}; public: template<typename CharT> class regex_98_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_98_matcher() = default;
         public: regex_98_matcher(regex_98_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4543,25 +3835,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_98_matcher> regex_98 {}; public: class regex_99_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,5>;
+  public: cpp2::regex::regular_expression<char,regex_98_matcher<char>> regex_98 {}; public: template<typename CharT> class regex_99_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,5>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_99_matcher() = default;
         public: regex_99_matcher(regex_99_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4569,13 +3855,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_99_matcher> regex_99 {}; 
+  public: cpp2::regex::regular_expression<char,regex_99_matcher<char>> regex_99 {}; 
   public: test_tests_12_case_insensitive() = default;
   public: test_tests_12_case_insensitive(test_tests_12_case_insensitive const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_12_case_insensitive const&) -> void = delete;
 
 
-#line 408 "pure2-regex_12_case_insensitive.cpp2"
+#line 409 "pure2-regex_12_case_insensitive.cpp2"
 };
 auto main() -> int;
 
@@ -4679,6 +3965,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -4694,7 +3981,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_12_case_insensitive.cpp2"
+#line 113 "pure2-regex_12_case_insensitive.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -4707,7 +3994,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_12_case_insensitive.cpp2"
+#line 125 "pure2-regex_12_case_insensitive.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -4748,7 +4035,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 285 "pure2-regex_12_case_insensitive.cpp2"
+#line 286 "pure2-regex_12_case_insensitive.cpp2"
   auto test_tests_12_case_insensitive::run() const& -> void{
     std::cout << "Running tests_12_case_insensitive:" << std::endl;
     test(regex_01, "01", R"('abc'i)", "ABC", "y", R"($&)", "ABC");
@@ -4876,61 +4163,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> lower_str_tmp_0 {"abc"}; 
-
-  std::array<char,3 + 1> upper_str_tmp_0 {"ABC"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (!((CPP2_ASSERT_IN_BOUNDS(lower_str_tmp_0, i) == CPP2_ASSERT_IN_BOUNDS(r.pos, i) || CPP2_ASSERT_IN_BOUNDS(upper_str_tmp_0, i) == CPP2_ASSERT_IN_BOUNDS(r.pos, i)))) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_01_matcher::to_string() -> std::string{return R"('abc'i)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4960,10 +4193,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4971,19 +4205,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_02_matcher::to_string() -> std::string{return R"('abc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_01_matcher<CharT>::to_string() -> std::string{return R"('abc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5013,10 +4247,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5024,19 +4259,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_03_matcher::to_string() -> std::string{return R"('abc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_02_matcher<CharT>::to_string() -> std::string{return R"('abc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5066,10 +4301,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5077,19 +4313,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_04_matcher::to_string() -> std::string{return R"('abc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_03_matcher<CharT>::to_string() -> std::string{return R"('abc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5119,10 +4355,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5130,19 +4367,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_05_matcher::to_string() -> std::string{return R"('abc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_04_matcher<CharT>::to_string() -> std::string{return R"('abc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5172,10 +4409,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5183,19 +4421,73 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_06_matcher::to_string() -> std::string{return R"('abc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_05_matcher<CharT>::to_string() -> std::string{return R"('abc'i)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> lower_str_tmp_0 {"abc"}; 
+
+  std::array<char,3 + 1> upper_str_tmp_0 {"ABC"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (!((CPP2_ASSERT_IN_BOUNDS(lower_str_tmp_0, i) == CPP2_ASSERT_IN_BOUNDS(r.pos, i) || CPP2_ASSERT_IN_BOUNDS(upper_str_tmp_0, i) == CPP2_ASSERT_IN_BOUNDS(r.pos, i)))) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_06_matcher<CharT>::to_string() -> std::string{return R"('abc'i)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5225,11 +4517,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5259,11 +4552,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5293,10 +4587,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5304,19 +4599,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher::to_string() -> std::string{return R"('ab*c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_07_matcher<CharT>::to_string() -> std::string{return R"('ab*c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5346,11 +4641,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5380,11 +4676,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5414,10 +4711,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5425,19 +4723,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher::to_string() -> std::string{return R"('ab*bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_08_matcher<CharT>::to_string() -> std::string{return R"('ab*bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5467,11 +4765,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5501,11 +4800,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5535,10 +4835,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5546,19 +4847,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher::to_string() -> std::string{return R"('ab*bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_09_matcher<CharT>::to_string() -> std::string{return R"('ab*bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5588,11 +4889,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5622,11 +4924,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5656,10 +4959,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5667,19 +4971,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher::to_string() -> std::string{return R"('ab*?bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_10_matcher<CharT>::to_string() -> std::string{return R"('ab*?bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5694,11 +4998,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5713,11 +5018,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5731,10 +5037,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5742,19 +5049,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher::to_string() -> std::string{return R"('[a-zA-Z_][a-zA-Z0-9_]*'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_100_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_100_matcher<CharT>::to_string() -> std::string{return R"('[a-zA-Z_][a-zA-Z0-9_]*'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5784,11 +5091,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5818,11 +5126,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5836,11 +5145,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5871,11 +5181,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5907,11 +5218,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5953,16 +5265,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5994,11 +5307,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6012,11 +5326,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6030,10 +5345,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6041,19 +5357,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher::to_string() -> std::string{return R"('^a(bc+|b[eh])g|.h$'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_101_matcher<CharT>::to_string() -> std::string{return R"('^a(bc+|b[eh])g|.h$'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6083,11 +5399,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6117,11 +5434,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6152,11 +5470,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6186,11 +5505,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6220,11 +5540,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6255,11 +5576,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6289,11 +5611,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6307,11 +5630,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_10::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_10::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6341,11 +5665,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_11::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_11::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6375,11 +5700,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6410,11 +5736,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_12::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_12::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6440,16 +5767,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6464,11 +5792,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::func_13::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::func_13::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6494,10 +5823,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6505,19 +5835,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_102_matcher<CharT>::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6547,11 +5877,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6581,11 +5912,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6616,11 +5948,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6650,11 +5983,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6684,11 +6018,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6719,11 +6054,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6753,11 +6089,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6771,11 +6108,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_10::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_10::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6805,11 +6143,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_11::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_11::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6839,11 +6178,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6874,11 +6214,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_12::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_12::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6904,16 +6245,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6928,11 +6270,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::func_13::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::func_13::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6958,10 +6301,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6969,19 +6313,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_103_matcher<CharT>::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7011,11 +6355,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7045,11 +6390,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7080,11 +6426,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7114,11 +6461,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7148,11 +6496,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7183,11 +6532,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7217,11 +6567,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7235,11 +6586,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_10::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_10::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7269,11 +6621,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_11::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_11::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7303,11 +6656,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7338,11 +6692,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_12::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_12::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7368,16 +6723,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7392,11 +6748,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::func_13::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::func_13::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7422,10 +6779,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7433,19 +6791,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_104_matcher<CharT>::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7475,11 +6833,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7509,11 +6868,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7544,11 +6904,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7578,11 +6939,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7612,11 +6974,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7647,11 +7010,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7681,11 +7045,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7699,11 +7064,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_10::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_10::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7733,11 +7099,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_11::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_11::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7767,11 +7134,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7802,11 +7170,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_12::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_12::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7832,16 +7201,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7856,11 +7226,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::func_13::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::func_13::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7886,10 +7257,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7897,19 +7269,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_105_matcher<CharT>::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7939,11 +7311,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7973,11 +7346,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8008,11 +7382,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8042,11 +7417,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8076,11 +7452,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8111,11 +7488,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8145,11 +7523,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8163,11 +7542,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_10::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_10::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8197,11 +7577,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_11::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_11::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8231,11 +7612,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8266,11 +7648,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_12::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_12::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8296,16 +7679,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8320,11 +7704,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::func_13::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::func_13::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8350,10 +7735,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8361,19 +7747,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_106_matcher<CharT>::to_string() -> std::string{return R"('(bc+d$|ef*g.|h?i(j|k))'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_107_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_107_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8533,10 +7919,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_107_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_107_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8544,19 +7931,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_107_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_107_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_107_matcher::to_string() -> std::string{return R"('((((((((((a))))))))))'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_107_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_107_matcher<CharT>::to_string() -> std::string{return R"('((((((((((a))))))))))'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_108_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_108_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8706,7 +8093,7 @@ int i{0};
 
   auto tmp_10 {cpp2::regex::make_on_return(cpp2::move(tmp_10_func))}; 
   static_cast<void>(cpp2::move(tmp_10));
-  if (!(cpp2::regex::group_ref_token_matcher<char,10,true>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,10,true,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -8717,10 +8104,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_108_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_108_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8728,19 +8116,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_108_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_108_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_108_matcher::to_string() -> std::string{return R"('((((((((((a))))))))))\10'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_108_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_108_matcher<CharT>::to_string() -> std::string{return R"('((((((((((a))))))))))\10'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_109_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_109_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8887,10 +8275,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_109_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_109_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8898,19 +8287,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_109_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_109_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_109_matcher::to_string() -> std::string{return R"('(((((((((a)))))))))'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_109_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_109_matcher<CharT>::to_string() -> std::string{return R"('(((((((((a)))))))))'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8940,11 +8329,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8974,11 +8364,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9008,10 +8399,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9019,19 +8411,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher::to_string() -> std::string{return R"('ab{0,}?bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_11_matcher<CharT>::to_string() -> std::string{return R"('ab{0,}?bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_110_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_110_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9061,10 +8453,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_110_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_110_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9072,19 +8465,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_110_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_110_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_110_matcher::to_string() -> std::string{return R"('multiple words of text'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_110_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_110_matcher<CharT>::to_string() -> std::string{return R"('multiple words of text'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_111_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_111_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9114,10 +8507,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_111_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_111_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9125,19 +8519,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_111_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_111_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_111_matcher::to_string() -> std::string{return R"('multiple words'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_111_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_111_matcher<CharT>::to_string() -> std::string{return R"('multiple words'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9152,11 +8546,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9171,11 +8566,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9190,11 +8586,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9237,11 +8634,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9267,10 +8665,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9278,19 +8677,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher::to_string() -> std::string{return R"('(.*)c(.*)'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_112_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_112_matcher<CharT>::to_string() -> std::string{return R"('(.*)c(.*)'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9305,11 +8704,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9338,11 +8738,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9357,11 +8758,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9402,11 +8804,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9446,10 +8849,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9457,19 +8861,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher::to_string() -> std::string{return R"('\((.*), (.*)\)'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_113_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_113_matcher<CharT>::to_string() -> std::string{return R"('\((.*), (.*)\)'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_114_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_114_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9484,10 +8888,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_114_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_114_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9495,19 +8900,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_114_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_114_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_114_matcher::to_string() -> std::string{return R"('[k]'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_114_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_114_matcher<CharT>::to_string() -> std::string{return R"('[k]'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_115_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_115_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9537,10 +8942,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_115_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_115_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9548,19 +8954,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_115_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_115_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_115_matcher::to_string() -> std::string{return R"('abcd'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_115_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_115_matcher<CharT>::to_string() -> std::string{return R"('abcd'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_116_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_116_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9635,10 +9041,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_116_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_116_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9646,19 +9053,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_116_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_116_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_116_matcher::to_string() -> std::string{return R"('a(bc)d'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_116_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_116_matcher<CharT>::to_string() -> std::string{return R"('a(bc)d'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9673,11 +9080,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9707,11 +9115,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9741,10 +9150,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9752,19 +9162,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher::to_string() -> std::string{return R"('a[-]?c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_117_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_117_matcher<CharT>::to_string() -> std::string{return R"('a[-]?c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_118_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_118_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9797,7 +9207,7 @@ int i{0};
 
   auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
   static_cast<void>(cpp2::move(tmp_1));
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,true>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,true,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -9808,10 +9218,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_118_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_118_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9819,19 +9230,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_118_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_118_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_118_matcher::to_string() -> std::string{return R"('(abc)\1'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_118_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_118_matcher<CharT>::to_string() -> std::string{return R"('(abc)\1'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9846,11 +9257,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9865,11 +9277,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9885,7 +9298,7 @@ int i{0};
 
   auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
   static_cast<void>(cpp2::move(tmp_0));
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,true>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,true,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -9896,10 +9309,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9907,19 +9321,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher::to_string() -> std::string{return R"('([a-c]*)\1'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_119_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_119_matcher<CharT>::to_string() -> std::string{return R"('([a-c]*)\1'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9949,11 +9363,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9983,11 +9398,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10017,10 +9433,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10028,19 +9445,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher::to_string() -> std::string{return R"('ab+?bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_12_matcher<CharT>::to_string() -> std::string{return R"('ab+?bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10070,11 +9487,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10104,11 +9522,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10138,10 +9557,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10149,19 +9569,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher::to_string() -> std::string{return R"('ab+bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_13_matcher<CharT>::to_string() -> std::string{return R"('ab+bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10191,11 +9611,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10225,11 +9646,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10259,10 +9681,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10270,19 +9693,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher::to_string() -> std::string{return R"('ab+bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_14_matcher<CharT>::to_string() -> std::string{return R"('ab+bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10312,11 +9735,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10346,11 +9770,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10380,10 +9805,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10391,19 +9817,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher::to_string() -> std::string{return R"('ab{1,}bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_15_matcher<CharT>::to_string() -> std::string{return R"('ab{1,}bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10433,11 +9859,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10467,11 +9894,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10501,10 +9929,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10512,19 +9941,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher::to_string() -> std::string{return R"('ab+bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_16_matcher<CharT>::to_string() -> std::string{return R"('ab+bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10554,11 +9983,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10588,11 +10018,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10622,10 +10053,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10633,19 +10065,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher::to_string() -> std::string{return R"('ab{1,}?bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_17_matcher<CharT>::to_string() -> std::string{return R"('ab{1,}?bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10675,11 +10107,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10709,11 +10142,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10743,10 +10177,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10754,19 +10189,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher::to_string() -> std::string{return R"('ab{1,3}?bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_18_matcher<CharT>::to_string() -> std::string{return R"('ab{1,3}?bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10796,11 +10231,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10830,11 +10266,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10864,10 +10301,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10875,19 +10313,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher::to_string() -> std::string{return R"('ab{3,4}?bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_19_matcher<CharT>::to_string() -> std::string{return R"('ab{3,4}?bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10917,11 +10355,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10951,11 +10390,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10985,10 +10425,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10996,19 +10437,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher::to_string() -> std::string{return R"('ab{4,5}?bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_20_matcher<CharT>::to_string() -> std::string{return R"('ab{4,5}?bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11038,11 +10479,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11072,11 +10514,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11106,10 +10549,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11117,19 +10561,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher::to_string() -> std::string{return R"('ab??bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_21_matcher<CharT>::to_string() -> std::string{return R"('ab??bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11159,11 +10603,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11193,11 +10638,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11227,10 +10673,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11238,19 +10685,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher::to_string() -> std::string{return R"('ab??bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_22_matcher<CharT>::to_string() -> std::string{return R"('ab??bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11280,11 +10727,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11314,11 +10762,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11348,10 +10797,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11359,19 +10809,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher::to_string() -> std::string{return R"('ab{0,1}?bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_23_matcher<CharT>::to_string() -> std::string{return R"('ab{0,1}?bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11401,11 +10851,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11435,11 +10886,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11469,10 +10921,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11480,19 +10933,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher::to_string() -> std::string{return R"('ab??bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_24_matcher<CharT>::to_string() -> std::string{return R"('ab??bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11522,11 +10975,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11556,11 +11010,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11590,10 +11045,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11601,19 +11057,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher::to_string() -> std::string{return R"('ab??c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_25_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_25_matcher<CharT>::to_string() -> std::string{return R"('ab??c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11643,11 +11099,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11677,11 +11134,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11711,10 +11169,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11722,19 +11181,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher::to_string() -> std::string{return R"('ab{0,1}?c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_26_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_26_matcher<CharT>::to_string() -> std::string{return R"('ab{0,1}?c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_27_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_27_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11766,10 +11225,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_27_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_27_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11777,19 +11237,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_27_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_27_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_27_matcher::to_string() -> std::string{return R"('^abc$'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_27_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_27_matcher<CharT>::to_string() -> std::string{return R"('^abc$'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_28_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_28_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11821,10 +11281,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_28_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_28_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11832,19 +11293,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_28_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_28_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_28_matcher::to_string() -> std::string{return R"('^abc$'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_28_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_28_matcher<CharT>::to_string() -> std::string{return R"('^abc$'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_29_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_29_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11875,10 +11336,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_29_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_29_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11886,19 +11348,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_29_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_29_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_29_matcher::to_string() -> std::string{return R"('^abc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_29_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_29_matcher<CharT>::to_string() -> std::string{return R"('^abc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_30_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_30_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11930,10 +11392,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_30_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_30_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11941,19 +11404,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_30_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_30_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_30_matcher::to_string() -> std::string{return R"('^abc$'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_30_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_30_matcher<CharT>::to_string() -> std::string{return R"('^abc$'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_31_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_31_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11984,10 +11447,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_31_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_31_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11995,19 +11459,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_31_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_31_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_31_matcher::to_string() -> std::string{return R"('abc$'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_31_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_31_matcher<CharT>::to_string() -> std::string{return R"('abc$'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_32_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_32_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12022,10 +11486,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_32_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_32_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12033,19 +11498,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_32_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_32_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_32_matcher::to_string() -> std::string{return R"('^'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_32_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_32_matcher<CharT>::to_string() -> std::string{return R"('^'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_33_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_33_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12060,10 +11525,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_33_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_33_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12071,19 +11537,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_33_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_33_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_33_matcher::to_string() -> std::string{return R"('$'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_33_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_33_matcher<CharT>::to_string() -> std::string{return R"('$'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_34_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_34_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12130,10 +11596,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_34_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_34_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12141,19 +11608,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_34_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_34_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_34_matcher::to_string() -> std::string{return R"('a.c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_34_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_34_matcher<CharT>::to_string() -> std::string{return R"('a.c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_35_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_35_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12200,10 +11667,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_35_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_35_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12211,19 +11679,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_35_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_35_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_35_matcher::to_string() -> std::string{return R"('a.c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_35_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_35_matcher<CharT>::to_string() -> std::string{return R"('a.c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_36_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_36_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12270,10 +11738,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_36_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_36_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12281,19 +11750,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_36_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_36_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_36_matcher::to_string() -> std::string{return R"('a\Nc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_36_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_36_matcher<CharT>::to_string() -> std::string{return R"('a\Nc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12308,11 +11777,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12342,11 +11812,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12376,10 +11847,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12387,19 +11859,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher::to_string() -> std::string{return R"('a.*?c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_37_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_37_matcher<CharT>::to_string() -> std::string{return R"('a.*?c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12414,11 +11886,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12448,11 +11921,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12482,10 +11956,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12493,19 +11968,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher::to_string() -> std::string{return R"('a.*c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_38_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_38_matcher<CharT>::to_string() -> std::string{return R"('a.*c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_39_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_39_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12552,10 +12027,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_39_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_39_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12563,19 +12039,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_39_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_39_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_39_matcher::to_string() -> std::string{return R"('a[bc]d'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_39_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_39_matcher<CharT>::to_string() -> std::string{return R"('a[bc]d'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_40_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_40_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12622,10 +12098,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_40_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_40_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12633,19 +12110,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_40_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_40_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_40_matcher::to_string() -> std::string{return R"('a[bc]d'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_40_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_40_matcher<CharT>::to_string() -> std::string{return R"('a[bc]d'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_41_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_41_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12692,10 +12169,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_41_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_41_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12703,19 +12181,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_41_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_41_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_41_matcher::to_string() -> std::string{return R"('a[b-d]e'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_41_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_41_matcher<CharT>::to_string() -> std::string{return R"('a[b-d]e'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_42_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_42_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12762,10 +12240,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_42_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_42_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12773,19 +12252,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_42_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_42_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_42_matcher::to_string() -> std::string{return R"('a[b-d]e'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_42_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_42_matcher<CharT>::to_string() -> std::string{return R"('a[b-d]e'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_43_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_43_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12816,10 +12295,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_43_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_43_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12827,19 +12307,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_43_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_43_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_43_matcher::to_string() -> std::string{return R"('a[b-d]'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_43_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_43_matcher<CharT>::to_string() -> std::string{return R"('a[b-d]'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_44_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_44_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12870,10 +12350,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_44_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_44_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12881,19 +12362,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_44_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_44_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_44_matcher::to_string() -> std::string{return R"('a[-b]'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_44_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_44_matcher<CharT>::to_string() -> std::string{return R"('a[-b]'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_45_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_45_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12924,10 +12405,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_45_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_45_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12935,19 +12417,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_45_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_45_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_45_matcher::to_string() -> std::string{return R"('a[b-]'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_45_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_45_matcher<CharT>::to_string() -> std::string{return R"('a[b-]'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_46_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_46_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12977,10 +12459,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_46_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_46_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12988,19 +12471,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_46_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_46_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_46_matcher::to_string() -> std::string{return R"('a]'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_46_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_46_matcher<CharT>::to_string() -> std::string{return R"('a]'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_47_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_47_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13047,10 +12530,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_47_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_47_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13058,19 +12542,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_47_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_47_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_47_matcher::to_string() -> std::string{return R"('a[]]b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_47_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_47_matcher<CharT>::to_string() -> std::string{return R"('a[]]b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_48_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_48_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13117,10 +12601,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_48_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_48_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13128,19 +12613,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_48_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_48_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_48_matcher::to_string() -> std::string{return R"('a[^bc]d'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_48_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_48_matcher<CharT>::to_string() -> std::string{return R"('a[^bc]d'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_49_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_49_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13187,10 +12672,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_49_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_49_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13198,19 +12684,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_49_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_49_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_49_matcher::to_string() -> std::string{return R"('a[^bc]d'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_49_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_49_matcher<CharT>::to_string() -> std::string{return R"('a[^bc]d'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_50_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_50_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13257,10 +12743,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_50_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_50_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13268,19 +12755,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_50_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_50_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_50_matcher::to_string() -> std::string{return R"('a[^-b]c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_50_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_50_matcher<CharT>::to_string() -> std::string{return R"('a[^-b]c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_51_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_51_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13327,10 +12814,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_51_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_51_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13338,19 +12826,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_51_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_51_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_51_matcher::to_string() -> std::string{return R"('a[^-b]c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_51_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_51_matcher<CharT>::to_string() -> std::string{return R"('a[^-b]c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_52_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_52_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13397,10 +12885,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_52_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_52_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13408,19 +12897,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_52_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_52_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_52_matcher::to_string() -> std::string{return R"('a[^]b]c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_52_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_52_matcher<CharT>::to_string() -> std::string{return R"('a[^]b]c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_53_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_53_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13467,10 +12956,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_53_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_53_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13478,19 +12968,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_53_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_53_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_53_matcher::to_string() -> std::string{return R"('a[^]b]c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_53_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_53_matcher<CharT>::to_string() -> std::string{return R"('a[^]b]c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13520,11 +13010,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13554,11 +13045,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13572,11 +13064,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13590,10 +13083,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13601,19 +13095,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher::to_string() -> std::string{return R"('ab|cd'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_54_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_54_matcher<CharT>::to_string() -> std::string{return R"('ab|cd'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13643,11 +13137,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13677,11 +13172,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13695,11 +13191,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13713,10 +13210,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13724,19 +13222,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher::to_string() -> std::string{return R"('ab|cd'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_55_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_55_matcher<CharT>::to_string() -> std::string{return R"('ab|cd'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_56_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_56_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13779,10 +13277,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_56_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_56_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13790,19 +13289,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_56_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_56_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_56_matcher::to_string() -> std::string{return R"('()ef'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_56_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_56_matcher<CharT>::to_string() -> std::string{return R"('()ef'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_57_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_57_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13833,10 +13332,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_57_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_57_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13844,19 +13344,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_57_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_57_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_57_matcher::to_string() -> std::string{return R"('$b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_57_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_57_matcher<CharT>::to_string() -> std::string{return R"('$b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_58_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_58_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13886,10 +13386,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_58_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_58_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13897,19 +13398,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_58_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_58_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_58_matcher::to_string() -> std::string{return R"('a\(b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_58_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_58_matcher<CharT>::to_string() -> std::string{return R"('a\(b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13937,11 +13438,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13971,11 +13473,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14005,10 +13508,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14016,19 +13520,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher::to_string() -> std::string{return R"('a\(*b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_59_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_59_matcher<CharT>::to_string() -> std::string{return R"('a\(*b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14056,11 +13560,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14090,11 +13595,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14124,10 +13630,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14135,19 +13642,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher::to_string() -> std::string{return R"('a\(*b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_60_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_60_matcher<CharT>::to_string() -> std::string{return R"('a\(*b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_61_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_61_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14177,10 +13684,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_61_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_61_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14188,19 +13696,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_61_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_61_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_61_matcher::to_string() -> std::string{return R"('a\\b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_61_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_61_matcher<CharT>::to_string() -> std::string{return R"('a\\b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_62_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_62_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14256,10 +13764,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_62_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_62_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14267,19 +13776,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_62_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_62_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_62_matcher::to_string() -> std::string{return R"('((a))'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_62_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_62_matcher<CharT>::to_string() -> std::string{return R"('((a))'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_63_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_63_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14367,10 +13876,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_63_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_63_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14378,19 +13888,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_63_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_63_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_63_matcher::to_string() -> std::string{return R"('(a)b(c)'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_63_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_63_matcher<CharT>::to_string() -> std::string{return R"('(a)b(c)'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14420,11 +13930,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14438,11 +13949,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14472,11 +13984,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14490,11 +14003,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14524,10 +14038,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14535,19 +14050,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher::to_string() -> std::string{return R"('a+b+c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_64_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_64_matcher<CharT>::to_string() -> std::string{return R"('a+b+c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14577,11 +14092,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14595,11 +14111,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14629,11 +14146,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14647,11 +14165,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14681,10 +14200,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14692,19 +14212,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher::to_string() -> std::string{return R"('a{1,}b{1,}c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_65_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_65_matcher<CharT>::to_string() -> std::string{return R"('a{1,}b{1,}c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14719,11 +14239,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14753,11 +14274,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14787,10 +14309,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14798,19 +14321,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher::to_string() -> std::string{return R"('a.+?c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_66_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_66_matcher<CharT>::to_string() -> std::string{return R"('a.+?c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14825,11 +14348,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14859,11 +14383,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14893,10 +14418,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14904,19 +14430,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher::to_string() -> std::string{return R"('a.*?c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_67_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_67_matcher<CharT>::to_string() -> std::string{return R"('a.*?c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14931,11 +14457,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14965,11 +14492,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14999,10 +14527,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15010,19 +14539,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher::to_string() -> std::string{return R"('a.{0,5}?c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_68_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_68_matcher<CharT>::to_string() -> std::string{return R"('a.{0,5}?c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15052,11 +14581,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15070,11 +14600,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15088,11 +14619,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15122,11 +14654,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15141,11 +14674,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15171,16 +14705,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15194,11 +14729,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15212,10 +14748,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15223,19 +14760,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher::to_string() -> std::string{return R"('(a+|b)*'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_69_matcher<CharT>::to_string() -> std::string{return R"('(a+|b)*'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15265,11 +14802,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15283,11 +14821,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15301,11 +14840,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15335,11 +14875,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15354,11 +14895,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15384,16 +14926,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15407,11 +14950,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15425,10 +14969,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15436,19 +14981,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher::to_string() -> std::string{return R"('(a+|b){0,}'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_70_matcher<CharT>::to_string() -> std::string{return R"('(a+|b){0,}'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15478,11 +15023,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15496,11 +15042,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15514,11 +15061,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15548,11 +15096,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15567,11 +15116,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15597,16 +15147,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15620,11 +15171,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15638,10 +15190,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15649,19 +15202,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher::to_string() -> std::string{return R"('(a+|b)+'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_71_matcher<CharT>::to_string() -> std::string{return R"('(a+|b)+'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15691,11 +15244,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15709,11 +15263,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15727,11 +15282,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15761,11 +15317,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15780,11 +15337,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15810,16 +15368,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15833,11 +15392,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15851,10 +15411,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15862,19 +15423,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher::to_string() -> std::string{return R"('(a+|b){1,}'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_72_matcher<CharT>::to_string() -> std::string{return R"('(a+|b){1,}'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15904,11 +15465,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15922,11 +15484,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15940,11 +15503,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15974,11 +15538,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15993,11 +15558,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16023,16 +15589,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16046,11 +15613,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16064,10 +15632,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -16075,19 +15644,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher::to_string() -> std::string{return R"('(a+|b)?'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_73_matcher<CharT>::to_string() -> std::string{return R"('(a+|b)?'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16117,11 +15686,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16135,11 +15705,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16153,11 +15724,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16187,11 +15759,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16206,11 +15779,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16236,16 +15810,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16259,11 +15834,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16277,10 +15853,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -16288,19 +15865,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher::to_string() -> std::string{return R"('(a+|b){0,1}'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_74_matcher<CharT>::to_string() -> std::string{return R"('(a+|b){0,1}'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16330,11 +15907,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16348,11 +15926,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16366,11 +15945,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16400,11 +15980,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16419,11 +16000,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16449,16 +16031,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16472,11 +16055,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16490,10 +16074,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -16501,19 +16086,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher::to_string() -> std::string{return R"('(a+|b){0,1}?'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_75_matcher<CharT>::to_string() -> std::string{return R"('(a+|b){0,1}?'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16528,11 +16113,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16546,11 +16132,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16564,10 +16151,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -16575,19 +16163,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher::to_string() -> std::string{return R"('[^ab]*'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_76_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_76_matcher<CharT>::to_string() -> std::string{return R"('[^ab]*'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_77_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_77_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16617,10 +16205,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_77_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_77_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -16628,19 +16217,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_77_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_77_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_77_matcher::to_string() -> std::string{return R"('abc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_77_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_77_matcher<CharT>::to_string() -> std::string{return R"('abc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16670,11 +16259,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16688,11 +16278,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16706,10 +16297,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -16717,19 +16309,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher::to_string() -> std::string{return R"('a*'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_78_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_78_matcher<CharT>::to_string() -> std::string{return R"('a*'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16757,16 +16349,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_79_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_79_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16780,11 +16373,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16814,10 +16408,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -16825,19 +16420,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher::to_string() -> std::string{return R"('([abc])*d'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_79_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_79_matcher<CharT>::to_string() -> std::string{return R"('([abc])*d'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16865,16 +16460,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_12_case_insensitive::regex_80_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_12_case_insensitive::regex_80_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16888,11 +16484,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16922,10 +16519,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -16933,19 +16531,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher::to_string() -> std::string{return R"('([abc])*bcd'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_80_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_80_matcher<CharT>::to_string() -> std::string{return R"('([abc])*bcd'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -16975,11 +16573,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17009,11 +16608,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17043,11 +16643,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17077,11 +16678,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17111,11 +16713,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17129,11 +16732,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17147,10 +16751,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -17158,19 +16763,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher::to_string() -> std::string{return R"('a|b|c|d|e'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_81_matcher<CharT>::to_string() -> std::string{return R"('a|b|c|d|e'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17200,11 +16805,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17234,11 +16840,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17268,11 +16875,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17302,11 +16910,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17336,11 +16945,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17355,11 +16965,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17401,10 +17012,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -17412,19 +17024,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher::to_string() -> std::string{return R"('(a|b|c|d|e)f'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_82_matcher<CharT>::to_string() -> std::string{return R"('(a|b|c|d|e)f'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17454,11 +17066,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17488,11 +17101,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17522,10 +17136,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -17533,19 +17148,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher::to_string() -> std::string{return R"('abcd*efg'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_83_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_83_matcher<CharT>::to_string() -> std::string{return R"('abcd*efg'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17575,11 +17190,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17609,11 +17225,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17627,10 +17244,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -17638,19 +17256,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher::to_string() -> std::string{return R"('ab*'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_84_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_84_matcher<CharT>::to_string() -> std::string{return R"('ab*'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17680,11 +17298,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17714,11 +17333,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17732,10 +17352,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -17743,19 +17364,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher::to_string() -> std::string{return R"('ab*'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_85_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_85_matcher<CharT>::to_string() -> std::string{return R"('ab*'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17785,11 +17406,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17819,11 +17441,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17838,11 +17461,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17884,10 +17508,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -17895,19 +17520,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher::to_string() -> std::string{return R"('(ab|cd)e'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_86_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_86_matcher<CharT>::to_string() -> std::string{return R"('(ab|cd)e'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_87_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_87_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17938,10 +17563,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_87_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_87_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -17949,19 +17575,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_87_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_87_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_87_matcher::to_string() -> std::string{return R"('[abhgefdc]ij'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_87_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_87_matcher<CharT>::to_string() -> std::string{return R"('[abhgefdc]ij'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -17991,11 +17617,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18025,11 +17652,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18045,11 +17673,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18091,10 +17720,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -18102,19 +17732,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher::to_string() -> std::string{return R"('^(ab|cd)e'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_88_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_88_matcher<CharT>::to_string() -> std::string{return R"('^(ab|cd)e'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18144,11 +17774,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18162,11 +17793,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18181,11 +17813,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18227,10 +17860,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -18238,19 +17872,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher::to_string() -> std::string{return R"('(abc|)ef'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_89_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_89_matcher<CharT>::to_string() -> std::string{return R"('(abc|)ef'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18280,11 +17914,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18314,11 +17949,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18333,11 +17969,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18367,11 +18004,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18397,11 +18035,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18431,10 +18070,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -18442,19 +18082,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher::to_string() -> std::string{return R"('(a|b)c*d'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_90_matcher<CharT>::to_string() -> std::string{return R"('(a|b)c*d'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18484,11 +18124,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18518,11 +18159,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18552,11 +18194,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18570,11 +18213,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18589,11 +18233,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18635,10 +18280,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -18646,19 +18292,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher::to_string() -> std::string{return R"('(ab|ab*)bc'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_91_matcher<CharT>::to_string() -> std::string{return R"('(ab|ab*)bc'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18673,11 +18319,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18708,11 +18355,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18742,11 +18390,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18772,11 +18421,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18790,10 +18440,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -18801,19 +18452,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher::to_string() -> std::string{return R"('a([bc]*)c*'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_92_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_92_matcher<CharT>::to_string() -> std::string{return R"('a([bc]*)c*'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18828,11 +18479,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18863,11 +18515,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18897,11 +18550,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18928,11 +18582,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -18974,10 +18629,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -18985,19 +18641,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher::to_string() -> std::string{return R"('a([bc]*)(c*d)'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_93_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_93_matcher<CharT>::to_string() -> std::string{return R"('a([bc]*)(c*d)'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19012,11 +18668,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19047,11 +18704,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19081,11 +18739,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19112,11 +18771,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19158,10 +18818,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -19169,19 +18830,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher::to_string() -> std::string{return R"('a([bc]+)(c*d)'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_94_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_94_matcher<CharT>::to_string() -> std::string{return R"('a([bc]+)(c*d)'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19196,11 +18857,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19231,11 +18893,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19265,11 +18928,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19296,11 +18960,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19342,10 +19007,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -19353,19 +19019,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher::to_string() -> std::string{return R"('a([bc]*)(c+d)'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_95_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_95_matcher<CharT>::to_string() -> std::string{return R"('a([bc]*)(c+d)'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19380,11 +19046,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19414,11 +19081,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19448,10 +19116,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -19459,19 +19128,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher::to_string() -> std::string{return R"('a[bcd]*dcdcde'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_96_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_96_matcher<CharT>::to_string() -> std::string{return R"('a[bcd]*dcdcde'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19486,11 +19155,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19520,11 +19190,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19554,10 +19225,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -19565,19 +19237,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher::to_string() -> std::string{return R"('a[bcd]+dcdcde'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_97_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_97_matcher<CharT>::to_string() -> std::string{return R"('a[bcd]+dcdcde'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19607,11 +19279,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19641,11 +19314,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19660,11 +19334,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19694,11 +19369,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19724,11 +19400,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19758,10 +19435,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -19769,19 +19447,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher::to_string() -> std::string{return R"('(ab|a)b*c'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_98_matcher<CharT>::to_string() -> std::string{return R"('(ab|a)b*c'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_99_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_99_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -19911,10 +19589,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_99_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_12_case_insensitive::regex_99_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -19922,15 +19601,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_99_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_99_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_12_case_insensitive::regex_99_matcher::to_string() -> std::string{return R"('((a)(b)c)(d)'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_12_case_insensitive::regex_99_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_12_case_insensitive::regex_99_matcher<CharT>::to_string() -> std::string{return R"('((a)(b)c)(d)'i)"; }
 
 
-#line 409 "pure2-regex_12_case_insensitive.cpp2"
+#line 410 "pure2-regex_12_case_insensitive.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_12_case_insensitive());
 }

--- a/regression-tests/test-results/pure2-regex_13_possessive_modifier.cpp
+++ b/regression-tests/test-results/pure2-regex_13_possessive_modifier.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_13_possessive_modifier.cpp2"
 
-#line 165 "pure2-regex_13_possessive_modifier.cpp2"
+#line 166 "pure2-regex_13_possessive_modifier.cpp2"
 class test_tests_13_possessive_modifier;
   
 
@@ -18,47 +18,41 @@ class test_tests_13_possessive_modifier;
 #line 1 "pure2-regex_13_possessive_modifier.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_13_possessive_modifier.cpp2"
+#line 113 "pure2-regex_13_possessive_modifier.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_13_possessive_modifier.cpp2"
+#line 125 "pure2-regex_13_possessive_modifier.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_13_possessive_modifier.cpp2"
+#line 166 "pure2-regex_13_possessive_modifier.cpp2"
 class test_tests_13_possessive_modifier {
 
-#line 214 "pure2-regex_13_possessive_modifier.cpp2"
+#line 215 "pure2-regex_13_possessive_modifier.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -66,35 +60,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -102,35 +90,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -138,35 +120,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -174,35 +150,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -210,35 +180,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -246,35 +210,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -282,35 +240,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -318,35 +270,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -354,35 +300,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -390,35 +330,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -426,35 +360,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -462,35 +390,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -498,35 +420,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -534,35 +450,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -570,35 +480,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -606,11 +510,10 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -620,26 +523,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -647,26 +545,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -676,41 +573,36 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -718,11 +610,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -732,26 +623,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -759,26 +645,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -788,41 +673,36 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -830,11 +710,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; public: class regex_21_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -844,26 +723,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_21_matcher() = default;
         public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -871,26 +745,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_21_matcher> regex_21 {}; public: class regex_22_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -900,41 +773,36 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_22_matcher() = default;
         public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -942,11 +810,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_22_matcher> regex_22 {}; public: class regex_23_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -956,26 +823,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_23_matcher() = default;
         public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -983,26 +845,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_23_matcher> regex_23 {}; public: class regex_24_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1012,41 +873,36 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_24_matcher() = default;
         public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1054,11 +910,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_24_matcher> regex_24 {}; public: class regex_25_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; public: template<typename CharT> class regex_25_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1068,26 +923,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_25_matcher() = default;
         public: regex_25_matcher(regex_25_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1095,26 +945,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_25_matcher> regex_25 {}; public: class regex_26_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_25_matcher<char>> regex_25 {}; public: template<typename CharT> class regex_26_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1124,26 +973,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_26_matcher() = default;
         public: regex_26_matcher(regex_26_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1151,11 +995,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_26_matcher> regex_26 {}; public: class regex_27_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_26_matcher<char>> regex_26 {}; public: template<typename CharT> class regex_27_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1165,26 +1008,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_27_matcher() = default;
         public: regex_27_matcher(regex_27_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1192,26 +1030,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_27_matcher> regex_27 {}; public: class regex_28_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_27_matcher<char>> regex_27 {}; public: template<typename CharT> class regex_28_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1221,26 +1058,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_28_matcher() = default;
         public: regex_28_matcher(regex_28_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1248,11 +1080,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_28_matcher> regex_28 {}; public: class regex_29_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_28_matcher<char>> regex_28 {}; public: template<typename CharT> class regex_29_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1262,26 +1093,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_29_matcher() = default;
         public: regex_29_matcher(regex_29_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1289,26 +1115,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_29_matcher> regex_29 {}; public: class regex_30_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_29_matcher<char>> regex_29 {}; public: template<typename CharT> class regex_30_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1318,26 +1143,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_30_matcher() = default;
         public: regex_30_matcher(regex_30_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1345,11 +1165,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_30_matcher> regex_30 {}; public: class regex_31_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_30_matcher<char>> regex_30 {}; public: template<typename CharT> class regex_31_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1359,26 +1178,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_31_matcher() = default;
         public: regex_31_matcher(regex_31_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1386,26 +1200,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_31_matcher> regex_31 {}; public: class regex_32_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_31_matcher<char>> regex_31 {}; public: template<typename CharT> class regex_32_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1415,26 +1228,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_32_matcher() = default;
         public: regex_32_matcher(regex_32_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1442,11 +1250,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_32_matcher> regex_32 {}; public: class regex_33_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_32_matcher<char>> regex_32 {}; public: template<typename CharT> class regex_33_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1456,26 +1263,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_33_matcher() = default;
         public: regex_33_matcher(regex_33_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1483,26 +1285,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_33_matcher> regex_33 {}; public: class regex_34_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_33_matcher<char>> regex_33 {}; public: template<typename CharT> class regex_34_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1512,41 +1313,36 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_34_matcher() = default;
         public: regex_34_matcher(regex_34_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1554,11 +1350,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_34_matcher> regex_34 {}; public: class regex_35_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_34_matcher<char>> regex_34 {}; public: template<typename CharT> class regex_35_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1568,26 +1363,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_35_matcher() = default;
         public: regex_35_matcher(regex_35_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1595,26 +1385,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_35_matcher> regex_35 {}; public: class regex_36_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_35_matcher<char>> regex_35 {}; public: template<typename CharT> class regex_36_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1624,41 +1413,36 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_36_matcher() = default;
         public: regex_36_matcher(regex_36_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1666,11 +1450,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_36_matcher> regex_36 {}; public: class regex_37_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_36_matcher<char>> regex_36 {}; public: template<typename CharT> class regex_37_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1680,26 +1463,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_37_matcher() = default;
         public: regex_37_matcher(regex_37_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1707,26 +1485,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_37_matcher> regex_37 {}; public: class regex_38_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_37_matcher<char>> regex_37 {}; public: template<typename CharT> class regex_38_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1736,41 +1513,36 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_38_matcher() = default;
         public: regex_38_matcher(regex_38_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1778,11 +1550,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_38_matcher> regex_38 {}; public: class regex_39_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_38_matcher<char>> regex_38 {}; public: template<typename CharT> class regex_39_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1792,26 +1563,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_39_matcher() = default;
         public: regex_39_matcher(regex_39_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1819,26 +1585,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_39_matcher> regex_39 {}; public: class regex_40_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_39_matcher<char>> regex_39 {}; public: template<typename CharT> class regex_40_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1848,41 +1613,36 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_40_matcher() = default;
         public: regex_40_matcher(regex_40_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1890,11 +1650,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_40_matcher> regex_40 {}; public: class regex_41_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_40_matcher<char>> regex_40 {}; public: template<typename CharT> class regex_41_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1904,26 +1663,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_41_matcher() = default;
         public: regex_41_matcher(regex_41_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1931,26 +1685,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_41_matcher> regex_41 {}; public: class regex_42_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_41_matcher<char>> regex_41 {}; public: template<typename CharT> class regex_42_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1960,26 +1713,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_42_matcher() = default;
         public: regex_42_matcher(regex_42_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1987,11 +1735,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_42_matcher> regex_42 {}; public: class regex_43_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_42_matcher<char>> regex_42 {}; public: template<typename CharT> class regex_43_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -2001,26 +1748,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_43_matcher() = default;
         public: regex_43_matcher(regex_43_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2028,26 +1770,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_43_matcher> regex_43 {}; public: class regex_44_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_43_matcher<char>> regex_43 {}; public: template<typename CharT> class regex_44_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -2057,26 +1798,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_44_matcher() = default;
         public: regex_44_matcher(regex_44_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2084,11 +1820,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_44_matcher> regex_44 {}; public: class regex_45_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_44_matcher<char>> regex_44 {}; public: template<typename CharT> class regex_45_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -2098,26 +1833,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_45_matcher() = default;
         public: regex_45_matcher(regex_45_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2125,26 +1855,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_45_matcher> regex_45 {}; public: class regex_46_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_45_matcher<char>> regex_45 {}; public: template<typename CharT> class regex_46_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -2154,26 +1883,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_46_matcher() = default;
         public: regex_46_matcher(regex_46_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2181,11 +1905,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_46_matcher> regex_46 {}; public: class regex_47_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_46_matcher<char>> regex_46 {}; public: template<typename CharT> class regex_47_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -2195,26 +1918,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_47_matcher() = default;
         public: regex_47_matcher(regex_47_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2222,26 +1940,25 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_47_matcher> regex_47 {}; public: class regex_48_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_47_matcher<char>> regex_47 {}; public: template<typename CharT> class regex_48_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -2251,26 +1968,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_48_matcher() = default;
         public: regex_48_matcher(regex_48_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2278,13 +1990,13 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_48_matcher> regex_48 {}; 
+  public: cpp2::regex::regular_expression<char,regex_48_matcher<char>> regex_48 {}; 
   public: test_tests_13_possessive_modifier() = default;
   public: test_tests_13_possessive_modifier(test_tests_13_possessive_modifier const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_13_possessive_modifier const&) -> void = delete;
 
 
-#line 266 "pure2-regex_13_possessive_modifier.cpp2"
+#line 267 "pure2-regex_13_possessive_modifier.cpp2"
 };
 auto main() -> int;
 
@@ -2388,6 +2100,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -2403,7 +2116,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_13_possessive_modifier.cpp2"
+#line 113 "pure2-regex_13_possessive_modifier.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -2416,7 +2129,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_13_possessive_modifier.cpp2"
+#line 125 "pure2-regex_13_possessive_modifier.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -2457,7 +2170,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 214 "pure2-regex_13_possessive_modifier.cpp2"
+#line 215 "pure2-regex_13_possessive_modifier.cpp2"
   auto test_tests_13_possessive_modifier::run() const& -> void{
     std::cout << "Running tests_13_possessive_modifier:" << std::endl;
     test(regex_01, "01", R"(a++a)", "aaaaa", "n", R"(-)", "-");
@@ -2514,8 +2227,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2543,11 +2255,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2561,11 +2274,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2593,10 +2307,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2604,19 +2319,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher::to_string() -> std::string{return R"(a++a)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_01_matcher<CharT>::to_string() -> std::string{return R"(a++a)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2644,11 +2359,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2662,11 +2378,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2694,10 +2411,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2705,19 +2423,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher::to_string() -> std::string{return R"(a*+a)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_02_matcher<CharT>::to_string() -> std::string{return R"(a*+a)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2745,11 +2463,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2763,11 +2482,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2795,10 +2515,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2806,19 +2527,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher::to_string() -> std::string{return R"(a{1,5}+a)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_03_matcher<CharT>::to_string() -> std::string{return R"(a{1,5}+a)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2846,11 +2567,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2864,11 +2586,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2896,10 +2619,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2907,19 +2631,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher::to_string() -> std::string{return R"(a?+a)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_04_matcher<CharT>::to_string() -> std::string{return R"(a?+a)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2947,11 +2671,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2965,11 +2690,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2997,10 +2723,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3008,19 +2735,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher::to_string() -> std::string{return R"(a++b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_05_matcher<CharT>::to_string() -> std::string{return R"(a++b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3048,11 +2775,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3066,11 +2794,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3098,10 +2827,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3109,19 +2839,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher::to_string() -> std::string{return R"(a*+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_06_matcher<CharT>::to_string() -> std::string{return R"(a*+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3149,11 +2879,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3167,11 +2898,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3199,10 +2931,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3210,19 +2943,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher::to_string() -> std::string{return R"(a{1,5}+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_07_matcher<CharT>::to_string() -> std::string{return R"(a{1,5}+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3250,11 +2983,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3268,11 +3002,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3300,10 +3035,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3311,19 +3047,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher::to_string() -> std::string{return R"(a?+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_08_matcher<CharT>::to_string() -> std::string{return R"(a?+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3351,11 +3087,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3383,11 +3120,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3415,10 +3153,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3426,19 +3165,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher::to_string() -> std::string{return R"(fooa++a)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_09_matcher<CharT>::to_string() -> std::string{return R"(fooa++a)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3466,11 +3205,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3498,11 +3238,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3530,10 +3271,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3541,19 +3283,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher::to_string() -> std::string{return R"(fooa*+a)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_10_matcher<CharT>::to_string() -> std::string{return R"(fooa*+a)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3581,11 +3323,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3613,11 +3356,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3645,10 +3389,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3656,19 +3401,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher::to_string() -> std::string{return R"(fooa{1,5}+a)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_11_matcher<CharT>::to_string() -> std::string{return R"(fooa{1,5}+a)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3696,11 +3441,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3728,11 +3474,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3760,10 +3507,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3771,19 +3519,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher::to_string() -> std::string{return R"(fooa?+a)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_12_matcher<CharT>::to_string() -> std::string{return R"(fooa?+a)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3811,11 +3559,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3843,11 +3592,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3875,10 +3625,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3886,19 +3637,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher::to_string() -> std::string{return R"(fooa++b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_13_matcher<CharT>::to_string() -> std::string{return R"(fooa++b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3926,11 +3677,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3958,11 +3710,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3990,10 +3743,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4001,19 +3755,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher::to_string() -> std::string{return R"(fooa*+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_14_matcher<CharT>::to_string() -> std::string{return R"(fooa*+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4041,11 +3795,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4073,11 +3828,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4105,10 +3861,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4116,19 +3873,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher::to_string() -> std::string{return R"(fooa{1,5}+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_15_matcher<CharT>::to_string() -> std::string{return R"(fooa{1,5}+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4156,11 +3913,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4188,11 +3946,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4220,10 +3979,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4231,19 +3991,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher::to_string() -> std::string{return R"(fooa?+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_16_matcher<CharT>::to_string() -> std::string{return R"(fooa?+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4284,16 +4044,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_17_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_17_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4307,11 +4068,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4352,10 +4114,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4363,19 +4126,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher::to_string() -> std::string{return R"((aA)++(aA))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_17_matcher<CharT>::to_string() -> std::string{return R"((aA)++(aA))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4403,11 +4166,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4435,11 +4199,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4454,11 +4219,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4484,16 +4250,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4507,11 +4274,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4539,11 +4307,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4571,11 +4340,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4590,11 +4360,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4620,10 +4391,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4631,19 +4403,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher::to_string() -> std::string{return R"((aA|bB)++(aA|bB))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_18_matcher<CharT>::to_string() -> std::string{return R"((aA|bB)++(aA|bB))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4684,16 +4456,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_19_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_19_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4707,11 +4480,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4752,10 +4526,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4763,19 +4538,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher::to_string() -> std::string{return R"((aA)*+(aA))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_19_matcher<CharT>::to_string() -> std::string{return R"((aA)*+(aA))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4803,11 +4578,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4835,11 +4611,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4854,11 +4631,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4884,16 +4662,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4907,11 +4686,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4939,11 +4719,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4971,11 +4752,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4990,11 +4772,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5020,10 +4803,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5031,19 +4815,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher::to_string() -> std::string{return R"((aA|bB)*+(aA|bB))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_20_matcher<CharT>::to_string() -> std::string{return R"((aA|bB)*+(aA|bB))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5084,16 +4868,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_21_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_21_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5107,11 +4892,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5152,10 +4938,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5163,19 +4950,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher::to_string() -> std::string{return R"((aA){1,5}+(aA))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_21_matcher<CharT>::to_string() -> std::string{return R"((aA){1,5}+(aA))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5203,11 +4990,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5235,11 +5023,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5254,11 +5043,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5284,16 +5074,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5307,11 +5098,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5339,11 +5131,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5371,11 +5164,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5390,11 +5184,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5420,10 +5215,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5431,19 +5227,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher::to_string() -> std::string{return R"((aA|bB){1,5}+(aA|bB))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_22_matcher<CharT>::to_string() -> std::string{return R"((aA|bB){1,5}+(aA|bB))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5484,16 +5280,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_23_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_23_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5507,11 +5304,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5552,10 +5350,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5563,19 +5362,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher::to_string() -> std::string{return R"((aA)?+(aA))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_23_matcher<CharT>::to_string() -> std::string{return R"((aA)?+(aA))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5603,11 +5402,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5635,11 +5435,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5654,11 +5455,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5684,16 +5486,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5707,11 +5510,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5739,11 +5543,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5771,11 +5576,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5790,11 +5596,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5820,10 +5627,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5831,19 +5639,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher::to_string() -> std::string{return R"((aA|bB)?+(aA|bB))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_24_matcher<CharT>::to_string() -> std::string{return R"((aA|bB)?+(aA|bB))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5884,16 +5692,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_25_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_25_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5907,11 +5716,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5939,10 +5749,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5950,19 +5761,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher::to_string() -> std::string{return R"((aA)++b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_25_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_25_matcher<CharT>::to_string() -> std::string{return R"((aA)++b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5990,11 +5801,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6022,11 +5834,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6041,11 +5854,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6071,16 +5885,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_26_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6094,11 +5909,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6126,10 +5942,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6137,19 +5954,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher::to_string() -> std::string{return R"((aA|bB)++b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_26_matcher<CharT>::to_string() -> std::string{return R"((aA|bB)++b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6190,16 +6007,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_27_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_27_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6213,11 +6031,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6245,10 +6064,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6256,19 +6076,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher::to_string() -> std::string{return R"((aA)*+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_27_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_27_matcher<CharT>::to_string() -> std::string{return R"((aA)*+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6296,11 +6116,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6328,11 +6149,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6347,11 +6169,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6377,16 +6200,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_28_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6400,11 +6224,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6432,10 +6257,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6443,19 +6269,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher::to_string() -> std::string{return R"((aA|bB)*+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_28_matcher<CharT>::to_string() -> std::string{return R"((aA|bB)*+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6496,16 +6322,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_29_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_29_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6519,11 +6346,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6551,10 +6379,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6562,19 +6391,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher::to_string() -> std::string{return R"((aA){1,5}+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_29_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_29_matcher<CharT>::to_string() -> std::string{return R"((aA){1,5}+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6602,11 +6431,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6634,11 +6464,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6653,11 +6484,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6683,16 +6515,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_30_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6706,11 +6539,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6738,10 +6572,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6749,19 +6584,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher::to_string() -> std::string{return R"((aA|bB){1,5}+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_30_matcher<CharT>::to_string() -> std::string{return R"((aA|bB){1,5}+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6802,16 +6637,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_31_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_31_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6825,11 +6661,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6857,10 +6694,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6868,19 +6706,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher::to_string() -> std::string{return R"((aA)?+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_31_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_31_matcher<CharT>::to_string() -> std::string{return R"((aA)?+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6908,11 +6746,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6940,11 +6779,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6959,11 +6799,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6989,16 +6830,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_32_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7012,11 +6854,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7044,10 +6887,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7055,19 +6899,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher::to_string() -> std::string{return R"((aA|bB)?+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_32_matcher<CharT>::to_string() -> std::string{return R"((aA|bB)?+b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7108,1728 +6952,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_33_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_33_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,1,-1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_2());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(2, r.pos);
-
-  std::array<char,2 + 1> str_tmp_3 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  ctx.set_group_end(2, r.pos);
-
-  auto tmp_4_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
-  }
-  }
-  }; 
-
-  auto tmp_4 {cpp2::regex::make_on_return(cpp2::move(tmp_4_func))}; 
-  static_cast<void>(cpp2::move(tmp_4));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher::to_string() -> std::string{return R"(foo(aA)++(aA))"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_2 {"bB"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_3_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_3 {cpp2::regex::make_on_return(cpp2::move(tmp_3_func))}; 
-  static_cast<void>(cpp2::move(tmp_3));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
-  ctx.set_group_invalid(1);
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,1,-1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_5());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_4 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_5 {"bB"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_5, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(2, r.pos);
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_8(), func_6(), cpp2::regex::no_reset(), func_7(), cpp2::regex::no_reset());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_end(2, r.pos);
-
-  auto tmp_6_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
-  }
-  }
-  }; 
-
-  auto tmp_6 {cpp2::regex::make_on_return(cpp2::move(tmp_6_func))}; 
-  static_cast<void>(cpp2::move(tmp_6));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher::to_string() -> std::string{return R"(foo(aA|bB)++(aA|bB))"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-
-  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_2_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
-  static_cast<void>(cpp2::move(tmp_2));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_35_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
-  ctx.set_group_invalid(1);
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,0,-1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_2());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(2, r.pos);
-
-  std::array<char,2 + 1> str_tmp_3 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  ctx.set_group_end(2, r.pos);
-
-  auto tmp_4_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
-  }
-  }
-  }; 
-
-  auto tmp_4 {cpp2::regex::make_on_return(cpp2::move(tmp_4_func))}; 
-  static_cast<void>(cpp2::move(tmp_4));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher::to_string() -> std::string{return R"(foo(aA)*+(aA))"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_2 {"bB"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_3_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_3 {cpp2::regex::make_on_return(cpp2::move(tmp_3_func))}; 
-  static_cast<void>(cpp2::move(tmp_3));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
-  ctx.set_group_invalid(1);
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,0,-1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_5());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_4 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_5 {"bB"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_5, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(2, r.pos);
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_8(), func_6(), cpp2::regex::no_reset(), func_7(), cpp2::regex::no_reset());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_end(2, r.pos);
-
-  auto tmp_6_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
-  }
-  }
-  }; 
-
-  auto tmp_6 {cpp2::regex::make_on_return(cpp2::move(tmp_6_func))}; 
-  static_cast<void>(cpp2::move(tmp_6));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher::to_string() -> std::string{return R"(foo(aA|bB)*+(aA|bB))"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-
-  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_2_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
-  static_cast<void>(cpp2::move(tmp_2));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_37_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
-  ctx.set_group_invalid(1);
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,1,5,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_2());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(2, r.pos);
-
-  std::array<char,2 + 1> str_tmp_3 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  ctx.set_group_end(2, r.pos);
-
-  auto tmp_4_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
-  }
-  }
-  }; 
-
-  auto tmp_4 {cpp2::regex::make_on_return(cpp2::move(tmp_4_func))}; 
-  static_cast<void>(cpp2::move(tmp_4));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher::to_string() -> std::string{return R"(foo(aA){1,5}+(aA))"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_2 {"bB"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_3_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_3 {cpp2::regex::make_on_return(cpp2::move(tmp_3_func))}; 
-  static_cast<void>(cpp2::move(tmp_3));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
-  ctx.set_group_invalid(1);
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,1,5,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_5());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_4 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_5 {"bB"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_5, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(2, r.pos);
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_8(), func_6(), cpp2::regex::no_reset(), func_7(), cpp2::regex::no_reset());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_end(2, r.pos);
-
-  auto tmp_6_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
-  }
-  }
-  }; 
-
-  auto tmp_6 {cpp2::regex::make_on_return(cpp2::move(tmp_6_func))}; 
-  static_cast<void>(cpp2::move(tmp_6));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher::to_string() -> std::string{return R"(foo(aA|bB){1,5}+(aA|bB))"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-
-  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_2_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
-  static_cast<void>(cpp2::move(tmp_2));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_39_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
-  ctx.set_group_invalid(1);
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,0,1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_2());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(2, r.pos);
-
-  std::array<char,2 + 1> str_tmp_3 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  ctx.set_group_end(2, r.pos);
-
-  auto tmp_4_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
-  }
-  }
-  }; 
-
-  auto tmp_4 {cpp2::regex::make_on_return(cpp2::move(tmp_4_func))}; 
-  static_cast<void>(cpp2::move(tmp_4));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher::to_string() -> std::string{return R"(foo(aA)?+(aA))"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_2 {"bB"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_3_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_3 {cpp2::regex::make_on_return(cpp2::move(tmp_3_func))}; 
-  static_cast<void>(cpp2::move(tmp_3));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
-  ctx.set_group_invalid(1);
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,0,1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_5());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_4 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_5 {"bB"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_5, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(2, r.pos);
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_8(), func_6(), cpp2::regex::no_reset(), func_7(), cpp2::regex::no_reset());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_end(2, r.pos);
-
-  auto tmp_6_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
-  }
-  }
-  }; 
-
-  auto tmp_6 {cpp2::regex::make_on_return(cpp2::move(tmp_6_func))}; 
-  static_cast<void>(cpp2::move(tmp_6));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher::to_string() -> std::string{return R"(foo(aA|bB)?+(aA|bB))"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-
-  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_2_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
-  static_cast<void>(cpp2::move(tmp_2));
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_41_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
-  ctx.set_group_invalid(1);
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8857,28 +6990,42 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
+  ctx.set_group_start(2, r.pos);
 
-  std::array<char,1 + 1> str_tmp_3 {"b"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  std::array<char,2 + 1> str_tmp_3 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
   r.matched = false;
   break;
   }
 {
 int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
   if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
   }
 }
-  if (r.matched) {r.pos += 1;}
+  if (r.matched) {r.pos += 2;}
   else {break;}
+  ctx.set_group_end(2, r.pos);
+
+  auto tmp_4_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
+  }
+  }
+  }; 
+
+  auto tmp_4 {cpp2::regex::make_on_return(cpp2::move(tmp_4_func))}; 
+  static_cast<void>(cpp2::move(tmp_4));
   }
    while ( 
   false
@@ -8889,10 +7036,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8900,19 +7048,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher::to_string() -> std::string{return R"(foo(aA)++b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_33_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_33_matcher<CharT>::to_string() -> std::string{return R"(foo(aA)++(aA))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8940,11 +7088,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8972,11 +7121,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8991,11 +7141,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9021,16 +7172,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_42_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9058,27 +7210,28 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
 
-  std::array<char,1 + 1> str_tmp_4 {"b"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  std::array<char,2 + 1> str_tmp_4 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
   r.matched = false;
   break;
   }
 {
 int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
   if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
   }
 }
-  if (r.matched) {r.pos += 1;}
+  if (r.matched) {r.pos += 2;}
   else {break;}
   }
    while ( 
@@ -9090,10 +7243,95 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_5 {"bB"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_5, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(2, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_8(), func_6(), cpp2::regex::no_reset(), func_7(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(2, r.pos);
+
+  auto tmp_6_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
+  }
+  }
+  }; 
+
+  auto tmp_6 {cpp2::regex::make_on_return(cpp2::move(tmp_6_func))}; 
+  static_cast<void>(cpp2::move(tmp_6));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9101,19 +7339,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher::to_string() -> std::string{return R"(foo(aA|bB)++b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_34_matcher<CharT>::to_string() -> std::string{return R"(foo(aA|bB)++(aA|bB))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9154,16 +7392,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_43_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_35_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9191,28 +7430,42 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
+  ctx.set_group_start(2, r.pos);
 
-  std::array<char,1 + 1> str_tmp_3 {"b"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  std::array<char,2 + 1> str_tmp_3 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
   r.matched = false;
   break;
   }
 {
 int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
   if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
   }
 }
-  if (r.matched) {r.pos += 1;}
+  if (r.matched) {r.pos += 2;}
   else {break;}
+  ctx.set_group_end(2, r.pos);
+
+  auto tmp_4_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
+  }
+  }
+  }; 
+
+  auto tmp_4 {cpp2::regex::make_on_return(cpp2::move(tmp_4_func))}; 
+  static_cast<void>(cpp2::move(tmp_4));
   }
    while ( 
   false
@@ -9223,10 +7476,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9234,19 +7488,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher::to_string() -> std::string{return R"(foo(aA)*+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_35_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_35_matcher<CharT>::to_string() -> std::string{return R"(foo(aA)*+(aA))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9274,11 +7528,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9306,11 +7561,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9325,11 +7581,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9355,16 +7612,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_44_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9392,27 +7650,28 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
 
-  std::array<char,1 + 1> str_tmp_4 {"b"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  std::array<char,2 + 1> str_tmp_4 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
   r.matched = false;
   break;
   }
 {
 int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
   if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
   }
 }
-  if (r.matched) {r.pos += 1;}
+  if (r.matched) {r.pos += 2;}
   else {break;}
   }
    while ( 
@@ -9424,10 +7683,95 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_5 {"bB"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_5, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(2, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_8(), func_6(), cpp2::regex::no_reset(), func_7(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(2, r.pos);
+
+  auto tmp_6_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
+  }
+  }
+  }; 
+
+  auto tmp_6 {cpp2::regex::make_on_return(cpp2::move(tmp_6_func))}; 
+  static_cast<void>(cpp2::move(tmp_6));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9435,19 +7779,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher::to_string() -> std::string{return R"(foo(aA|bB)*+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_36_matcher<CharT>::to_string() -> std::string{return R"(foo(aA|bB)*+(aA|bB))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9488,16 +7832,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_45_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_37_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9525,28 +7870,42 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
+  ctx.set_group_start(2, r.pos);
 
-  std::array<char,1 + 1> str_tmp_3 {"b"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  std::array<char,2 + 1> str_tmp_3 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
   r.matched = false;
   break;
   }
 {
 int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
   if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
   }
 }
-  if (r.matched) {r.pos += 1;}
+  if (r.matched) {r.pos += 2;}
   else {break;}
+  ctx.set_group_end(2, r.pos);
+
+  auto tmp_4_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
+  }
+  }
+  }; 
+
+  auto tmp_4 {cpp2::regex::make_on_return(cpp2::move(tmp_4_func))}; 
+  static_cast<void>(cpp2::move(tmp_4));
   }
    while ( 
   false
@@ -9557,10 +7916,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9568,19 +7928,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher::to_string() -> std::string{return R"(foo(aA){1,5}+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_37_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_37_matcher<CharT>::to_string() -> std::string{return R"(foo(aA){1,5}+(aA))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9608,11 +7968,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9640,11 +8001,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9659,11 +8021,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9689,16 +8052,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_46_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9726,27 +8090,28 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
 
-  std::array<char,1 + 1> str_tmp_4 {"b"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  std::array<char,2 + 1> str_tmp_4 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
   r.matched = false;
   break;
   }
 {
 int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
   if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
   }
 }
-  if (r.matched) {r.pos += 1;}
+  if (r.matched) {r.pos += 2;}
   else {break;}
   }
    while ( 
@@ -9758,10 +8123,95 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_5 {"bB"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_5, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(2, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_8(), func_6(), cpp2::regex::no_reset(), func_7(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(2, r.pos);
+
+  auto tmp_6_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
+  }
+  }
+  }; 
+
+  auto tmp_6 {cpp2::regex::make_on_return(cpp2::move(tmp_6_func))}; 
+  static_cast<void>(cpp2::move(tmp_6));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9769,19 +8219,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher::to_string() -> std::string{return R"(foo(aA|bB){1,5}+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_38_matcher<CharT>::to_string() -> std::string{return R"(foo(aA|bB){1,5}+(aA|bB))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9822,16 +8272,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_47_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_39_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9859,28 +8310,42 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
+  ctx.set_group_start(2, r.pos);
 
-  std::array<char,1 + 1> str_tmp_3 {"b"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  std::array<char,2 + 1> str_tmp_3 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
   r.matched = false;
   break;
   }
 {
 int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
   if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
   }
 }
-  if (r.matched) {r.pos += 1;}
+  if (r.matched) {r.pos += 2;}
   else {break;}
+  ctx.set_group_end(2, r.pos);
+
+  auto tmp_4_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
+  }
+  }
+  }; 
+
+  auto tmp_4 {cpp2::regex::make_on_return(cpp2::move(tmp_4_func))}; 
+  static_cast<void>(cpp2::move(tmp_4));
   }
    while ( 
   false
@@ -9891,10 +8356,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9902,19 +8368,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher::to_string() -> std::string{return R"(foo(aA)?+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_39_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_39_matcher<CharT>::to_string() -> std::string{return R"(foo(aA)?+(aA))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9942,11 +8408,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9974,11 +8441,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9993,11 +8461,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10023,16 +8492,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_13_possessive_modifier::regex_48_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10060,11 +8530,439 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_4 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_5 {"bB"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_5, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(2, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_8(), func_6(), cpp2::regex::no_reset(), func_7(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(2, r.pos);
+
+  auto tmp_6_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(2);
+  }
+  }
+  }; 
+
+  auto tmp_6 {cpp2::regex::make_on_return(cpp2::move(tmp_6_func))}; 
+  static_cast<void>(cpp2::move(tmp_6));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_40_matcher<CharT>::to_string() -> std::string{return R"(foo(aA|bB)?+(aA|bB))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_41_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  ctx.set_group_invalid(1);
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,-1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_3 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_41_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_41_matcher<CharT>::to_string() -> std::string{return R"(foo(aA)++b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_2 {"bB"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_3_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_3 {cpp2::regex::make_on_return(cpp2::move(tmp_3_func))}; 
+  static_cast<void>(cpp2::move(tmp_3));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  ctx.set_group_invalid(1);
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,-1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_5());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10092,10 +8990,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10103,15 +9002,1045 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher::to_string() -> std::string{return R"(foo(aA|bB)?+b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_42_matcher<CharT>::to_string() -> std::string{return R"(foo(aA|bB)++b)"; }
 
 
-#line 267 "pure2-regex_13_possessive_modifier.cpp2"
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_43_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  ctx.set_group_invalid(1);
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_3 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_43_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_43_matcher<CharT>::to_string() -> std::string{return R"(foo(aA)*+b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_2 {"bB"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_3_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_3 {cpp2::regex::make_on_return(cpp2::move(tmp_3_func))}; 
+  static_cast<void>(cpp2::move(tmp_3));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  ctx.set_group_invalid(1);
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_5());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_4 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_44_matcher<CharT>::to_string() -> std::string{return R"(foo(aA|bB)*+b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_45_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  ctx.set_group_invalid(1);
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,5,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_3 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_45_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_45_matcher<CharT>::to_string() -> std::string{return R"(foo(aA){1,5}+b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_2 {"bB"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_3_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_3 {cpp2::regex::make_on_return(cpp2::move(tmp_3_func))}; 
+  static_cast<void>(cpp2::move(tmp_3));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  ctx.set_group_invalid(1);
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,5,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_5());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_4 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_46_matcher<CharT>::to_string() -> std::string{return R"(foo(aA|bB){1,5}+b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_47_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  ctx.set_group_invalid(1);
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_3 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_3, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_47_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_47_matcher<CharT>::to_string() -> std::string{return R"(foo(aA)?+b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_1 {"aA"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_2 {"bB"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_4(), func_2(), cpp2::regex::no_reset(), func_3(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_3_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_3 {cpp2::regex::make_on_return(cpp2::move(tmp_3_func))}; 
+  static_cast<void>(cpp2::move(tmp_3));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  ctx.set_group_invalid(1);
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,3>::match(r.pos, ctx, func_1(), reset_0(), other, func_5());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_4 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_4, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_13_possessive_modifier::regex_48_matcher<CharT>::to_string() -> std::string{return R"(foo(aA|bB)?+b)"; }
+
+
+#line 268 "pure2-regex_13_possessive_modifier.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_13_possessive_modifier());
 }

--- a/regression-tests/test-results/pure2-regex_14_multiline_modifier.cpp
+++ b/regression-tests/test-results/pure2-regex_14_multiline_modifier.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_14_multiline_modifier.cpp2"
 
-#line 165 "pure2-regex_14_multiline_modifier.cpp2"
+#line 166 "pure2-regex_14_multiline_modifier.cpp2"
 class test_tests_14_multiline_modifier;
   
 
@@ -18,37 +18,31 @@ class test_tests_14_multiline_modifier;
 #line 1 "pure2-regex_14_multiline_modifier.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_14_multiline_modifier.cpp2"
+#line 113 "pure2-regex_14_multiline_modifier.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_14_multiline_modifier.cpp2"
+#line 125 "pure2-regex_14_multiline_modifier.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_14_multiline_modifier.cpp2"
+#line 166 "pure2-regex_14_multiline_modifier.cpp2"
 class test_tests_14_multiline_modifier {
 
-#line 365 "pure2-regex_14_multiline_modifier.cpp2"
+#line 366 "pure2-regex_14_multiline_modifier.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,25 +70,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -108,25 +90,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -134,25 +110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -160,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -186,25 +150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -212,25 +170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -238,25 +190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -264,25 +210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -290,25 +230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_100_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_100_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_100_matcher() = default;
         public: regex_100_matcher(regex_100_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -316,25 +250,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_100_matcher> regex_100 {}; public: class regex_101_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_100_matcher<char>> regex_100 {}; public: template<typename CharT> class regex_101_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_101_matcher() = default;
         public: regex_101_matcher(regex_101_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -342,25 +270,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_101_matcher> regex_101 {}; public: class regex_102_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_101_matcher<char>> regex_101 {}; public: template<typename CharT> class regex_102_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_102_matcher() = default;
         public: regex_102_matcher(regex_102_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -368,25 +290,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_102_matcher> regex_102 {}; public: class regex_103_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_102_matcher<char>> regex_102 {}; public: template<typename CharT> class regex_103_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_103_matcher() = default;
         public: regex_103_matcher(regex_103_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -394,25 +310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_103_matcher> regex_103 {}; public: class regex_104_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_103_matcher<char>> regex_103 {}; public: template<typename CharT> class regex_104_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_104_matcher() = default;
         public: regex_104_matcher(regex_104_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -420,25 +330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_104_matcher> regex_104 {}; public: class regex_105_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_104_matcher<char>> regex_104 {}; public: template<typename CharT> class regex_105_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_105_matcher() = default;
         public: regex_105_matcher(regex_105_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -446,25 +350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_105_matcher> regex_105 {}; public: class regex_106_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_105_matcher<char>> regex_105 {}; public: template<typename CharT> class regex_106_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_106_matcher() = default;
         public: regex_106_matcher(regex_106_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -472,25 +370,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_106_matcher> regex_106 {}; public: class regex_107_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_106_matcher<char>> regex_106 {}; public: template<typename CharT> class regex_107_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_107_matcher() = default;
         public: regex_107_matcher(regex_107_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -498,25 +390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_107_matcher> regex_107 {}; public: class regex_108_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_107_matcher<char>> regex_107 {}; public: template<typename CharT> class regex_108_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_108_matcher() = default;
         public: regex_108_matcher(regex_108_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -524,25 +410,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_108_matcher> regex_108 {}; public: class regex_109_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_108_matcher<char>> regex_108 {}; public: template<typename CharT> class regex_109_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_109_matcher() = default;
         public: regex_109_matcher(regex_109_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -550,25 +430,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_109_matcher> regex_109 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_109_matcher<char>> regex_109 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -576,25 +450,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_110_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_110_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_110_matcher() = default;
         public: regex_110_matcher(regex_110_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -602,25 +470,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_110_matcher> regex_110 {}; public: class regex_111_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_110_matcher<char>> regex_110 {}; public: template<typename CharT> class regex_111_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_111_matcher() = default;
         public: regex_111_matcher(regex_111_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -628,25 +490,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_111_matcher> regex_111 {}; public: class regex_112_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_111_matcher<char>> regex_111 {}; public: template<typename CharT> class regex_112_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_112_matcher() = default;
         public: regex_112_matcher(regex_112_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -654,25 +510,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_112_matcher> regex_112 {}; public: class regex_113_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_112_matcher<char>> regex_112 {}; public: template<typename CharT> class regex_113_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_113_matcher() = default;
         public: regex_113_matcher(regex_113_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -680,25 +530,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_113_matcher> regex_113 {}; public: class regex_114_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_113_matcher<char>> regex_113 {}; public: template<typename CharT> class regex_114_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_114_matcher() = default;
         public: regex_114_matcher(regex_114_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -706,25 +550,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_114_matcher> regex_114 {}; public: class regex_115_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_114_matcher<char>> regex_114 {}; public: template<typename CharT> class regex_115_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_115_matcher() = default;
         public: regex_115_matcher(regex_115_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -732,25 +570,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_115_matcher> regex_115 {}; public: class regex_116_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_115_matcher<char>> regex_115 {}; public: template<typename CharT> class regex_116_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_116_matcher() = default;
         public: regex_116_matcher(regex_116_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -758,25 +590,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_116_matcher> regex_116 {}; public: class regex_117_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_116_matcher<char>> regex_116 {}; public: template<typename CharT> class regex_117_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_117_matcher() = default;
         public: regex_117_matcher(regex_117_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -784,25 +610,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_117_matcher> regex_117 {}; public: class regex_118_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_117_matcher<char>> regex_117 {}; public: template<typename CharT> class regex_118_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_118_matcher() = default;
         public: regex_118_matcher(regex_118_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -810,25 +630,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_118_matcher> regex_118 {}; public: class regex_119_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_118_matcher<char>> regex_118 {}; public: template<typename CharT> class regex_119_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_119_matcher() = default;
         public: regex_119_matcher(regex_119_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -836,25 +650,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_119_matcher> regex_119 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_119_matcher<char>> regex_119 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -862,25 +670,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_120_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_120_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_120_matcher() = default;
         public: regex_120_matcher(regex_120_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -888,25 +690,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_120_matcher> regex_120 {}; public: class regex_121_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_120_matcher<char>> regex_120 {}; public: template<typename CharT> class regex_121_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_121_matcher() = default;
         public: regex_121_matcher(regex_121_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -914,25 +710,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_121_matcher> regex_121 {}; public: class regex_122_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_121_matcher<char>> regex_121 {}; public: template<typename CharT> class regex_122_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_122_matcher() = default;
         public: regex_122_matcher(regex_122_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -940,25 +730,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_122_matcher> regex_122 {}; public: class regex_123_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_122_matcher<char>> regex_122 {}; public: template<typename CharT> class regex_123_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_123_matcher() = default;
         public: regex_123_matcher(regex_123_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -966,25 +750,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_123_matcher> regex_123 {}; public: class regex_124_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_123_matcher<char>> regex_123 {}; public: template<typename CharT> class regex_124_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_124_matcher() = default;
         public: regex_124_matcher(regex_124_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -992,25 +770,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_124_matcher> regex_124 {}; public: class regex_125_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_124_matcher<char>> regex_124 {}; public: template<typename CharT> class regex_125_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_125_matcher() = default;
         public: regex_125_matcher(regex_125_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1018,25 +790,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_125_matcher> regex_125 {}; public: class regex_126_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_125_matcher<char>> regex_125 {}; public: template<typename CharT> class regex_126_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_126_matcher() = default;
         public: regex_126_matcher(regex_126_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1044,25 +810,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_126_matcher> regex_126 {}; public: class regex_127_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_126_matcher<char>> regex_126 {}; public: template<typename CharT> class regex_127_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_127_matcher() = default;
         public: regex_127_matcher(regex_127_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1070,25 +830,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_127_matcher> regex_127 {}; public: class regex_128_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_127_matcher<char>> regex_127 {}; public: template<typename CharT> class regex_128_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_128_matcher() = default;
         public: regex_128_matcher(regex_128_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1096,25 +850,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_128_matcher> regex_128 {}; public: class regex_129_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_128_matcher<char>> regex_128 {}; public: template<typename CharT> class regex_129_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_129_matcher() = default;
         public: regex_129_matcher(regex_129_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1122,25 +870,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_129_matcher> regex_129 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_129_matcher<char>> regex_129 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1148,25 +890,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_130_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_130_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_130_matcher() = default;
         public: regex_130_matcher(regex_130_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1174,25 +910,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_130_matcher> regex_130 {}; public: class regex_131_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_130_matcher<char>> regex_130 {}; public: template<typename CharT> class regex_131_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_131_matcher() = default;
         public: regex_131_matcher(regex_131_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1200,25 +930,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_131_matcher> regex_131 {}; public: class regex_132_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_131_matcher<char>> regex_131 {}; public: template<typename CharT> class regex_132_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_132_matcher() = default;
         public: regex_132_matcher(regex_132_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1226,25 +950,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_132_matcher> regex_132 {}; public: class regex_133_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_132_matcher<char>> regex_132 {}; public: template<typename CharT> class regex_133_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_133_matcher() = default;
         public: regex_133_matcher(regex_133_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1252,25 +970,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_133_matcher> regex_133 {}; public: class regex_134_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_133_matcher<char>> regex_133 {}; public: template<typename CharT> class regex_134_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_134_matcher() = default;
         public: regex_134_matcher(regex_134_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1278,25 +990,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_134_matcher> regex_134 {}; public: class regex_135_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_134_matcher<char>> regex_134 {}; public: template<typename CharT> class regex_135_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_135_matcher() = default;
         public: regex_135_matcher(regex_135_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1304,25 +1010,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_135_matcher> regex_135 {}; public: class regex_136_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_135_matcher<char>> regex_135 {}; public: template<typename CharT> class regex_136_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_136_matcher() = default;
         public: regex_136_matcher(regex_136_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1330,25 +1030,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_136_matcher> regex_136 {}; public: class regex_137_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_136_matcher<char>> regex_136 {}; public: template<typename CharT> class regex_137_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_137_matcher() = default;
         public: regex_137_matcher(regex_137_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1356,25 +1050,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_137_matcher> regex_137 {}; public: class regex_138_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_137_matcher<char>> regex_137 {}; public: template<typename CharT> class regex_138_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_138_matcher() = default;
         public: regex_138_matcher(regex_138_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1382,25 +1070,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_138_matcher> regex_138 {}; public: class regex_139_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_138_matcher<char>> regex_138 {}; public: template<typename CharT> class regex_139_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_139_matcher() = default;
         public: regex_139_matcher(regex_139_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1408,25 +1090,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_139_matcher> regex_139 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_139_matcher<char>> regex_139 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1434,25 +1110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_140_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_140_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_140_matcher() = default;
         public: regex_140_matcher(regex_140_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1460,25 +1130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_140_matcher> regex_140 {}; public: class regex_141_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_140_matcher<char>> regex_140 {}; public: template<typename CharT> class regex_141_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_141_matcher() = default;
         public: regex_141_matcher(regex_141_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1486,25 +1150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_141_matcher> regex_141 {}; public: class regex_142_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_141_matcher<char>> regex_141 {}; public: template<typename CharT> class regex_142_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_142_matcher() = default;
         public: regex_142_matcher(regex_142_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1512,25 +1170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_142_matcher> regex_142 {}; public: class regex_143_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_142_matcher<char>> regex_142 {}; public: template<typename CharT> class regex_143_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_143_matcher() = default;
         public: regex_143_matcher(regex_143_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1538,25 +1190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_143_matcher> regex_143 {}; public: class regex_144_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_143_matcher<char>> regex_143 {}; public: template<typename CharT> class regex_144_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_144_matcher() = default;
         public: regex_144_matcher(regex_144_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1564,25 +1210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_144_matcher> regex_144 {}; public: class regex_145_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_144_matcher<char>> regex_144 {}; public: template<typename CharT> class regex_145_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_145_matcher() = default;
         public: regex_145_matcher(regex_145_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1590,25 +1230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_145_matcher> regex_145 {}; public: class regex_146_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_145_matcher<char>> regex_145 {}; public: template<typename CharT> class regex_146_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_146_matcher() = default;
         public: regex_146_matcher(regex_146_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1616,25 +1250,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_146_matcher> regex_146 {}; public: class regex_147_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_146_matcher<char>> regex_146 {}; public: template<typename CharT> class regex_147_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_147_matcher() = default;
         public: regex_147_matcher(regex_147_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1642,25 +1270,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_147_matcher> regex_147 {}; public: class regex_148_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_147_matcher<char>> regex_147 {}; public: template<typename CharT> class regex_148_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_148_matcher() = default;
         public: regex_148_matcher(regex_148_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1668,25 +1290,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_148_matcher> regex_148 {}; public: class regex_149_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_148_matcher<char>> regex_148 {}; public: template<typename CharT> class regex_149_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_149_matcher() = default;
         public: regex_149_matcher(regex_149_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1694,25 +1310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_149_matcher> regex_149 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_149_matcher<char>> regex_149 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1720,25 +1330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_150_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_150_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_150_matcher() = default;
         public: regex_150_matcher(regex_150_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1746,25 +1350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_150_matcher> regex_150 {}; public: class regex_151_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_150_matcher<char>> regex_150 {}; public: template<typename CharT> class regex_151_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_151_matcher() = default;
         public: regex_151_matcher(regex_151_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1772,25 +1370,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_151_matcher> regex_151 {}; public: class regex_152_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_151_matcher<char>> regex_151 {}; public: template<typename CharT> class regex_152_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_152_matcher() = default;
         public: regex_152_matcher(regex_152_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1798,25 +1390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_152_matcher> regex_152 {}; public: class regex_153_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_152_matcher<char>> regex_152 {}; public: template<typename CharT> class regex_153_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_153_matcher() = default;
         public: regex_153_matcher(regex_153_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1824,25 +1410,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_153_matcher> regex_153 {}; public: class regex_154_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_153_matcher<char>> regex_153 {}; public: template<typename CharT> class regex_154_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_154_matcher() = default;
         public: regex_154_matcher(regex_154_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1850,25 +1430,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_154_matcher> regex_154 {}; public: class regex_155_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_154_matcher<char>> regex_154 {}; public: template<typename CharT> class regex_155_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_155_matcher() = default;
         public: regex_155_matcher(regex_155_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1876,25 +1450,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_155_matcher> regex_155 {}; public: class regex_156_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_155_matcher<char>> regex_155 {}; public: template<typename CharT> class regex_156_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_156_matcher() = default;
         public: regex_156_matcher(regex_156_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1902,25 +1470,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_156_matcher> regex_156 {}; public: class regex_157_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_156_matcher<char>> regex_156 {}; public: template<typename CharT> class regex_157_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_157_matcher() = default;
         public: regex_157_matcher(regex_157_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1928,25 +1490,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_157_matcher> regex_157 {}; public: class regex_158_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_157_matcher<char>> regex_157 {}; public: template<typename CharT> class regex_158_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_158_matcher() = default;
         public: regex_158_matcher(regex_158_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1954,25 +1510,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_158_matcher> regex_158 {}; public: class regex_159_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_158_matcher<char>> regex_158 {}; public: template<typename CharT> class regex_159_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_159_matcher() = default;
         public: regex_159_matcher(regex_159_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1980,25 +1530,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_159_matcher> regex_159 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_159_matcher<char>> regex_159 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2006,25 +1550,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_160_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_160_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_160_matcher() = default;
         public: regex_160_matcher(regex_160_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2032,25 +1570,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_160_matcher> regex_160 {}; public: class regex_161_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_160_matcher<char>> regex_160 {}; public: template<typename CharT> class regex_161_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_161_matcher() = default;
         public: regex_161_matcher(regex_161_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2058,25 +1590,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_161_matcher> regex_161 {}; public: class regex_162_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_161_matcher<char>> regex_161 {}; public: template<typename CharT> class regex_162_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_162_matcher() = default;
         public: regex_162_matcher(regex_162_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2084,25 +1610,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_162_matcher> regex_162 {}; public: class regex_163_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_162_matcher<char>> regex_162 {}; public: template<typename CharT> class regex_163_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_163_matcher() = default;
         public: regex_163_matcher(regex_163_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2110,25 +1630,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_163_matcher> regex_163 {}; public: class regex_164_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_163_matcher<char>> regex_163 {}; public: template<typename CharT> class regex_164_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_164_matcher() = default;
         public: regex_164_matcher(regex_164_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2136,25 +1650,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_164_matcher> regex_164 {}; public: class regex_165_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_164_matcher<char>> regex_164 {}; public: template<typename CharT> class regex_165_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_165_matcher() = default;
         public: regex_165_matcher(regex_165_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2162,25 +1670,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_165_matcher> regex_165 {}; public: class regex_166_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_165_matcher<char>> regex_165 {}; public: template<typename CharT> class regex_166_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_166_matcher() = default;
         public: regex_166_matcher(regex_166_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2188,25 +1690,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_166_matcher> regex_166 {}; public: class regex_167_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_166_matcher<char>> regex_166 {}; public: template<typename CharT> class regex_167_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_167_matcher() = default;
         public: regex_167_matcher(regex_167_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2214,25 +1710,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_167_matcher> regex_167 {}; public: class regex_168_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_167_matcher<char>> regex_167 {}; public: template<typename CharT> class regex_168_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_168_matcher() = default;
         public: regex_168_matcher(regex_168_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2240,25 +1730,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_168_matcher> regex_168 {}; public: class regex_169_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_168_matcher<char>> regex_168 {}; public: template<typename CharT> class regex_169_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_169_matcher() = default;
         public: regex_169_matcher(regex_169_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2266,25 +1750,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_169_matcher> regex_169 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_169_matcher<char>> regex_169 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2292,25 +1770,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_170_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_170_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_170_matcher() = default;
         public: regex_170_matcher(regex_170_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2318,25 +1790,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_170_matcher> regex_170 {}; public: class regex_171_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_170_matcher<char>> regex_170 {}; public: template<typename CharT> class regex_171_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_171_matcher() = default;
         public: regex_171_matcher(regex_171_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2344,25 +1810,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_171_matcher> regex_171 {}; public: class regex_172_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_171_matcher<char>> regex_171 {}; public: template<typename CharT> class regex_172_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_172_matcher() = default;
         public: regex_172_matcher(regex_172_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2370,25 +1830,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_172_matcher> regex_172 {}; public: class regex_173_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_172_matcher<char>> regex_172 {}; public: template<typename CharT> class regex_173_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_173_matcher() = default;
         public: regex_173_matcher(regex_173_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2396,25 +1850,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_173_matcher> regex_173 {}; public: class regex_174_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_173_matcher<char>> regex_173 {}; public: template<typename CharT> class regex_174_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_174_matcher() = default;
         public: regex_174_matcher(regex_174_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2422,25 +1870,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_174_matcher> regex_174 {}; public: class regex_175_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_174_matcher<char>> regex_174 {}; public: template<typename CharT> class regex_175_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_175_matcher() = default;
         public: regex_175_matcher(regex_175_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2448,25 +1890,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_175_matcher> regex_175 {}; public: class regex_176_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_175_matcher<char>> regex_175 {}; public: template<typename CharT> class regex_176_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_176_matcher() = default;
         public: regex_176_matcher(regex_176_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2474,25 +1910,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_176_matcher> regex_176 {}; public: class regex_177_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_176_matcher<char>> regex_176 {}; public: template<typename CharT> class regex_177_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_177_matcher() = default;
         public: regex_177_matcher(regex_177_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2500,25 +1930,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_177_matcher> regex_177 {}; public: class regex_178_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_177_matcher<char>> regex_177 {}; public: template<typename CharT> class regex_178_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_178_matcher() = default;
         public: regex_178_matcher(regex_178_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2526,25 +1950,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_178_matcher> regex_178 {}; public: class regex_179_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_178_matcher<char>> regex_178 {}; public: template<typename CharT> class regex_179_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_179_matcher() = default;
         public: regex_179_matcher(regex_179_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2552,25 +1970,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_179_matcher> regex_179 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_179_matcher<char>> regex_179 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2578,25 +1990,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_180_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_180_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_180_matcher() = default;
         public: regex_180_matcher(regex_180_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2604,25 +2010,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_180_matcher> regex_180 {}; public: class regex_181_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_180_matcher<char>> regex_180 {}; public: template<typename CharT> class regex_181_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_181_matcher() = default;
         public: regex_181_matcher(regex_181_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2630,25 +2030,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_181_matcher> regex_181 {}; public: class regex_182_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_181_matcher<char>> regex_181 {}; public: template<typename CharT> class regex_182_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_182_matcher() = default;
         public: regex_182_matcher(regex_182_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2656,25 +2050,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_182_matcher> regex_182 {}; public: class regex_183_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_182_matcher<char>> regex_182 {}; public: template<typename CharT> class regex_183_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_183_matcher() = default;
         public: regex_183_matcher(regex_183_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2682,25 +2070,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_183_matcher> regex_183 {}; public: class regex_184_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_183_matcher<char>> regex_183 {}; public: template<typename CharT> class regex_184_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_184_matcher() = default;
         public: regex_184_matcher(regex_184_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2708,25 +2090,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_184_matcher> regex_184 {}; public: class regex_185_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_184_matcher<char>> regex_184 {}; public: template<typename CharT> class regex_185_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_185_matcher() = default;
         public: regex_185_matcher(regex_185_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2734,25 +2110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_185_matcher> regex_185 {}; public: class regex_186_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_185_matcher<char>> regex_185 {}; public: template<typename CharT> class regex_186_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_186_matcher() = default;
         public: regex_186_matcher(regex_186_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2760,25 +2130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_186_matcher> regex_186 {}; public: class regex_187_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_186_matcher<char>> regex_186 {}; public: template<typename CharT> class regex_187_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_187_matcher() = default;
         public: regex_187_matcher(regex_187_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2786,25 +2150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_187_matcher> regex_187 {}; public: class regex_188_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_187_matcher<char>> regex_187 {}; public: template<typename CharT> class regex_188_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_188_matcher() = default;
         public: regex_188_matcher(regex_188_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2812,25 +2170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_188_matcher> regex_188 {}; public: class regex_189_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_188_matcher<char>> regex_188 {}; public: template<typename CharT> class regex_189_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_189_matcher() = default;
         public: regex_189_matcher(regex_189_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2838,25 +2190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_189_matcher> regex_189 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_189_matcher<char>> regex_189 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2864,25 +2210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_190_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_190_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_190_matcher() = default;
         public: regex_190_matcher(regex_190_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2890,25 +2230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_190_matcher> regex_190 {}; public: class regex_191_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_190_matcher<char>> regex_190 {}; public: template<typename CharT> class regex_191_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_191_matcher() = default;
         public: regex_191_matcher(regex_191_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2916,25 +2250,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_191_matcher> regex_191 {}; public: class regex_192_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_191_matcher<char>> regex_191 {}; public: template<typename CharT> class regex_192_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_192_matcher() = default;
         public: regex_192_matcher(regex_192_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2942,25 +2270,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_192_matcher> regex_192 {}; public: class regex_193_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_192_matcher<char>> regex_192 {}; public: template<typename CharT> class regex_193_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_193_matcher() = default;
         public: regex_193_matcher(regex_193_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2968,25 +2290,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_193_matcher> regex_193 {}; public: class regex_194_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_193_matcher<char>> regex_193 {}; public: template<typename CharT> class regex_194_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_194_matcher() = default;
         public: regex_194_matcher(regex_194_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2994,25 +2310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_194_matcher> regex_194 {}; public: class regex_195_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_194_matcher<char>> regex_194 {}; public: template<typename CharT> class regex_195_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_195_matcher() = default;
         public: regex_195_matcher(regex_195_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3020,25 +2330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_195_matcher> regex_195 {}; public: class regex_196_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_195_matcher<char>> regex_195 {}; public: template<typename CharT> class regex_196_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_196_matcher() = default;
         public: regex_196_matcher(regex_196_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3046,25 +2350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_196_matcher> regex_196 {}; public: class regex_197_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_196_matcher<char>> regex_196 {}; public: template<typename CharT> class regex_197_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_197_matcher() = default;
         public: regex_197_matcher(regex_197_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3072,25 +2370,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_197_matcher> regex_197 {}; public: class regex_198_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_197_matcher<char>> regex_197 {}; public: template<typename CharT> class regex_198_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_198_matcher() = default;
         public: regex_198_matcher(regex_198_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3098,25 +2390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_198_matcher> regex_198 {}; public: class regex_199_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_198_matcher<char>> regex_198 {}; public: template<typename CharT> class regex_199_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_199_matcher() = default;
         public: regex_199_matcher(regex_199_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3124,25 +2410,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_199_matcher> regex_199 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_199_matcher<char>> regex_199 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3150,25 +2430,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; public: class regex_21_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_21_matcher() = default;
         public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3176,25 +2450,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_21_matcher> regex_21 {}; public: class regex_22_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_22_matcher() = default;
         public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3202,25 +2470,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_22_matcher> regex_22 {}; public: class regex_23_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_23_matcher() = default;
         public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3228,25 +2490,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_23_matcher> regex_23 {}; public: class regex_24_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_24_matcher() = default;
         public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3254,25 +2510,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_24_matcher> regex_24 {}; public: class regex_25_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; public: template<typename CharT> class regex_25_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_25_matcher() = default;
         public: regex_25_matcher(regex_25_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3280,25 +2530,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_25_matcher> regex_25 {}; public: class regex_26_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_25_matcher<char>> regex_25 {}; public: template<typename CharT> class regex_26_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_26_matcher() = default;
         public: regex_26_matcher(regex_26_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3306,25 +2550,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_26_matcher> regex_26 {}; public: class regex_27_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_26_matcher<char>> regex_26 {}; public: template<typename CharT> class regex_27_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_27_matcher() = default;
         public: regex_27_matcher(regex_27_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3332,25 +2570,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_27_matcher> regex_27 {}; public: class regex_28_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_27_matcher<char>> regex_27 {}; public: template<typename CharT> class regex_28_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_28_matcher() = default;
         public: regex_28_matcher(regex_28_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3358,25 +2590,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_28_matcher> regex_28 {}; public: class regex_29_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_28_matcher<char>> regex_28 {}; public: template<typename CharT> class regex_29_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_29_matcher() = default;
         public: regex_29_matcher(regex_29_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3384,25 +2610,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_29_matcher> regex_29 {}; public: class regex_30_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_29_matcher<char>> regex_29 {}; public: template<typename CharT> class regex_30_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_30_matcher() = default;
         public: regex_30_matcher(regex_30_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3410,25 +2630,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_30_matcher> regex_30 {}; public: class regex_31_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_30_matcher<char>> regex_30 {}; public: template<typename CharT> class regex_31_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_31_matcher() = default;
         public: regex_31_matcher(regex_31_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3436,25 +2650,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_31_matcher> regex_31 {}; public: class regex_32_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_31_matcher<char>> regex_31 {}; public: template<typename CharT> class regex_32_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_32_matcher() = default;
         public: regex_32_matcher(regex_32_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3462,25 +2670,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_32_matcher> regex_32 {}; public: class regex_33_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_32_matcher<char>> regex_32 {}; public: template<typename CharT> class regex_33_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_33_matcher() = default;
         public: regex_33_matcher(regex_33_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3488,25 +2690,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_33_matcher> regex_33 {}; public: class regex_34_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_33_matcher<char>> regex_33 {}; public: template<typename CharT> class regex_34_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_34_matcher() = default;
         public: regex_34_matcher(regex_34_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3514,25 +2710,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_34_matcher> regex_34 {}; public: class regex_35_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_34_matcher<char>> regex_34 {}; public: template<typename CharT> class regex_35_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_35_matcher() = default;
         public: regex_35_matcher(regex_35_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3540,25 +2730,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_35_matcher> regex_35 {}; public: class regex_36_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_35_matcher<char>> regex_35 {}; public: template<typename CharT> class regex_36_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_36_matcher() = default;
         public: regex_36_matcher(regex_36_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3566,25 +2750,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_36_matcher> regex_36 {}; public: class regex_37_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_36_matcher<char>> regex_36 {}; public: template<typename CharT> class regex_37_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_37_matcher() = default;
         public: regex_37_matcher(regex_37_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3592,25 +2770,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_37_matcher> regex_37 {}; public: class regex_38_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_37_matcher<char>> regex_37 {}; public: template<typename CharT> class regex_38_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_38_matcher() = default;
         public: regex_38_matcher(regex_38_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3618,25 +2790,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_38_matcher> regex_38 {}; public: class regex_39_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_38_matcher<char>> regex_38 {}; public: template<typename CharT> class regex_39_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_39_matcher() = default;
         public: regex_39_matcher(regex_39_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3644,25 +2810,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_39_matcher> regex_39 {}; public: class regex_40_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_39_matcher<char>> regex_39 {}; public: template<typename CharT> class regex_40_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_40_matcher() = default;
         public: regex_40_matcher(regex_40_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3670,25 +2830,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_40_matcher> regex_40 {}; public: class regex_41_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_40_matcher<char>> regex_40 {}; public: template<typename CharT> class regex_41_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_41_matcher() = default;
         public: regex_41_matcher(regex_41_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3696,25 +2850,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_41_matcher> regex_41 {}; public: class regex_42_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_41_matcher<char>> regex_41 {}; public: template<typename CharT> class regex_42_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_42_matcher() = default;
         public: regex_42_matcher(regex_42_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3722,25 +2870,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_42_matcher> regex_42 {}; public: class regex_43_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_42_matcher<char>> regex_42 {}; public: template<typename CharT> class regex_43_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_43_matcher() = default;
         public: regex_43_matcher(regex_43_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3748,25 +2890,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_43_matcher> regex_43 {}; public: class regex_44_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_43_matcher<char>> regex_43 {}; public: template<typename CharT> class regex_44_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_44_matcher() = default;
         public: regex_44_matcher(regex_44_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3774,25 +2910,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_44_matcher> regex_44 {}; public: class regex_45_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_44_matcher<char>> regex_44 {}; public: template<typename CharT> class regex_45_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_45_matcher() = default;
         public: regex_45_matcher(regex_45_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3800,25 +2930,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_45_matcher> regex_45 {}; public: class regex_46_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_45_matcher<char>> regex_45 {}; public: template<typename CharT> class regex_46_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_46_matcher() = default;
         public: regex_46_matcher(regex_46_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3826,25 +2950,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_46_matcher> regex_46 {}; public: class regex_47_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_46_matcher<char>> regex_46 {}; public: template<typename CharT> class regex_47_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_47_matcher() = default;
         public: regex_47_matcher(regex_47_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3852,25 +2970,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_47_matcher> regex_47 {}; public: class regex_48_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_47_matcher<char>> regex_47 {}; public: template<typename CharT> class regex_48_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_48_matcher() = default;
         public: regex_48_matcher(regex_48_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3878,25 +2990,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_48_matcher> regex_48 {}; public: class regex_49_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_48_matcher<char>> regex_48 {}; public: template<typename CharT> class regex_49_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_49_matcher() = default;
         public: regex_49_matcher(regex_49_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3904,25 +3010,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_49_matcher> regex_49 {}; public: class regex_50_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_49_matcher<char>> regex_49 {}; public: template<typename CharT> class regex_50_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_50_matcher() = default;
         public: regex_50_matcher(regex_50_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3930,25 +3030,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_50_matcher> regex_50 {}; public: class regex_51_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_50_matcher<char>> regex_50 {}; public: template<typename CharT> class regex_51_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_51_matcher() = default;
         public: regex_51_matcher(regex_51_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3956,25 +3050,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_51_matcher> regex_51 {}; public: class regex_52_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_51_matcher<char>> regex_51 {}; public: template<typename CharT> class regex_52_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_52_matcher() = default;
         public: regex_52_matcher(regex_52_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -3982,25 +3070,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_52_matcher> regex_52 {}; public: class regex_53_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_52_matcher<char>> regex_52 {}; public: template<typename CharT> class regex_53_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_53_matcher() = default;
         public: regex_53_matcher(regex_53_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4008,25 +3090,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_53_matcher> regex_53 {}; public: class regex_54_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_53_matcher<char>> regex_53 {}; public: template<typename CharT> class regex_54_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_54_matcher() = default;
         public: regex_54_matcher(regex_54_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4034,25 +3110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_54_matcher> regex_54 {}; public: class regex_55_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_54_matcher<char>> regex_54 {}; public: template<typename CharT> class regex_55_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_55_matcher() = default;
         public: regex_55_matcher(regex_55_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4060,25 +3130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_55_matcher> regex_55 {}; public: class regex_56_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_55_matcher<char>> regex_55 {}; public: template<typename CharT> class regex_56_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_56_matcher() = default;
         public: regex_56_matcher(regex_56_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4086,25 +3150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_56_matcher> regex_56 {}; public: class regex_57_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_56_matcher<char>> regex_56 {}; public: template<typename CharT> class regex_57_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_57_matcher() = default;
         public: regex_57_matcher(regex_57_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4112,25 +3170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_57_matcher> regex_57 {}; public: class regex_58_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_57_matcher<char>> regex_57 {}; public: template<typename CharT> class regex_58_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_58_matcher() = default;
         public: regex_58_matcher(regex_58_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4138,25 +3190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_58_matcher> regex_58 {}; public: class regex_59_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_58_matcher<char>> regex_58 {}; public: template<typename CharT> class regex_59_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_59_matcher() = default;
         public: regex_59_matcher(regex_59_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4164,25 +3210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_59_matcher> regex_59 {}; public: class regex_60_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_59_matcher<char>> regex_59 {}; public: template<typename CharT> class regex_60_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_60_matcher() = default;
         public: regex_60_matcher(regex_60_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4190,25 +3230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_60_matcher> regex_60 {}; public: class regex_61_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_60_matcher<char>> regex_60 {}; public: template<typename CharT> class regex_61_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_61_matcher() = default;
         public: regex_61_matcher(regex_61_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4216,25 +3250,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_61_matcher> regex_61 {}; public: class regex_62_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_61_matcher<char>> regex_61 {}; public: template<typename CharT> class regex_62_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_62_matcher() = default;
         public: regex_62_matcher(regex_62_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4242,25 +3270,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_62_matcher> regex_62 {}; public: class regex_63_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_62_matcher<char>> regex_62 {}; public: template<typename CharT> class regex_63_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_63_matcher() = default;
         public: regex_63_matcher(regex_63_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4268,25 +3290,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_63_matcher> regex_63 {}; public: class regex_64_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_63_matcher<char>> regex_63 {}; public: template<typename CharT> class regex_64_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_64_matcher() = default;
         public: regex_64_matcher(regex_64_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4294,25 +3310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_64_matcher> regex_64 {}; public: class regex_65_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_64_matcher<char>> regex_64 {}; public: template<typename CharT> class regex_65_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_65_matcher() = default;
         public: regex_65_matcher(regex_65_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4320,25 +3330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_65_matcher> regex_65 {}; public: class regex_66_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_65_matcher<char>> regex_65 {}; public: template<typename CharT> class regex_66_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_66_matcher() = default;
         public: regex_66_matcher(regex_66_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4346,25 +3350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_66_matcher> regex_66 {}; public: class regex_67_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_66_matcher<char>> regex_66 {}; public: template<typename CharT> class regex_67_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_67_matcher() = default;
         public: regex_67_matcher(regex_67_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4372,25 +3370,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_67_matcher> regex_67 {}; public: class regex_68_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_67_matcher<char>> regex_67 {}; public: template<typename CharT> class regex_68_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_68_matcher() = default;
         public: regex_68_matcher(regex_68_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4398,25 +3390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_68_matcher> regex_68 {}; public: class regex_69_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_68_matcher<char>> regex_68 {}; public: template<typename CharT> class regex_69_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_69_matcher() = default;
         public: regex_69_matcher(regex_69_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4424,25 +3410,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_69_matcher> regex_69 {}; public: class regex_70_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_69_matcher<char>> regex_69 {}; public: template<typename CharT> class regex_70_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_70_matcher() = default;
         public: regex_70_matcher(regex_70_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4450,25 +3430,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_70_matcher> regex_70 {}; public: class regex_71_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_70_matcher<char>> regex_70 {}; public: template<typename CharT> class regex_71_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_71_matcher() = default;
         public: regex_71_matcher(regex_71_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4476,25 +3450,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_71_matcher> regex_71 {}; public: class regex_72_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_71_matcher<char>> regex_71 {}; public: template<typename CharT> class regex_72_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_72_matcher() = default;
         public: regex_72_matcher(regex_72_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4502,25 +3470,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_72_matcher> regex_72 {}; public: class regex_73_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_72_matcher<char>> regex_72 {}; public: template<typename CharT> class regex_73_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_73_matcher() = default;
         public: regex_73_matcher(regex_73_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4528,25 +3490,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_73_matcher> regex_73 {}; public: class regex_74_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_73_matcher<char>> regex_73 {}; public: template<typename CharT> class regex_74_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_74_matcher() = default;
         public: regex_74_matcher(regex_74_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4554,25 +3510,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_74_matcher> regex_74 {}; public: class regex_75_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_74_matcher<char>> regex_74 {}; public: template<typename CharT> class regex_75_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_75_matcher() = default;
         public: regex_75_matcher(regex_75_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4580,25 +3530,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_75_matcher> regex_75 {}; public: class regex_76_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_75_matcher<char>> regex_75 {}; public: template<typename CharT> class regex_76_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_76_matcher() = default;
         public: regex_76_matcher(regex_76_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4606,25 +3550,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_76_matcher> regex_76 {}; public: class regex_77_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_76_matcher<char>> regex_76 {}; public: template<typename CharT> class regex_77_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_77_matcher() = default;
         public: regex_77_matcher(regex_77_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4632,25 +3570,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_77_matcher> regex_77 {}; public: class regex_78_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_77_matcher<char>> regex_77 {}; public: template<typename CharT> class regex_78_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_78_matcher() = default;
         public: regex_78_matcher(regex_78_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4658,25 +3590,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_78_matcher> regex_78 {}; public: class regex_79_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_78_matcher<char>> regex_78 {}; public: template<typename CharT> class regex_79_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_79_matcher() = default;
         public: regex_79_matcher(regex_79_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4684,25 +3610,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_79_matcher> regex_79 {}; public: class regex_80_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_79_matcher<char>> regex_79 {}; public: template<typename CharT> class regex_80_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_80_matcher() = default;
         public: regex_80_matcher(regex_80_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4710,25 +3630,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_80_matcher> regex_80 {}; public: class regex_81_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_80_matcher<char>> regex_80 {}; public: template<typename CharT> class regex_81_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_81_matcher() = default;
         public: regex_81_matcher(regex_81_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4736,25 +3650,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_81_matcher> regex_81 {}; public: class regex_82_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_81_matcher<char>> regex_81 {}; public: template<typename CharT> class regex_82_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_82_matcher() = default;
         public: regex_82_matcher(regex_82_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4762,25 +3670,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_82_matcher> regex_82 {}; public: class regex_83_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_82_matcher<char>> regex_82 {}; public: template<typename CharT> class regex_83_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_83_matcher() = default;
         public: regex_83_matcher(regex_83_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4788,25 +3690,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_83_matcher> regex_83 {}; public: class regex_84_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_83_matcher<char>> regex_83 {}; public: template<typename CharT> class regex_84_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_84_matcher() = default;
         public: regex_84_matcher(regex_84_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4814,25 +3710,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_84_matcher> regex_84 {}; public: class regex_85_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_84_matcher<char>> regex_84 {}; public: template<typename CharT> class regex_85_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_85_matcher() = default;
         public: regex_85_matcher(regex_85_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4840,25 +3730,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_85_matcher> regex_85 {}; public: class regex_86_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_85_matcher<char>> regex_85 {}; public: template<typename CharT> class regex_86_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_86_matcher() = default;
         public: regex_86_matcher(regex_86_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4866,25 +3750,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_86_matcher> regex_86 {}; public: class regex_87_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_86_matcher<char>> regex_86 {}; public: template<typename CharT> class regex_87_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_87_matcher() = default;
         public: regex_87_matcher(regex_87_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4892,25 +3770,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_87_matcher> regex_87 {}; public: class regex_88_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_87_matcher<char>> regex_87 {}; public: template<typename CharT> class regex_88_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_88_matcher() = default;
         public: regex_88_matcher(regex_88_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4918,25 +3790,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_88_matcher> regex_88 {}; public: class regex_89_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_88_matcher<char>> regex_88 {}; public: template<typename CharT> class regex_89_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_89_matcher() = default;
         public: regex_89_matcher(regex_89_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4944,25 +3810,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_89_matcher> regex_89 {}; public: class regex_90_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_89_matcher<char>> regex_89 {}; public: template<typename CharT> class regex_90_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_90_matcher() = default;
         public: regex_90_matcher(regex_90_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4970,25 +3830,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_90_matcher> regex_90 {}; public: class regex_91_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_90_matcher<char>> regex_90 {}; public: template<typename CharT> class regex_91_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_91_matcher() = default;
         public: regex_91_matcher(regex_91_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -4996,25 +3850,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_91_matcher> regex_91 {}; public: class regex_92_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_91_matcher<char>> regex_91 {}; public: template<typename CharT> class regex_92_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_92_matcher() = default;
         public: regex_92_matcher(regex_92_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -5022,25 +3870,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_92_matcher> regex_92 {}; public: class regex_93_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_92_matcher<char>> regex_92 {}; public: template<typename CharT> class regex_93_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_93_matcher() = default;
         public: regex_93_matcher(regex_93_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -5048,25 +3890,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_93_matcher> regex_93 {}; public: class regex_94_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_93_matcher<char>> regex_93 {}; public: template<typename CharT> class regex_94_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_94_matcher() = default;
         public: regex_94_matcher(regex_94_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -5074,25 +3910,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_94_matcher> regex_94 {}; public: class regex_95_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_94_matcher<char>> regex_94 {}; public: template<typename CharT> class regex_95_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_95_matcher() = default;
         public: regex_95_matcher(regex_95_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -5100,25 +3930,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_95_matcher> regex_95 {}; public: class regex_96_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_95_matcher<char>> regex_95 {}; public: template<typename CharT> class regex_96_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_96_matcher() = default;
         public: regex_96_matcher(regex_96_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -5126,25 +3950,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_96_matcher> regex_96 {}; public: class regex_97_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_96_matcher<char>> regex_96 {}; public: template<typename CharT> class regex_97_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_97_matcher() = default;
         public: regex_97_matcher(regex_97_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -5152,25 +3970,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_97_matcher> regex_97 {}; public: class regex_98_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_97_matcher<char>> regex_97 {}; public: template<typename CharT> class regex_98_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_98_matcher() = default;
         public: regex_98_matcher(regex_98_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -5178,25 +3990,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_98_matcher> regex_98 {}; public: class regex_99_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_98_matcher<char>> regex_98 {}; public: template<typename CharT> class regex_99_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_99_matcher() = default;
         public: regex_99_matcher(regex_99_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -5204,13 +4010,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_99_matcher> regex_99 {}; 
+  public: cpp2::regex::regular_expression<char,regex_99_matcher<char>> regex_99 {}; 
   public: test_tests_14_multiline_modifier() = default;
   public: test_tests_14_multiline_modifier(test_tests_14_multiline_modifier const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_14_multiline_modifier const&) -> void = delete;
 
 
-#line 568 "pure2-regex_14_multiline_modifier.cpp2"
+#line 569 "pure2-regex_14_multiline_modifier.cpp2"
 };
 auto main() -> int;
 
@@ -5314,6 +4120,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -5329,7 +4136,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_14_multiline_modifier.cpp2"
+#line 113 "pure2-regex_14_multiline_modifier.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -5342,7 +4149,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_14_multiline_modifier.cpp2"
+#line 125 "pure2-regex_14_multiline_modifier.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -5383,7 +4190,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 365 "pure2-regex_14_multiline_modifier.cpp2"
+#line 366 "pure2-regex_14_multiline_modifier.cpp2"
   auto test_tests_14_multiline_modifier::run() const& -> void{
     std::cout << "Running tests_14_multiline_modifier:" << std::endl;
     test(regex_01, "01", R"(\Z)", "a\nb\n", "y", R"($-[0])", "3");
@@ -5591,8 +4398,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5607,10 +4413,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5618,19 +4425,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_01_matcher::to_string() -> std::string{return R"(\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_01_matcher<CharT>::to_string() -> std::string{return R"(\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5645,10 +4452,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5656,19 +4464,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_02_matcher::to_string() -> std::string{return R"(\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_02_matcher<CharT>::to_string() -> std::string{return R"(\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5683,10 +4491,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5694,19 +4503,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_03_matcher::to_string() -> std::string{return R"($)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_03_matcher<CharT>::to_string() -> std::string{return R"($)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5721,10 +4530,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5732,19 +4542,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_04_matcher::to_string() -> std::string{return R"(\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_04_matcher<CharT>::to_string() -> std::string{return R"(\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5759,10 +4569,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5770,19 +4581,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_05_matcher::to_string() -> std::string{return R"(\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_05_matcher<CharT>::to_string() -> std::string{return R"(\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5797,10 +4608,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5808,19 +4620,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_06_matcher::to_string() -> std::string{return R"($)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_06_matcher<CharT>::to_string() -> std::string{return R"($)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5835,10 +4647,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5846,19 +4659,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_07_matcher::to_string() -> std::string{return R"(\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_07_matcher<CharT>::to_string() -> std::string{return R"(\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5873,10 +4686,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5884,19 +4698,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_08_matcher::to_string() -> std::string{return R"(\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_08_matcher<CharT>::to_string() -> std::string{return R"(\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5911,10 +4725,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5922,19 +4737,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_09_matcher::to_string() -> std::string{return R"($)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_09_matcher<CharT>::to_string() -> std::string{return R"($)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5949,10 +4764,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5960,19 +4776,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_10_matcher::to_string() -> std::string{return R"('\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_10_matcher<CharT>::to_string() -> std::string{return R"('\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_100_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_100_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6001,10 +4817,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_100_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_100_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6012,19 +4829,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_100_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_100_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_100_matcher::to_string() -> std::string{return R"('ab\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_100_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_100_matcher<CharT>::to_string() -> std::string{return R"('ab\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_101_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_101_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6053,10 +4870,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_101_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_101_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6064,19 +4882,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_101_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_101_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_101_matcher::to_string() -> std::string{return R"('ab\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_101_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_101_matcher<CharT>::to_string() -> std::string{return R"('ab\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_102_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_102_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6105,10 +4923,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_102_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_102_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6116,19 +4935,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_102_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_102_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_102_matcher::to_string() -> std::string{return R"('ab$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_102_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_102_matcher<CharT>::to_string() -> std::string{return R"('ab$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_103_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_103_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6157,10 +4976,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_103_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_103_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6168,19 +4988,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_103_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_103_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_103_matcher::to_string() -> std::string{return R"('ab\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_103_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_103_matcher<CharT>::to_string() -> std::string{return R"('ab\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_104_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_104_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6209,10 +5029,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_104_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_104_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6220,19 +5041,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_104_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_104_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_104_matcher::to_string() -> std::string{return R"('ab\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_104_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_104_matcher<CharT>::to_string() -> std::string{return R"('ab\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_105_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_105_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6261,10 +5082,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_105_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_105_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6272,19 +5094,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_105_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_105_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_105_matcher::to_string() -> std::string{return R"('ab$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_105_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_105_matcher<CharT>::to_string() -> std::string{return R"('ab$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_106_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_106_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6313,10 +5135,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_106_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_106_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6324,19 +5147,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_106_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_106_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_106_matcher::to_string() -> std::string{return R"('ab\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_106_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_106_matcher<CharT>::to_string() -> std::string{return R"('ab\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_107_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_107_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6365,10 +5188,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_107_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_107_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6376,19 +5200,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_107_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_107_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_107_matcher::to_string() -> std::string{return R"('ab\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_107_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_107_matcher<CharT>::to_string() -> std::string{return R"('ab\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_108_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_108_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6417,10 +5241,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_108_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_108_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6428,19 +5253,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_108_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_108_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_108_matcher::to_string() -> std::string{return R"('ab$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_108_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_108_matcher<CharT>::to_string() -> std::string{return R"('ab$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_109_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_109_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6469,10 +5294,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_109_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_109_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6480,19 +5306,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_109_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_109_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_109_matcher::to_string() -> std::string{return R"(ab\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_109_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_109_matcher<CharT>::to_string() -> std::string{return R"(ab\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6507,10 +5333,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6518,175 +5345,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_11_matcher::to_string() -> std::string{return R"('\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_11_matcher<CharT>::to_string() -> std::string{return R"('\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_110_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_110_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_110_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_110_matcher::to_string() -> std::string{return R"(ab\z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_111_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_111_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_111_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_111_matcher::to_string() -> std::string{return R"(ab$)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_112_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_112_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_112_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_112_matcher::to_string() -> std::string{return R"(ab\Z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_113_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_110_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6715,10 +5386,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_113_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_110_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6726,19 +5398,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_113_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_110_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_113_matcher::to_string() -> std::string{return R"(ab\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_110_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_110_matcher<CharT>::to_string() -> std::string{return R"(ab\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_114_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_111_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6767,10 +5439,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_114_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_111_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6778,19 +5451,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_114_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_111_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_114_matcher::to_string() -> std::string{return R"(ab$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_111_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_111_matcher<CharT>::to_string() -> std::string{return R"(ab$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_115_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_112_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6819,10 +5492,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_115_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_112_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6830,19 +5504,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_115_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_112_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_115_matcher::to_string() -> std::string{return R"(ab\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_112_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_112_matcher<CharT>::to_string() -> std::string{return R"(ab\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_116_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_113_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6871,10 +5545,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_116_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_113_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6882,19 +5557,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_116_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_113_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_116_matcher::to_string() -> std::string{return R"(ab\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_113_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_113_matcher<CharT>::to_string() -> std::string{return R"(ab\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_117_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_114_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6923,10 +5598,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_117_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_114_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6934,19 +5610,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_117_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_114_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_117_matcher::to_string() -> std::string{return R"(ab$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_114_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_114_matcher<CharT>::to_string() -> std::string{return R"(ab$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_118_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_115_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6975,10 +5651,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_118_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_115_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6986,19 +5663,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_118_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_115_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_118_matcher::to_string() -> std::string{return R"('ab\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_115_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_115_matcher<CharT>::to_string() -> std::string{return R"(ab\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_119_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_116_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7027,10 +5704,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_119_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_116_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7038,19 +5716,178 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_119_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_116_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_119_matcher::to_string() -> std::string{return R"('ab\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_116_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_116_matcher<CharT>::to_string() -> std::string{return R"(ab\z)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_117_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_117_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_117_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_117_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_117_matcher<CharT>::to_string() -> std::string{return R"(ab$)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_118_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_118_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_118_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_118_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_118_matcher<CharT>::to_string() -> std::string{return R"('ab\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_119_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_119_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_119_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_119_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_119_matcher<CharT>::to_string() -> std::string{return R"('ab\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7065,10 +5902,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7076,175 +5914,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_12_matcher::to_string() -> std::string{return R"('$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_12_matcher<CharT>::to_string() -> std::string{return R"('$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_120_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_120_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_120_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_120_matcher::to_string() -> std::string{return R"('ab$'m)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_121_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_121_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_121_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_121_matcher::to_string() -> std::string{return R"('ab\Z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_122_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_122_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_122_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_122_matcher::to_string() -> std::string{return R"('ab\z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_123_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_120_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7273,10 +5955,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_123_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_120_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7284,19 +5967,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_123_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_120_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_123_matcher::to_string() -> std::string{return R"('ab$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_120_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_120_matcher<CharT>::to_string() -> std::string{return R"('ab$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_124_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_121_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7325,10 +6008,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_124_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_121_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7336,19 +6020,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_124_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_121_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_124_matcher::to_string() -> std::string{return R"('ab\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_121_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_121_matcher<CharT>::to_string() -> std::string{return R"('ab\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_125_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_122_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7377,10 +6061,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_125_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_122_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7388,681 +6073,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_125_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_122_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_125_matcher::to_string() -> std::string{return R"('ab\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_122_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_122_matcher<CharT>::to_string() -> std::string{return R"('ab\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_126_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_126_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_126_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_126_matcher::to_string() -> std::string{return R"('ab$'m)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_127_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_127_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_127_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_127_matcher::to_string() -> std::string{return R"(ab\Z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_128_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_128_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_128_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_128_matcher::to_string() -> std::string{return R"(ab\z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_129_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_129_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_129_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_129_matcher::to_string() -> std::string{return R"(ab$)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_13_matcher::to_string() -> std::string{return R"('\Z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_130_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_130_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_130_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_130_matcher::to_string() -> std::string{return R"(ab\Z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_131_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_131_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_131_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_131_matcher::to_string() -> std::string{return R"(ab\z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_132_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_132_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_132_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_132_matcher::to_string() -> std::string{return R"(ab$)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_133_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_133_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_133_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_133_matcher::to_string() -> std::string{return R"(ab\Z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_134_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_134_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_134_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_134_matcher::to_string() -> std::string{return R"(ab\z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_135_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_135_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_135_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_135_matcher::to_string() -> std::string{return R"(ab$)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_136_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_136_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_136_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_136_matcher::to_string() -> std::string{return R"('ab\Z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_137_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 2;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_137_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_137_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_137_matcher::to_string() -> std::string{return R"('ab\z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_138_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_123_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8091,10 +6114,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_138_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_123_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8102,19 +6126,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_138_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_123_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_138_matcher::to_string() -> std::string{return R"('ab$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_123_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_123_matcher<CharT>::to_string() -> std::string{return R"('ab$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_139_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_124_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8143,10 +6167,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_139_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_124_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8154,57 +6179,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_139_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_124_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_139_matcher::to_string() -> std::string{return R"('ab\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_124_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_124_matcher<CharT>::to_string() -> std::string{return R"('ab\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_14_matcher::to_string() -> std::string{return R"('\z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_140_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_125_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8233,10 +6220,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_140_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_125_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8244,19 +6232,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_140_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_125_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_140_matcher::to_string() -> std::string{return R"('ab\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_125_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_125_matcher<CharT>::to_string() -> std::string{return R"('ab\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_141_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_126_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8285,10 +6273,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_141_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_126_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8296,19 +6285,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_141_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_126_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_141_matcher::to_string() -> std::string{return R"('ab$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_126_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_126_matcher<CharT>::to_string() -> std::string{return R"('ab$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_142_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_127_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8337,10 +6326,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_142_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_127_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8348,19 +6338,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_142_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_127_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_142_matcher::to_string() -> std::string{return R"('ab\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_127_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_127_matcher<CharT>::to_string() -> std::string{return R"(ab\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_143_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_128_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8389,10 +6379,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_143_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_128_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8400,19 +6391,535 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_143_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_128_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_143_matcher::to_string() -> std::string{return R"('ab\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_128_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_128_matcher<CharT>::to_string() -> std::string{return R"(ab\z)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_129_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_144_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_129_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_129_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_129_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_129_matcher<CharT>::to_string() -> std::string{return R"(ab$)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_13_matcher<CharT>::to_string() -> std::string{return R"('\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_130_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_130_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_130_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_130_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_130_matcher<CharT>::to_string() -> std::string{return R"(ab\Z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_131_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_131_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_131_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_131_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_131_matcher<CharT>::to_string() -> std::string{return R"(ab\z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_132_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_132_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_132_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_132_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_132_matcher<CharT>::to_string() -> std::string{return R"(ab$)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_133_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_133_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_133_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_133_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_133_matcher<CharT>::to_string() -> std::string{return R"(ab\Z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_134_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_134_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_134_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_134_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_134_matcher<CharT>::to_string() -> std::string{return R"(ab\z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_135_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_135_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_135_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_135_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_135_matcher<CharT>::to_string() -> std::string{return R"(ab$)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_136_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_136_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_136_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_136_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_136_matcher<CharT>::to_string() -> std::string{return R"('ab\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_137_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_137_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_137_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_137_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_137_matcher<CharT>::to_string() -> std::string{return R"('ab\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_138_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8441,10 +6948,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_144_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_138_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8452,19 +6960,376 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_144_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_138_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_144_matcher::to_string() -> std::string{return R"('ab$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_138_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_138_matcher<CharT>::to_string() -> std::string{return R"('ab$'m)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_139_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_145_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_139_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_139_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_139_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_139_matcher<CharT>::to_string() -> std::string{return R"('ab\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_14_matcher<CharT>::to_string() -> std::string{return R"('\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_140_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_140_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_140_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_140_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_140_matcher<CharT>::to_string() -> std::string{return R"('ab\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_141_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_141_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_141_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_141_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_141_matcher<CharT>::to_string() -> std::string{return R"('ab$'m)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_142_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_142_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_142_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_142_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_142_matcher<CharT>::to_string() -> std::string{return R"('ab\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_143_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_143_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_143_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_143_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_143_matcher<CharT>::to_string() -> std::string{return R"('ab\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_144_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"ab"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_144_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_144_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_144_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_144_matcher<CharT>::to_string() -> std::string{return R"('ab$'m)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_145_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8493,10 +7358,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_145_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_145_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8504,19 +7370,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_145_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_145_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_145_matcher::to_string() -> std::string{return R"(abb\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_145_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_145_matcher<CharT>::to_string() -> std::string{return R"(abb\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_146_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_146_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8545,10 +7411,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_146_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_146_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8556,19 +7423,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_146_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_146_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_146_matcher::to_string() -> std::string{return R"(abb\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_146_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_146_matcher<CharT>::to_string() -> std::string{return R"(abb\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_147_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_147_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8597,10 +7464,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_147_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_147_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8608,19 +7476,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_147_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_147_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_147_matcher::to_string() -> std::string{return R"(abb$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_147_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_147_matcher<CharT>::to_string() -> std::string{return R"(abb$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_148_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_148_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8649,10 +7517,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_148_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_148_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8660,19 +7529,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_148_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_148_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_148_matcher::to_string() -> std::string{return R"(abb\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_148_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_148_matcher<CharT>::to_string() -> std::string{return R"(abb\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_149_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_149_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8701,10 +7570,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_149_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_149_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8712,19 +7582,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_149_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_149_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_149_matcher::to_string() -> std::string{return R"(abb\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_149_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_149_matcher<CharT>::to_string() -> std::string{return R"(abb\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8739,10 +7609,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8750,19 +7621,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_15_matcher::to_string() -> std::string{return R"('$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_15_matcher<CharT>::to_string() -> std::string{return R"('$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_150_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_150_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8791,10 +7662,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_150_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_150_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8802,19 +7674,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_150_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_150_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_150_matcher::to_string() -> std::string{return R"(abb$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_150_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_150_matcher<CharT>::to_string() -> std::string{return R"(abb$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_151_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_151_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8843,10 +7715,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_151_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_151_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8854,19 +7727,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_151_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_151_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_151_matcher::to_string() -> std::string{return R"(abb\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_151_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_151_matcher<CharT>::to_string() -> std::string{return R"(abb\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_152_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_152_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8895,10 +7768,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_152_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_152_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8906,19 +7780,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_152_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_152_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_152_matcher::to_string() -> std::string{return R"(abb\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_152_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_152_matcher<CharT>::to_string() -> std::string{return R"(abb\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_153_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_153_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8947,10 +7821,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_153_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_153_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8958,19 +7833,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_153_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_153_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_153_matcher::to_string() -> std::string{return R"(abb$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_153_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_153_matcher<CharT>::to_string() -> std::string{return R"(abb$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_154_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_154_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8999,10 +7874,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_154_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_154_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9010,19 +7886,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_154_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_154_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_154_matcher::to_string() -> std::string{return R"('abb\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_154_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_154_matcher<CharT>::to_string() -> std::string{return R"('abb\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_155_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_155_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9051,10 +7927,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_155_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_155_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9062,1031 +7939,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_155_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_155_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_155_matcher::to_string() -> std::string{return R"('abb\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_155_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_155_matcher<CharT>::to_string() -> std::string{return R"('abb\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_156_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_156_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_156_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_156_matcher::to_string() -> std::string{return R"('abb$'m)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_157_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_157_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_157_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_157_matcher::to_string() -> std::string{return R"('abb\Z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_158_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_158_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_158_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_158_matcher::to_string() -> std::string{return R"('abb\z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_159_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_159_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_159_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_159_matcher::to_string() -> std::string{return R"('abb$'m)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_16_matcher::to_string() -> std::string{return R"('\Z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_160_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_160_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_160_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_160_matcher::to_string() -> std::string{return R"('abb\Z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_161_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_161_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_161_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_161_matcher::to_string() -> std::string{return R"('abb\z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_162_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_162_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_162_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_162_matcher::to_string() -> std::string{return R"('abb$'m)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_163_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_163_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_163_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_163_matcher::to_string() -> std::string{return R"(abb\Z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_164_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_164_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_164_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_164_matcher::to_string() -> std::string{return R"(abb\z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_165_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_165_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_165_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_165_matcher::to_string() -> std::string{return R"(abb$)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_166_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_166_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_166_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_166_matcher::to_string() -> std::string{return R"(abb\Z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_167_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_167_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_167_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_167_matcher::to_string() -> std::string{return R"(abb\z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_168_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_168_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_168_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_168_matcher::to_string() -> std::string{return R"(abb$)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_169_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_169_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_169_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_169_matcher::to_string() -> std::string{return R"(abb\Z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_17_matcher::to_string() -> std::string{return R"('\z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_170_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_170_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_170_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_170_matcher::to_string() -> std::string{return R"(abb\z)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_171_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_171_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_171_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_171_matcher::to_string() -> std::string{return R"(abb$)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_172_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_172_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_172_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_172_matcher::to_string() -> std::string{return R"('abb\Z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_173_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_173_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_173_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_173_matcher::to_string() -> std::string{return R"('abb\z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_174_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_156_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10115,10 +7980,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_174_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_156_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10126,19 +7992,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_174_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_156_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_174_matcher::to_string() -> std::string{return R"('abb$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_156_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_156_matcher<CharT>::to_string() -> std::string{return R"('abb$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_175_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_157_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10167,10 +8033,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_175_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_157_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10178,19 +8045,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_175_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_157_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_175_matcher::to_string() -> std::string{return R"('abb\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_157_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_157_matcher<CharT>::to_string() -> std::string{return R"('abb\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_176_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_158_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10219,10 +8086,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_176_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_158_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10230,19 +8098,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_176_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_158_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_176_matcher::to_string() -> std::string{return R"('abb\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_158_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_158_matcher<CharT>::to_string() -> std::string{return R"('abb\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_177_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_159_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10271,10 +8139,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_177_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_159_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10282,19 +8151,58 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_177_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_159_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_177_matcher::to_string() -> std::string{return R"('abb$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_159_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_159_matcher<CharT>::to_string() -> std::string{return R"('abb$'m)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_178_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_16_matcher<CharT>::to_string() -> std::string{return R"('\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_160_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10323,10 +8231,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_178_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_160_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10334,19 +8243,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_178_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_160_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_178_matcher::to_string() -> std::string{return R"('abb\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_160_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_160_matcher<CharT>::to_string() -> std::string{return R"('abb\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_179_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_161_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10375,10 +8284,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_179_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_161_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10386,19 +8296,1012 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_179_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_161_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_179_matcher::to_string() -> std::string{return R"('abb\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_161_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_161_matcher<CharT>::to_string() -> std::string{return R"('abb\z'm)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_162_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_162_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_162_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_162_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_162_matcher<CharT>::to_string() -> std::string{return R"('abb$'m)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_163_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_163_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_163_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_163_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_163_matcher<CharT>::to_string() -> std::string{return R"(abb\Z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_164_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_164_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_164_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_164_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_164_matcher<CharT>::to_string() -> std::string{return R"(abb\z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_165_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_165_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_165_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_165_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_165_matcher<CharT>::to_string() -> std::string{return R"(abb$)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_166_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_166_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_166_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_166_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_166_matcher<CharT>::to_string() -> std::string{return R"(abb\Z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_167_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_167_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_167_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_167_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_167_matcher<CharT>::to_string() -> std::string{return R"(abb\z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_168_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_168_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_168_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_168_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_168_matcher<CharT>::to_string() -> std::string{return R"(abb$)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_169_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_169_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_169_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_169_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_169_matcher<CharT>::to_string() -> std::string{return R"(abb\Z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_17_matcher<CharT>::to_string() -> std::string{return R"('\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_170_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_170_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_170_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_170_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_170_matcher<CharT>::to_string() -> std::string{return R"(abb\z)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_171_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_171_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_171_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_171_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_171_matcher<CharT>::to_string() -> std::string{return R"(abb$)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_172_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_172_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_172_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_172_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_172_matcher<CharT>::to_string() -> std::string{return R"('abb\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_173_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_173_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_173_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_173_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_173_matcher<CharT>::to_string() -> std::string{return R"('abb\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_174_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_174_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_174_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_174_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_174_matcher<CharT>::to_string() -> std::string{return R"('abb$'m)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_175_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_175_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_175_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_175_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_175_matcher<CharT>::to_string() -> std::string{return R"('abb\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_176_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_176_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_176_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_176_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_176_matcher<CharT>::to_string() -> std::string{return R"('abb\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_177_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_177_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_177_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_177_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_177_matcher<CharT>::to_string() -> std::string{return R"('abb$'m)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_178_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_178_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_178_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_178_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_178_matcher<CharT>::to_string() -> std::string{return R"('abb\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_179_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"abb"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_179_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_179_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_179_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_179_matcher<CharT>::to_string() -> std::string{return R"('abb\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10413,10 +9316,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10424,19 +9328,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_18_matcher::to_string() -> std::string{return R"('$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_18_matcher<CharT>::to_string() -> std::string{return R"('$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_180_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_180_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10465,10 +9369,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_180_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_180_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10476,19 +9381,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_180_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_180_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_180_matcher::to_string() -> std::string{return R"('abb$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_180_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_180_matcher<CharT>::to_string() -> std::string{return R"('abb$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_181_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_181_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10517,10 +9422,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_181_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_181_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10528,19 +9434,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_181_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_181_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_181_matcher::to_string() -> std::string{return R"(abb\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_181_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_181_matcher<CharT>::to_string() -> std::string{return R"(abb\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_182_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_182_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10569,10 +9475,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_182_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_182_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10580,19 +9487,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_182_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_182_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_182_matcher::to_string() -> std::string{return R"(abb\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_182_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_182_matcher<CharT>::to_string() -> std::string{return R"(abb\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_183_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_183_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10621,10 +9528,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_183_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_183_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10632,19 +9540,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_183_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_183_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_183_matcher::to_string() -> std::string{return R"(abb$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_183_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_183_matcher<CharT>::to_string() -> std::string{return R"(abb$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_184_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_184_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10673,10 +9581,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_184_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_184_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10684,19 +9593,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_184_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_184_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_184_matcher::to_string() -> std::string{return R"(abb\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_184_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_184_matcher<CharT>::to_string() -> std::string{return R"(abb\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_185_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_185_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10725,10 +9634,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_185_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_185_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10736,19 +9646,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_185_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_185_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_185_matcher::to_string() -> std::string{return R"(abb\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_185_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_185_matcher<CharT>::to_string() -> std::string{return R"(abb\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_186_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_186_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10777,10 +9687,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_186_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_186_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10788,19 +9699,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_186_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_186_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_186_matcher::to_string() -> std::string{return R"(abb$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_186_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_186_matcher<CharT>::to_string() -> std::string{return R"(abb$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_187_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_187_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10829,10 +9740,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_187_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_187_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10840,19 +9752,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_187_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_187_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_187_matcher::to_string() -> std::string{return R"(abb\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_187_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_187_matcher<CharT>::to_string() -> std::string{return R"(abb\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_188_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_188_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10881,10 +9793,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_188_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_188_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10892,19 +9805,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_188_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_188_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_188_matcher::to_string() -> std::string{return R"(abb\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_188_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_188_matcher<CharT>::to_string() -> std::string{return R"(abb\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_189_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_189_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10933,10 +9846,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_189_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_189_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10944,19 +9858,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_189_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_189_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_189_matcher::to_string() -> std::string{return R"(abb$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_189_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_189_matcher<CharT>::to_string() -> std::string{return R"(abb$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -10985,10 +9899,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -10996,19 +9911,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_19_matcher::to_string() -> std::string{return R"(a\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_19_matcher<CharT>::to_string() -> std::string{return R"(a\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_190_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_190_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11037,10 +9952,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_190_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_190_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11048,19 +9964,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_190_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_190_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_190_matcher::to_string() -> std::string{return R"('abb\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_190_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_190_matcher<CharT>::to_string() -> std::string{return R"('abb\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_191_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_191_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11089,10 +10005,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_191_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_191_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11100,19 +10017,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_191_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_191_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_191_matcher::to_string() -> std::string{return R"('abb\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_191_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_191_matcher<CharT>::to_string() -> std::string{return R"('abb\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_192_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_192_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11141,10 +10058,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_192_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_192_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11152,19 +10070,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_192_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_192_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_192_matcher::to_string() -> std::string{return R"('abb$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_192_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_192_matcher<CharT>::to_string() -> std::string{return R"('abb$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_193_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_193_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11193,10 +10111,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_193_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_193_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11204,19 +10123,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_193_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_193_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_193_matcher::to_string() -> std::string{return R"('abb\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_193_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_193_matcher<CharT>::to_string() -> std::string{return R"('abb\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_194_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_194_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11245,10 +10164,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_194_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_194_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11256,19 +10176,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_194_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_194_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_194_matcher::to_string() -> std::string{return R"('abb\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_194_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_194_matcher<CharT>::to_string() -> std::string{return R"('abb\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_195_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_195_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11297,10 +10217,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_195_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_195_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11308,19 +10229,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_195_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_195_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_195_matcher::to_string() -> std::string{return R"('abb$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_195_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_195_matcher<CharT>::to_string() -> std::string{return R"('abb$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_196_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_196_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11349,10 +10270,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_196_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_196_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11360,19 +10282,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_196_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_196_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_196_matcher::to_string() -> std::string{return R"('abb\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_196_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_196_matcher<CharT>::to_string() -> std::string{return R"('abb\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_197_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_197_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11401,10 +10323,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_197_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_197_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11412,19 +10335,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_197_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_197_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_197_matcher::to_string() -> std::string{return R"('abb\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_197_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_197_matcher<CharT>::to_string() -> std::string{return R"('abb\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_198_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_198_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11453,10 +10376,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_198_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_198_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11464,19 +10388,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_198_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_198_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_198_matcher::to_string() -> std::string{return R"('abb$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_198_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_198_matcher<CharT>::to_string() -> std::string{return R"('abb$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_199_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_199_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11506,10 +10430,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_199_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_199_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11517,19 +10442,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_199_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_199_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_199_matcher::to_string() -> std::string{return R"('\Aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_199_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_199_matcher<CharT>::to_string() -> std::string{return R"('\Aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11558,10 +10483,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11569,19 +10495,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_20_matcher::to_string() -> std::string{return R"(a\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_20_matcher<CharT>::to_string() -> std::string{return R"(a\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_21_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11610,10 +10536,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_21_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11621,19 +10548,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_21_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_21_matcher::to_string() -> std::string{return R"(a$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_21_matcher<CharT>::to_string() -> std::string{return R"(a$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_22_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11662,10 +10589,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_22_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11673,19 +10601,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_22_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_22_matcher::to_string() -> std::string{return R"(a\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_22_matcher<CharT>::to_string() -> std::string{return R"(a\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_23_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11714,10 +10642,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_23_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11725,19 +10654,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_23_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_23_matcher::to_string() -> std::string{return R"(a\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_23_matcher<CharT>::to_string() -> std::string{return R"(a\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_24_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11766,10 +10695,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_24_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11777,19 +10707,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_24_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_24_matcher::to_string() -> std::string{return R"(a$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_24_matcher<CharT>::to_string() -> std::string{return R"(a$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_25_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_25_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11818,10 +10748,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_25_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_25_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11829,19 +10760,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_25_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_25_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_25_matcher::to_string() -> std::string{return R"(a\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_25_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_25_matcher<CharT>::to_string() -> std::string{return R"(a\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_26_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_26_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11870,10 +10801,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_26_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_26_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11881,19 +10813,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_26_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_26_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_26_matcher::to_string() -> std::string{return R"(a\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_26_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_26_matcher<CharT>::to_string() -> std::string{return R"(a\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_27_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_27_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11922,10 +10854,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_27_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_27_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11933,19 +10866,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_27_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_27_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_27_matcher::to_string() -> std::string{return R"(a$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_27_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_27_matcher<CharT>::to_string() -> std::string{return R"(a$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_28_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_28_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -11974,10 +10907,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_28_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_28_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -11985,19 +10919,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_28_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_28_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_28_matcher::to_string() -> std::string{return R"('a\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_28_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_28_matcher<CharT>::to_string() -> std::string{return R"('a\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_29_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_29_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12026,10 +10960,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_29_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_29_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12037,175 +10972,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_29_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_29_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_29_matcher::to_string() -> std::string{return R"('a\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_29_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_29_matcher<CharT>::to_string() -> std::string{return R"('a\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_30_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,1 + 1> str_tmp_0 {"a"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_30_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_30_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_30_matcher::to_string() -> std::string{return R"('a$'m)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_31_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,1 + 1> str_tmp_0 {"a"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_31_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_31_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_31_matcher::to_string() -> std::string{return R"('a\Z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_32_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,1 + 1> str_tmp_0 {"a"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_32_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_32_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_32_matcher::to_string() -> std::string{return R"('a\z'm)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_33_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_30_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12234,10 +11013,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_33_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_30_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12245,19 +11025,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_33_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_30_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_33_matcher::to_string() -> std::string{return R"('a$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_30_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_30_matcher<CharT>::to_string() -> std::string{return R"('a$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_34_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_31_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12286,10 +11066,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_34_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_31_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12297,19 +11078,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_34_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_31_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_34_matcher::to_string() -> std::string{return R"('a\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_31_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_31_matcher<CharT>::to_string() -> std::string{return R"('a\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_35_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_32_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12338,10 +11119,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_35_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_32_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12349,19 +11131,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_35_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_32_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_35_matcher::to_string() -> std::string{return R"('a\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_32_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_32_matcher<CharT>::to_string() -> std::string{return R"('a\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_36_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_33_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12390,10 +11172,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_36_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_33_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12401,19 +11184,178 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_36_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_33_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_36_matcher::to_string() -> std::string{return R"('a$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_33_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_33_matcher<CharT>::to_string() -> std::string{return R"('a$'m)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_34_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_37_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_34_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_34_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_34_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_34_matcher<CharT>::to_string() -> std::string{return R"('a\Z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_35_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,false,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_35_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_35_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_35_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_35_matcher<CharT>::to_string() -> std::string{return R"('a\z'm)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_36_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::line_end_token_matcher<char,true,true>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_36_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_36_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_36_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_36_matcher<CharT>::to_string() -> std::string{return R"('a$'m)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_37_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12442,10 +11384,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_37_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_37_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12453,19 +11396,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_37_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_37_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_37_matcher::to_string() -> std::string{return R"(aa\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_37_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_37_matcher<CharT>::to_string() -> std::string{return R"(aa\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_38_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_38_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12494,10 +11437,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_38_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_38_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12505,19 +11449,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_38_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_38_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_38_matcher::to_string() -> std::string{return R"(aa\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_38_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_38_matcher<CharT>::to_string() -> std::string{return R"(aa\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_39_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_39_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12546,10 +11490,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_39_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_39_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12557,19 +11502,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_39_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_39_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_39_matcher::to_string() -> std::string{return R"(aa$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_39_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_39_matcher<CharT>::to_string() -> std::string{return R"(aa$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_40_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_40_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12598,10 +11543,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_40_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_40_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12609,19 +11555,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_40_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_40_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_40_matcher::to_string() -> std::string{return R"(aa\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_40_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_40_matcher<CharT>::to_string() -> std::string{return R"(aa\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_41_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_41_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12650,10 +11596,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_41_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_41_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12661,19 +11608,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_41_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_41_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_41_matcher::to_string() -> std::string{return R"(aa\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_41_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_41_matcher<CharT>::to_string() -> std::string{return R"(aa\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_42_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_42_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12702,10 +11649,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_42_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_42_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12713,19 +11661,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_42_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_42_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_42_matcher::to_string() -> std::string{return R"(aa$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_42_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_42_matcher<CharT>::to_string() -> std::string{return R"(aa$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_43_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_43_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12754,10 +11702,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_43_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_43_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12765,19 +11714,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_43_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_43_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_43_matcher::to_string() -> std::string{return R"(aa\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_43_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_43_matcher<CharT>::to_string() -> std::string{return R"(aa\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_44_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_44_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12806,10 +11755,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_44_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_44_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12817,19 +11767,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_44_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_44_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_44_matcher::to_string() -> std::string{return R"(aa\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_44_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_44_matcher<CharT>::to_string() -> std::string{return R"(aa\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_45_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_45_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12858,10 +11808,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_45_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_45_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12869,19 +11820,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_45_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_45_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_45_matcher::to_string() -> std::string{return R"(aa$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_45_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_45_matcher<CharT>::to_string() -> std::string{return R"(aa$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_46_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_46_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12910,10 +11861,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_46_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_46_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12921,19 +11873,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_46_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_46_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_46_matcher::to_string() -> std::string{return R"('aa\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_46_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_46_matcher<CharT>::to_string() -> std::string{return R"('aa\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_47_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_47_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -12962,10 +11914,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_47_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_47_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -12973,19 +11926,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_47_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_47_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_47_matcher::to_string() -> std::string{return R"('aa\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_47_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_47_matcher<CharT>::to_string() -> std::string{return R"('aa\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_48_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_48_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13014,10 +11967,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_48_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_48_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13025,19 +11979,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_48_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_48_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_48_matcher::to_string() -> std::string{return R"('aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_48_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_48_matcher<CharT>::to_string() -> std::string{return R"('aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_49_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_49_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13066,10 +12020,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_49_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_49_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13077,19 +12032,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_49_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_49_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_49_matcher::to_string() -> std::string{return R"('aa\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_49_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_49_matcher<CharT>::to_string() -> std::string{return R"('aa\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_50_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_50_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13118,10 +12073,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_50_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_50_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13129,19 +12085,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_50_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_50_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_50_matcher::to_string() -> std::string{return R"('aa\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_50_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_50_matcher<CharT>::to_string() -> std::string{return R"('aa\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_51_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_51_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13170,10 +12126,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_51_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_51_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13181,19 +12138,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_51_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_51_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_51_matcher::to_string() -> std::string{return R"('aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_51_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_51_matcher<CharT>::to_string() -> std::string{return R"('aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_52_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_52_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13222,10 +12179,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_52_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_52_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13233,19 +12191,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_52_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_52_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_52_matcher::to_string() -> std::string{return R"('aa\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_52_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_52_matcher<CharT>::to_string() -> std::string{return R"('aa\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_53_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_53_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13274,10 +12232,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_53_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_53_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13285,19 +12244,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_53_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_53_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_53_matcher::to_string() -> std::string{return R"('aa\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_53_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_53_matcher<CharT>::to_string() -> std::string{return R"('aa\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_54_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_54_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13326,10 +12285,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_54_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_54_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13337,19 +12297,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_54_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_54_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_54_matcher::to_string() -> std::string{return R"('aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_54_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_54_matcher<CharT>::to_string() -> std::string{return R"('aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_55_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_55_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13378,10 +12338,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_55_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_55_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13389,19 +12350,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_55_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_55_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_55_matcher::to_string() -> std::string{return R"(aa\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_55_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_55_matcher<CharT>::to_string() -> std::string{return R"(aa\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_56_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_56_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13430,10 +12391,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_56_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_56_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13441,19 +12403,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_56_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_56_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_56_matcher::to_string() -> std::string{return R"(aa\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_56_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_56_matcher<CharT>::to_string() -> std::string{return R"(aa\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_57_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_57_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13482,10 +12444,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_57_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_57_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13493,19 +12456,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_57_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_57_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_57_matcher::to_string() -> std::string{return R"(aa$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_57_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_57_matcher<CharT>::to_string() -> std::string{return R"(aa$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_58_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_58_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13534,10 +12497,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_58_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_58_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13545,19 +12509,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_58_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_58_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_58_matcher::to_string() -> std::string{return R"(aa\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_58_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_58_matcher<CharT>::to_string() -> std::string{return R"(aa\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_59_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_59_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13586,10 +12550,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_59_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_59_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13597,19 +12562,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_59_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_59_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_59_matcher::to_string() -> std::string{return R"(aa\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_59_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_59_matcher<CharT>::to_string() -> std::string{return R"(aa\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_60_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_60_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13638,10 +12603,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_60_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_60_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13649,19 +12615,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_60_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_60_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_60_matcher::to_string() -> std::string{return R"(aa$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_60_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_60_matcher<CharT>::to_string() -> std::string{return R"(aa$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_61_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_61_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13690,10 +12656,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_61_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_61_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13701,19 +12668,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_61_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_61_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_61_matcher::to_string() -> std::string{return R"(aa\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_61_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_61_matcher<CharT>::to_string() -> std::string{return R"(aa\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_62_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_62_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13742,10 +12709,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_62_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_62_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13753,19 +12721,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_62_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_62_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_62_matcher::to_string() -> std::string{return R"(aa\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_62_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_62_matcher<CharT>::to_string() -> std::string{return R"(aa\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_63_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_63_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13794,10 +12762,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_63_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_63_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13805,19 +12774,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_63_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_63_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_63_matcher::to_string() -> std::string{return R"(aa$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_63_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_63_matcher<CharT>::to_string() -> std::string{return R"(aa$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_64_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_64_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13846,10 +12815,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_64_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_64_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13857,19 +12827,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_64_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_64_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_64_matcher::to_string() -> std::string{return R"('aa\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_64_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_64_matcher<CharT>::to_string() -> std::string{return R"('aa\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_65_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_65_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13898,10 +12868,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_65_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_65_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13909,19 +12880,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_65_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_65_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_65_matcher::to_string() -> std::string{return R"('aa\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_65_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_65_matcher<CharT>::to_string() -> std::string{return R"('aa\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_66_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_66_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -13950,10 +12921,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_66_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_66_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -13961,19 +12933,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_66_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_66_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_66_matcher::to_string() -> std::string{return R"('aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_66_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_66_matcher<CharT>::to_string() -> std::string{return R"('aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_67_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_67_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14002,10 +12974,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_67_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_67_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14013,19 +12986,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_67_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_67_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_67_matcher::to_string() -> std::string{return R"('aa\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_67_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_67_matcher<CharT>::to_string() -> std::string{return R"('aa\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_68_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_68_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14054,10 +13027,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_68_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_68_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14065,19 +13039,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_68_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_68_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_68_matcher::to_string() -> std::string{return R"('aa\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_68_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_68_matcher<CharT>::to_string() -> std::string{return R"('aa\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_69_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_69_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14106,10 +13080,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_69_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_69_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14117,19 +13092,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_69_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_69_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_69_matcher::to_string() -> std::string{return R"('aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_69_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_69_matcher<CharT>::to_string() -> std::string{return R"('aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_70_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_70_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14158,10 +13133,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_70_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_70_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14169,19 +13145,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_70_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_70_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_70_matcher::to_string() -> std::string{return R"('aa\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_70_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_70_matcher<CharT>::to_string() -> std::string{return R"('aa\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_71_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_71_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14210,10 +13186,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_71_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_71_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14221,19 +13198,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_71_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_71_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_71_matcher::to_string() -> std::string{return R"('aa\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_71_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_71_matcher<CharT>::to_string() -> std::string{return R"('aa\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_72_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_72_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14262,10 +13239,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_72_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_72_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14273,19 +13251,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_72_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_72_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_72_matcher::to_string() -> std::string{return R"('aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_72_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_72_matcher<CharT>::to_string() -> std::string{return R"('aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_73_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_73_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14314,10 +13292,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_73_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_73_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14325,19 +13304,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_73_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_73_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_73_matcher::to_string() -> std::string{return R"(aa\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_73_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_73_matcher<CharT>::to_string() -> std::string{return R"(aa\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_74_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_74_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14366,10 +13345,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_74_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_74_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14377,19 +13357,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_74_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_74_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_74_matcher::to_string() -> std::string{return R"(aa\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_74_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_74_matcher<CharT>::to_string() -> std::string{return R"(aa\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_75_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_75_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14418,10 +13398,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_75_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_75_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14429,19 +13410,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_75_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_75_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_75_matcher::to_string() -> std::string{return R"(aa$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_75_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_75_matcher<CharT>::to_string() -> std::string{return R"(aa$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_76_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_76_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14470,10 +13451,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_76_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_76_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14481,19 +13463,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_76_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_76_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_76_matcher::to_string() -> std::string{return R"(aa\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_76_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_76_matcher<CharT>::to_string() -> std::string{return R"(aa\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_77_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_77_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14522,10 +13504,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_77_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_77_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14533,19 +13516,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_77_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_77_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_77_matcher::to_string() -> std::string{return R"(aa\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_77_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_77_matcher<CharT>::to_string() -> std::string{return R"(aa\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_78_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_78_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14574,10 +13557,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_78_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_78_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14585,19 +13569,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_78_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_78_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_78_matcher::to_string() -> std::string{return R"(aa$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_78_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_78_matcher<CharT>::to_string() -> std::string{return R"(aa$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_79_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_79_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14626,10 +13610,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_79_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_79_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14637,19 +13622,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_79_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_79_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_79_matcher::to_string() -> std::string{return R"(aa\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_79_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_79_matcher<CharT>::to_string() -> std::string{return R"(aa\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_80_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_80_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14678,10 +13663,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_80_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_80_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14689,19 +13675,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_80_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_80_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_80_matcher::to_string() -> std::string{return R"(aa\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_80_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_80_matcher<CharT>::to_string() -> std::string{return R"(aa\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_81_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_81_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14730,10 +13716,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_81_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_81_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14741,19 +13728,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_81_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_81_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_81_matcher::to_string() -> std::string{return R"(aa$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_81_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_81_matcher<CharT>::to_string() -> std::string{return R"(aa$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_82_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_82_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14782,10 +13769,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_82_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_82_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14793,19 +13781,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_82_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_82_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_82_matcher::to_string() -> std::string{return R"('aa\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_82_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_82_matcher<CharT>::to_string() -> std::string{return R"('aa\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_83_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_83_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14834,10 +13822,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_83_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_83_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14845,19 +13834,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_83_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_83_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_83_matcher::to_string() -> std::string{return R"('aa\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_83_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_83_matcher<CharT>::to_string() -> std::string{return R"('aa\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_84_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_84_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14886,10 +13875,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_84_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_84_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14897,19 +13887,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_84_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_84_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_84_matcher::to_string() -> std::string{return R"('aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_84_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_84_matcher<CharT>::to_string() -> std::string{return R"('aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_85_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_85_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14938,10 +13928,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_85_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_85_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -14949,19 +13940,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_85_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_85_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_85_matcher::to_string() -> std::string{return R"('aa\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_85_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_85_matcher<CharT>::to_string() -> std::string{return R"('aa\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_86_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_86_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -14990,10 +13981,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_86_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_86_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15001,19 +13993,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_86_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_86_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_86_matcher::to_string() -> std::string{return R"('aa\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_86_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_86_matcher<CharT>::to_string() -> std::string{return R"('aa\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_87_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_87_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15042,10 +14034,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_87_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_87_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15053,19 +14046,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_87_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_87_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_87_matcher::to_string() -> std::string{return R"('aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_87_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_87_matcher<CharT>::to_string() -> std::string{return R"('aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_88_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_88_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15094,10 +14087,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_88_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_88_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15105,19 +14099,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_88_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_88_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_88_matcher::to_string() -> std::string{return R"('aa\Z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_88_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_88_matcher<CharT>::to_string() -> std::string{return R"('aa\Z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_89_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_89_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15146,10 +14140,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_89_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_89_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15157,19 +14152,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_89_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_89_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_89_matcher::to_string() -> std::string{return R"('aa\z'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_89_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_89_matcher<CharT>::to_string() -> std::string{return R"('aa\z'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_90_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_90_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15198,10 +14193,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_90_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_90_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15209,19 +14205,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_90_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_90_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_90_matcher::to_string() -> std::string{return R"('aa$'m)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_90_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_90_matcher<CharT>::to_string() -> std::string{return R"('aa$'m)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_91_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_91_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15250,10 +14246,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_91_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_91_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15261,19 +14258,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_91_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_91_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_91_matcher::to_string() -> std::string{return R"(ab\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_91_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_91_matcher<CharT>::to_string() -> std::string{return R"(ab\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_92_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_92_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15302,10 +14299,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_92_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_92_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15313,19 +14311,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_92_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_92_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_92_matcher::to_string() -> std::string{return R"(ab\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_92_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_92_matcher<CharT>::to_string() -> std::string{return R"(ab\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_93_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_93_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15354,10 +14352,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_93_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_93_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15365,19 +14364,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_93_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_93_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_93_matcher::to_string() -> std::string{return R"(ab$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_93_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_93_matcher<CharT>::to_string() -> std::string{return R"(ab$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_94_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_94_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15406,10 +14405,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_94_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_94_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15417,19 +14417,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_94_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_94_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_94_matcher::to_string() -> std::string{return R"(ab\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_94_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_94_matcher<CharT>::to_string() -> std::string{return R"(ab\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_95_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_95_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15458,10 +14458,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_95_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_95_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15469,19 +14470,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_95_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_95_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_95_matcher::to_string() -> std::string{return R"(ab\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_95_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_95_matcher<CharT>::to_string() -> std::string{return R"(ab\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_96_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_96_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15510,10 +14511,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_96_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_96_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15521,19 +14523,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_96_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_96_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_96_matcher::to_string() -> std::string{return R"(ab$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_96_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_96_matcher<CharT>::to_string() -> std::string{return R"(ab$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_97_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_97_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15562,10 +14564,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_97_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_97_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15573,19 +14576,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_97_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_97_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_97_matcher::to_string() -> std::string{return R"(ab\Z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_97_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_97_matcher<CharT>::to_string() -> std::string{return R"(ab\Z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_98_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_98_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15614,10 +14617,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_98_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_98_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15625,19 +14629,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_98_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_98_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_98_matcher::to_string() -> std::string{return R"(ab\z)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_98_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_98_matcher<CharT>::to_string() -> std::string{return R"(ab\z)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_99_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_99_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -15666,10 +14670,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_99_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_99_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -15677,15 +14682,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_99_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_99_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_14_multiline_modifier::regex_99_matcher::to_string() -> std::string{return R"(ab$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_14_multiline_modifier::regex_99_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_14_multiline_modifier::regex_99_matcher<CharT>::to_string() -> std::string{return R"(ab$)"; }
 
 
-#line 569 "pure2-regex_14_multiline_modifier.cpp2"
+#line 570 "pure2-regex_14_multiline_modifier.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_14_multiline_modifier());
 }

--- a/regression-tests/test-results/pure2-regex_15_group_modifiers.cpp
+++ b/regression-tests/test-results/pure2-regex_15_group_modifiers.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_15_group_modifiers.cpp2"
 
-#line 165 "pure2-regex_15_group_modifiers.cpp2"
+#line 166 "pure2-regex_15_group_modifiers.cpp2"
 class test_tests_15_group_modifiers;
   
 
@@ -18,37 +18,31 @@ class test_tests_15_group_modifiers;
 #line 1 "pure2-regex_15_group_modifiers.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_15_group_modifiers.cpp2"
+#line 113 "pure2-regex_15_group_modifiers.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_15_group_modifiers.cpp2"
+#line 125 "pure2-regex_15_group_modifiers.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_15_group_modifiers.cpp2"
+#line 166 "pure2-regex_15_group_modifiers.cpp2"
 class test_tests_15_group_modifiers {
 
-#line 219 "pure2-regex_15_group_modifiers.cpp2"
+#line 220 "pure2-regex_15_group_modifiers.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,25 +50,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -82,25 +70,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -108,25 +90,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -134,25 +110,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -160,25 +130,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -186,25 +150,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -212,25 +170,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -238,25 +190,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -264,25 +210,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -290,25 +230,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -316,25 +250,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -342,25 +270,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -368,25 +290,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -394,25 +310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -420,25 +330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -446,25 +350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -472,25 +370,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -498,25 +390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -524,25 +410,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -550,25 +430,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; public: class regex_21_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_21_matcher() = default;
         public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -576,25 +450,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_21_matcher> regex_21 {}; public: class regex_22_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_22_matcher() = default;
         public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -602,25 +470,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_22_matcher> regex_22 {}; public: class regex_23_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_23_matcher() = default;
         public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -628,25 +490,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_23_matcher> regex_23 {}; public: class regex_24_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_24_matcher() = default;
         public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -654,25 +510,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_24_matcher> regex_24 {}; public: class regex_25_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; public: template<typename CharT> class regex_25_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_25_matcher() = default;
         public: regex_25_matcher(regex_25_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -680,25 +530,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_25_matcher> regex_25 {}; public: class regex_26_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_25_matcher<char>> regex_25 {}; public: template<typename CharT> class regex_26_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_26_matcher() = default;
         public: regex_26_matcher(regex_26_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -706,25 +550,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_26_matcher> regex_26 {}; public: class regex_27_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_26_matcher<char>> regex_26 {}; public: template<typename CharT> class regex_27_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_27_matcher() = default;
         public: regex_27_matcher(regex_27_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -732,25 +570,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_27_matcher> regex_27 {}; public: class regex_28_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_27_matcher<char>> regex_27 {}; public: template<typename CharT> class regex_28_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_28_matcher() = default;
         public: regex_28_matcher(regex_28_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -758,25 +590,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_28_matcher> regex_28 {}; public: class regex_29_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_28_matcher<char>> regex_28 {}; public: template<typename CharT> class regex_29_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_29_matcher() = default;
         public: regex_29_matcher(regex_29_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -784,25 +610,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_29_matcher> regex_29 {}; public: class regex_30_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_29_matcher<char>> regex_29 {}; public: template<typename CharT> class regex_30_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_30_matcher() = default;
         public: regex_30_matcher(regex_30_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -810,25 +630,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_30_matcher> regex_30 {}; public: class regex_31_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_30_matcher<char>> regex_30 {}; public: template<typename CharT> class regex_31_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_31_matcher() = default;
         public: regex_31_matcher(regex_31_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -836,25 +650,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_31_matcher> regex_31 {}; public: class regex_32_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_31_matcher<char>> regex_31 {}; public: template<typename CharT> class regex_32_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_32_matcher() = default;
         public: regex_32_matcher(regex_32_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -862,25 +670,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_32_matcher> regex_32 {}; public: class regex_33_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_32_matcher<char>> regex_32 {}; public: template<typename CharT> class regex_33_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_33_matcher() = default;
         public: regex_33_matcher(regex_33_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -888,25 +690,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_33_matcher> regex_33 {}; public: class regex_34_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_33_matcher<char>> regex_33 {}; public: template<typename CharT> class regex_34_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_34_matcher() = default;
         public: regex_34_matcher(regex_34_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -914,25 +710,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_34_matcher> regex_34 {}; public: class regex_35_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_34_matcher<char>> regex_34 {}; public: template<typename CharT> class regex_35_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_35_matcher() = default;
         public: regex_35_matcher(regex_35_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -940,25 +730,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_35_matcher> regex_35 {}; public: class regex_36_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_35_matcher<char>> regex_35 {}; public: template<typename CharT> class regex_36_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_36_matcher() = default;
         public: regex_36_matcher(regex_36_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -966,25 +750,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_36_matcher> regex_36 {}; public: class regex_37_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_36_matcher<char>> regex_36 {}; public: template<typename CharT> class regex_37_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_37_matcher() = default;
         public: regex_37_matcher(regex_37_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -992,25 +770,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_37_matcher> regex_37 {}; public: class regex_38_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_37_matcher<char>> regex_37 {}; public: template<typename CharT> class regex_38_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_38_matcher() = default;
         public: regex_38_matcher(regex_38_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1018,25 +790,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_38_matcher> regex_38 {}; public: class regex_39_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_38_matcher<char>> regex_38 {}; public: template<typename CharT> class regex_39_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_39_matcher() = default;
         public: regex_39_matcher(regex_39_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1044,25 +810,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_39_matcher> regex_39 {}; public: class regex_40_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_39_matcher<char>> regex_39 {}; public: template<typename CharT> class regex_40_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_40_matcher() = default;
         public: regex_40_matcher(regex_40_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1070,55 +830,49 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_40_matcher> regex_40 {}; public: class regex_41_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_40_matcher<char>> regex_40 {}; public: template<typename CharT> class regex_41_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_41_matcher() = default;
         public: regex_41_matcher(regex_41_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1126,25 +880,19 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_41_matcher> regex_41 {}; public: class regex_42_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_41_matcher<char>> regex_41 {}; public: template<typename CharT> class regex_42_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_42_matcher() = default;
         public: regex_42_matcher(regex_42_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1152,25 +900,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_42_matcher> regex_42 {}; public: class regex_43_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_42_matcher<char>> regex_42 {}; public: template<typename CharT> class regex_43_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_43_matcher() = default;
         public: regex_43_matcher(regex_43_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1178,25 +920,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_43_matcher> regex_43 {}; public: class regex_44_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_43_matcher<char>> regex_43 {}; public: template<typename CharT> class regex_44_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_44_matcher() = default;
         public: regex_44_matcher(regex_44_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1204,25 +940,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_44_matcher> regex_44 {}; public: class regex_45_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_44_matcher<char>> regex_44 {}; public: template<typename CharT> class regex_45_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_45_matcher() = default;
         public: regex_45_matcher(regex_45_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1230,25 +960,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_45_matcher> regex_45 {}; public: class regex_46_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_45_matcher<char>> regex_45 {}; public: template<typename CharT> class regex_46_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_46_matcher() = default;
         public: regex_46_matcher(regex_46_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1256,25 +980,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_46_matcher> regex_46 {}; public: class regex_47_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_46_matcher<char>> regex_46 {}; public: template<typename CharT> class regex_47_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_47_matcher() = default;
         public: regex_47_matcher(regex_47_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1282,25 +1000,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_47_matcher> regex_47 {}; public: class regex_48_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_47_matcher<char>> regex_47 {}; public: template<typename CharT> class regex_48_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_48_matcher() = default;
         public: regex_48_matcher(regex_48_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1308,25 +1020,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_48_matcher> regex_48 {}; public: class regex_49_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_48_matcher<char>> regex_48 {}; public: template<typename CharT> class regex_49_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_49_matcher() = default;
         public: regex_49_matcher(regex_49_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1334,25 +1040,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_49_matcher> regex_49 {}; public: class regex_50_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_49_matcher<char>> regex_49 {}; public: template<typename CharT> class regex_50_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_50_matcher() = default;
         public: regex_50_matcher(regex_50_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1360,25 +1060,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_50_matcher> regex_50 {}; public: class regex_51_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_50_matcher<char>> regex_50 {}; public: template<typename CharT> class regex_51_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_51_matcher() = default;
         public: regex_51_matcher(regex_51_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1386,25 +1080,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_51_matcher> regex_51 {}; public: class regex_52_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_51_matcher<char>> regex_51 {}; public: template<typename CharT> class regex_52_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_52_matcher() = default;
         public: regex_52_matcher(regex_52_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1412,25 +1100,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_52_matcher> regex_52 {}; public: class regex_53_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_52_matcher<char>> regex_52 {}; public: template<typename CharT> class regex_53_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_53_matcher() = default;
         public: regex_53_matcher(regex_53_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1438,13 +1120,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_53_matcher> regex_53 {}; 
+  public: cpp2::regex::regular_expression<char,regex_53_matcher<char>> regex_53 {}; 
   public: test_tests_15_group_modifiers() = default;
   public: test_tests_15_group_modifiers(test_tests_15_group_modifiers const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_15_group_modifiers const&) -> void = delete;
 
 
-#line 276 "pure2-regex_15_group_modifiers.cpp2"
+#line 277 "pure2-regex_15_group_modifiers.cpp2"
 };
 auto main() -> int;
 
@@ -1548,6 +1230,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -1563,7 +1246,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_15_group_modifiers.cpp2"
+#line 113 "pure2-regex_15_group_modifiers.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -1576,7 +1259,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_15_group_modifiers.cpp2"
+#line 125 "pure2-regex_15_group_modifiers.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -1617,7 +1300,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 219 "pure2-regex_15_group_modifiers.cpp2"
+#line 220 "pure2-regex_15_group_modifiers.cpp2"
   auto test_tests_15_group_modifiers::run() const& -> void{
     std::cout << "Running tests_15_group_modifiers:" << std::endl;
     test(regex_01, "01", R"((?:(?i)a)b)", "ab", "y", R"($&)", "ab");
@@ -1679,8 +1362,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1724,10 +1406,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1735,19 +1418,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_01_matcher::to_string() -> std::string{return R"((?:(?i)a)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_01_matcher<CharT>::to_string() -> std::string{return R"((?:(?i)a)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1804,10 +1487,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1815,19 +1499,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_02_matcher::to_string() -> std::string{return R"(((?i)a)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_02_matcher<CharT>::to_string() -> std::string{return R"(((?i)a)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1871,10 +1555,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1882,19 +1567,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_03_matcher::to_string() -> std::string{return R"((?:(?i)a)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_03_matcher<CharT>::to_string() -> std::string{return R"((?:(?i)a)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1951,10 +1636,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1962,19 +1648,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_04_matcher::to_string() -> std::string{return R"(((?i)a)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_04_matcher<CharT>::to_string() -> std::string{return R"(((?i)a)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2018,10 +1704,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2029,19 +1716,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_05_matcher::to_string() -> std::string{return R"((?:(?i)a)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_05_matcher<CharT>::to_string() -> std::string{return R"((?:(?i)a)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2098,10 +1785,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2109,19 +1797,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_06_matcher::to_string() -> std::string{return R"(((?i)a)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_06_matcher<CharT>::to_string() -> std::string{return R"(((?i)a)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2165,10 +1853,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2176,19 +1865,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_07_matcher::to_string() -> std::string{return R"((?i:a)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_07_matcher<CharT>::to_string() -> std::string{return R"((?i:a)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2245,10 +1934,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2256,19 +1946,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_08_matcher::to_string() -> std::string{return R"(((?i:a))b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_08_matcher<CharT>::to_string() -> std::string{return R"(((?i:a))b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2312,10 +2002,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2323,19 +2014,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_09_matcher::to_string() -> std::string{return R"((?i:a)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_09_matcher<CharT>::to_string() -> std::string{return R"((?i:a)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2392,10 +2083,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2403,19 +2095,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_10_matcher::to_string() -> std::string{return R"(((?i:a))b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_10_matcher<CharT>::to_string() -> std::string{return R"(((?i:a))b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2459,10 +2151,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2470,19 +2163,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_11_matcher::to_string() -> std::string{return R"((?i:a)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_11_matcher<CharT>::to_string() -> std::string{return R"((?i:a)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2539,10 +2232,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2550,19 +2244,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_12_matcher::to_string() -> std::string{return R"(((?i:a))b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_12_matcher<CharT>::to_string() -> std::string{return R"(((?i:a))b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2606,10 +2300,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2617,19 +2312,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_13_matcher::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_13_matcher<CharT>::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2686,10 +2381,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2697,19 +2393,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_14_matcher::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_14_matcher<CharT>::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2753,10 +2449,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2764,19 +2461,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_15_matcher::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_15_matcher<CharT>::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2833,10 +2530,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2844,19 +2542,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_16_matcher::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_16_matcher<CharT>::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2900,10 +2598,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2911,19 +2610,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_17_matcher::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_17_matcher<CharT>::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2980,10 +2679,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2991,19 +2691,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_18_matcher::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_18_matcher<CharT>::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3047,10 +2747,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3058,19 +2759,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_19_matcher::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_19_matcher<CharT>::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3127,10 +2828,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3138,19 +2840,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_20_matcher::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_20_matcher<CharT>::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_21_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3194,10 +2896,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_21_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3205,19 +2908,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_21_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_21_matcher::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_21_matcher<CharT>::to_string() -> std::string{return R"('(?:(?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_22_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3274,10 +2977,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_22_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3285,19 +2989,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_22_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_22_matcher::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_22_matcher<CharT>::to_string() -> std::string{return R"('((?-i)a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_23_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3341,10 +3045,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_23_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3352,19 +3057,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_23_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_23_matcher::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_23_matcher<CharT>::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_24_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3421,10 +3126,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_24_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3432,19 +3138,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_24_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_24_matcher::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_24_matcher<CharT>::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_25_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_25_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3488,10 +3194,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_25_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_25_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3499,19 +3206,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_25_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_25_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_25_matcher::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_25_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_25_matcher<CharT>::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_26_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_26_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3568,10 +3275,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_26_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_26_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3579,19 +3287,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_26_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_26_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_26_matcher::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_26_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_26_matcher<CharT>::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_27_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_27_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3635,10 +3343,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_27_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_27_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3646,19 +3355,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_27_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_27_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_27_matcher::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_27_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_27_matcher<CharT>::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_28_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_28_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3715,10 +3424,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_28_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_28_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3726,19 +3436,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_28_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_28_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_28_matcher::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_28_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_28_matcher<CharT>::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_29_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_29_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3782,10 +3492,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_29_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_29_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3793,19 +3504,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_29_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_29_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_29_matcher::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_29_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_29_matcher<CharT>::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_30_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_30_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3862,10 +3573,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_30_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_30_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3873,19 +3585,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_30_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_30_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_30_matcher::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_30_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_30_matcher<CharT>::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_31_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_31_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3929,10 +3641,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_31_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_31_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3940,19 +3653,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_31_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_31_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_31_matcher::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_31_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_31_matcher<CharT>::to_string() -> std::string{return R"('(?-i:a)b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_32_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_32_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4009,10 +3722,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_32_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_32_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4020,19 +3734,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_32_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_32_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_32_matcher::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_32_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_32_matcher<CharT>::to_string() -> std::string{return R"('((?-i:a))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_33_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_33_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4090,10 +3804,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_33_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_33_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4101,19 +3816,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_33_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_33_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_33_matcher::to_string() -> std::string{return R"('((?-i:a.))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_33_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_33_matcher<CharT>::to_string() -> std::string{return R"('((?-i:a.))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_34_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_34_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4171,10 +3886,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_34_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_34_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4182,19 +3898,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_34_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_34_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_34_matcher::to_string() -> std::string{return R"('((?-i:a\N))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_34_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_34_matcher<CharT>::to_string() -> std::string{return R"('((?-i:a\N))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_35_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_35_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4252,10 +3968,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_35_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_35_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4263,19 +3980,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_35_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_35_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_35_matcher::to_string() -> std::string{return R"('((?s-i:a.))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_35_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_35_matcher<CharT>::to_string() -> std::string{return R"('((?s-i:a.))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_36_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_36_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4333,10 +4050,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_36_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_36_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4344,19 +4062,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_36_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_36_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_36_matcher::to_string() -> std::string{return R"('((?s-i:a\N))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_36_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_36_matcher<CharT>::to_string() -> std::string{return R"('((?s-i:a\N))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_37_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_37_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4414,10 +4132,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_37_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_37_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4425,19 +4144,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_37_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_37_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_37_matcher::to_string() -> std::string{return R"('((?s-i:a.))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_37_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_37_matcher<CharT>::to_string() -> std::string{return R"('((?s-i:a.))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_38_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_38_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4495,10 +4214,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_38_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_38_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4506,19 +4226,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_38_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_38_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_38_matcher::to_string() -> std::string{return R"('((?s-i:a\N))b'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_38_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_38_matcher<CharT>::to_string() -> std::string{return R"('((?s-i:a\N))b'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_39_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_39_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4535,10 +4255,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_39_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_39_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4546,19 +4267,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_39_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_39_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_39_matcher::to_string() -> std::string{return R"((?i:.[b].))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_39_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_39_matcher<CharT>::to_string() -> std::string{return R"((?i:.[b].))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_40_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_40_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4575,10 +4296,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_40_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_40_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4586,19 +4308,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_40_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_40_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_40_matcher::to_string() -> std::string{return R"((?i:\N[b]\N))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_40_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_40_matcher<CharT>::to_string() -> std::string{return R"((?i:\N[b]\N))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4626,11 +4348,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4644,11 +4367,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4676,11 +4400,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4694,11 +4419,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4712,11 +4438,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4731,11 +4458,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4750,10 +4478,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4761,19 +4490,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher::to_string() -> std::string{return R"(^(?:a?b?)*$)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_41_matcher<CharT>::to_string() -> std::string{return R"(^(?:a?b?)*$)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_42_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_42_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4858,10 +4587,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_42_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_42_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4869,19 +4599,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_42_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_42_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_42_matcher::to_string() -> std::string{return R"(((?s)^a(.))((?m)^b$))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_42_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_42_matcher<CharT>::to_string() -> std::string{return R"(((?s)^a(.))((?m)^b$))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_43_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_43_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4924,10 +4654,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_43_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_43_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4935,19 +4666,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_43_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_43_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_43_matcher::to_string() -> std::string{return R"(((?m)^b$))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_43_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_43_matcher<CharT>::to_string() -> std::string{return R"(((?m)^b$))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_44_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_44_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4976,10 +4707,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_44_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_44_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4987,19 +4719,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_44_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_44_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_44_matcher::to_string() -> std::string{return R"((?m)^b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_44_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_44_matcher<CharT>::to_string() -> std::string{return R"((?m)^b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_45_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_45_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5041,10 +4773,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_45_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_45_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5052,19 +4785,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_45_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_45_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_45_matcher::to_string() -> std::string{return R"((?m)^(b))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_45_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_45_matcher<CharT>::to_string() -> std::string{return R"((?m)^(b))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_46_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_46_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5106,10 +4839,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_46_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_46_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5117,19 +4851,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_46_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_46_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_46_matcher::to_string() -> std::string{return R"(((?m)^b))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_46_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_46_matcher<CharT>::to_string() -> std::string{return R"(((?m)^b))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_47_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_47_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5185,10 +4919,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_47_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_47_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5196,19 +4931,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_47_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_47_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_47_matcher::to_string() -> std::string{return R"(\n((?m)^b))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_47_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_47_matcher<CharT>::to_string() -> std::string{return R"(\n((?m)^b))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_48_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_48_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5237,10 +4972,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_48_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_48_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5248,19 +4984,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_48_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_48_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_48_matcher::to_string() -> std::string{return R"(^b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_48_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_48_matcher<CharT>::to_string() -> std::string{return R"(^b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_49_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_49_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5302,10 +5038,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_49_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_49_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5313,19 +5050,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_49_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_49_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_49_matcher::to_string() -> std::string{return R"(()^b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_49_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_49_matcher<CharT>::to_string() -> std::string{return R"(()^b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_50_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_50_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5367,10 +5104,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_50_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_50_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5378,19 +5116,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_50_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_50_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_50_matcher::to_string() -> std::string{return R"(((?m)^b))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_50_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_50_matcher<CharT>::to_string() -> std::string{return R"(((?m)^b))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_51_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_51_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5418,10 +5156,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_51_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_51_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5429,97 +5168,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_51_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_51_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_51_matcher::to_string() -> std::string{return R"('(?:foo)'n)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_51_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_51_matcher<CharT>::to_string() -> std::string{return R"('(?:foo)'n)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_52_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  ctx.set_group_start(1, r.pos);
-
-  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  ctx.set_group_end(1, r.pos);
-
-  auto tmp_1_func {
-[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
-  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
-  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
-  }
-  }
-  }; 
-
-  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
-  static_cast<void>(cpp2::move(tmp_1));
-
-  std::array<char,3 + 1> str_tmp_2 {"bar"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 3;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_52_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_52_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_52_matcher::to_string() -> std::string{return R"('(?-n)(foo)(?n)(?:bar)'n)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_53_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_52_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5574,10 +5235,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_53_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_52_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5585,15 +5247,95 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_53_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_52_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_15_group_modifiers::regex_53_matcher::to_string() -> std::string{return R"('(?-n:(foo)(?n:(?:bar)))'n)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_52_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_52_matcher<CharT>::to_string() -> std::string{return R"('(?-n)(foo)(?n)(?:bar)'n)"; }
 
 
-#line 277 "pure2-regex_15_group_modifiers.cpp2"
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_53_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_1_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
+  static_cast<void>(cpp2::move(tmp_1));
+
+  std::array<char,3 + 1> str_tmp_2 {"bar"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_15_group_modifiers::regex_53_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_53_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_15_group_modifiers::regex_53_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_15_group_modifiers::regex_53_matcher<CharT>::to_string() -> std::string{return R"('(?-n:(foo)(?n:(?:bar)))'n)"; }
+
+
+#line 278 "pure2-regex_15_group_modifiers.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_15_group_modifiers());
 }

--- a/regression-tests/test-results/pure2-regex_16_perl_syntax_modifier.cpp
+++ b/regression-tests/test-results/pure2-regex_16_perl_syntax_modifier.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_16_perl_syntax_modifier.cpp2"
 
-#line 165 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 166 "pure2-regex_16_perl_syntax_modifier.cpp2"
 class test_tests_16_perl_syntax_modifier;
   
 
@@ -18,47 +18,41 @@ class test_tests_16_perl_syntax_modifier;
 #line 1 "pure2-regex_16_perl_syntax_modifier.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 113 "pure2-regex_16_perl_syntax_modifier.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 125 "pure2-regex_16_perl_syntax_modifier.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 166 "pure2-regex_16_perl_syntax_modifier.cpp2"
 class test_tests_16_perl_syntax_modifier {
 
-#line 199 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 200 "pure2-regex_16_perl_syntax_modifier.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -66,35 +60,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -102,35 +90,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -138,35 +120,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -174,35 +150,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -210,35 +180,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -246,25 +210,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -272,35 +230,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -308,35 +260,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -344,25 +290,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -370,25 +310,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -396,25 +330,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -422,25 +350,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -448,25 +370,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -474,25 +390,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -500,25 +410,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -526,25 +430,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -552,25 +450,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -578,25 +470,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -604,25 +490,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -630,35 +510,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; public: class regex_21_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_21_matcher() = default;
         public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -666,35 +540,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_21_matcher> regex_21 {}; public: class regex_22_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_22_matcher() = default;
         public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -702,35 +570,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_22_matcher> regex_22 {}; public: class regex_23_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_23_matcher() = default;
         public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -738,35 +600,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_23_matcher> regex_23 {}; public: class regex_24_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_24_matcher() = default;
         public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -774,35 +630,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_24_matcher> regex_24 {}; public: class regex_25_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; public: template<typename CharT> class regex_25_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_25_matcher() = default;
         public: regex_25_matcher(regex_25_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -810,35 +660,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_25_matcher> regex_25 {}; public: class regex_26_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_25_matcher<char>> regex_25 {}; public: template<typename CharT> class regex_26_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_26_matcher() = default;
         public: regex_26_matcher(regex_26_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -846,25 +690,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_26_matcher> regex_26 {}; public: class regex_27_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_26_matcher<char>> regex_26 {}; public: template<typename CharT> class regex_27_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_27_matcher() = default;
         public: regex_27_matcher(regex_27_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -872,35 +710,29 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_27_matcher> regex_27 {}; public: class regex_28_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_27_matcher<char>> regex_27 {}; public: template<typename CharT> class regex_28_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_28_matcher() = default;
         public: regex_28_matcher(regex_28_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -908,35 +740,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_28_matcher> regex_28 {}; public: class regex_29_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_28_matcher<char>> regex_28 {}; public: template<typename CharT> class regex_29_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_29_matcher() = default;
         public: regex_29_matcher(regex_29_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -944,25 +770,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_29_matcher> regex_29 {}; public: class regex_30_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_29_matcher<char>> regex_29 {}; public: template<typename CharT> class regex_30_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_30_matcher() = default;
         public: regex_30_matcher(regex_30_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -970,25 +790,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_30_matcher> regex_30 {}; public: class regex_31_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_30_matcher<char>> regex_30 {}; public: template<typename CharT> class regex_31_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_31_matcher() = default;
         public: regex_31_matcher(regex_31_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -996,25 +810,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_31_matcher> regex_31 {}; public: class regex_32_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_31_matcher<char>> regex_31 {}; public: template<typename CharT> class regex_32_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_32_matcher() = default;
         public: regex_32_matcher(regex_32_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1022,25 +830,19 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_32_matcher> regex_32 {}; public: class regex_33_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_32_matcher<char>> regex_32 {}; public: template<typename CharT> class regex_33_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_33_matcher() = default;
         public: regex_33_matcher(regex_33_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1048,13 +850,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_33_matcher> regex_33 {}; 
+  public: cpp2::regex::regular_expression<char,regex_33_matcher<char>> regex_33 {}; 
   public: test_tests_16_perl_syntax_modifier() = default;
   public: test_tests_16_perl_syntax_modifier(test_tests_16_perl_syntax_modifier const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_16_perl_syntax_modifier const&) -> void = delete;
 
 
-#line 236 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 237 "pure2-regex_16_perl_syntax_modifier.cpp2"
 };
 auto main() -> int;
 
@@ -1158,6 +960,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -1173,7 +976,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 113 "pure2-regex_16_perl_syntax_modifier.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -1186,7 +989,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 125 "pure2-regex_16_perl_syntax_modifier.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -1227,7 +1030,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 199 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 200 "pure2-regex_16_perl_syntax_modifier.cpp2"
   auto test_tests_16_perl_syntax_modifier::run() const& -> void{
     std::cout << "Running tests_16_perl_syntax_modifier:" << std::endl;
     test(regex_01, "01", R"(/\N {1}/x)", "abbbbc", "y", R"($&)", "a");
@@ -1269,8 +1072,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1285,11 +1087,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1303,11 +1106,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1321,10 +1125,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1332,19 +1137,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher::to_string() -> std::string{return R"(/\N{1}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_01_matcher<CharT>::to_string() -> std::string{return R"(/\N{1}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1359,11 +1164,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1377,11 +1183,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1395,10 +1202,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1406,19 +1214,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher::to_string() -> std::string{return R"(/\N{1}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_02_matcher<CharT>::to_string() -> std::string{return R"(/\N{1}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1433,11 +1241,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1451,11 +1260,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1469,10 +1279,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1480,19 +1291,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher::to_string() -> std::string{return R"(/\N{1}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_03_matcher<CharT>::to_string() -> std::string{return R"(/\N{1}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1507,11 +1318,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1525,11 +1337,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1543,10 +1356,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1554,19 +1368,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_04_matcher<CharT>::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1581,11 +1395,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1599,11 +1414,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1617,10 +1433,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1628,19 +1445,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_05_matcher<CharT>::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1655,11 +1472,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1673,11 +1491,12 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1691,10 +1510,11 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1702,19 +1522,19 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_06_matcher<CharT>::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1757,10 +1577,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1768,19 +1589,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_07_matcher::to_string() -> std::string{return R"(/a\Nc/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_07_matcher<CharT>::to_string() -> std::string{return R"(/a\Nc/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1795,113 +1616,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,1 + 1> str_tmp_0 {"a"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,1 + 1> str_tmp_1 {"c"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher::to_string() -> std::string{return R"(/a\N*c/x)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::named_class_no_new_line<char,false>::match(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1929,11 +1649,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1961,10 +1682,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1972,19 +1694,124 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher::to_string() -> std::string{return R"(/a\N*c/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_08_matcher<CharT>::to_string() -> std::string{return R"(/a\N*c/x)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::named_class_no_new_line<char,false>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_09_matcher<CharT>::to_string() -> std::string{return R"(/a\N*c/x)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1999,10 +1826,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2010,19 +1838,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_10_matcher::to_string() -> std::string{return R"(/[a b]/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_10_matcher<CharT>::to_string() -> std::string{return R"(/[a b]/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2037,10 +1865,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2048,19 +1877,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_11_matcher::to_string() -> std::string{return R"(/[a b]/xx)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_11_matcher<CharT>::to_string() -> std::string{return R"(/[a b]/xx)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2075,10 +1904,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2086,19 +1916,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_12_matcher::to_string() -> std::string{return R"(/[a\ b]/xx)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_12_matcher<CharT>::to_string() -> std::string{return R"(/[a\ b]/xx)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2113,10 +1943,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2124,19 +1955,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_13_matcher::to_string() -> std::string{return R"(/[ ^ a b ]/xx)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_13_matcher<CharT>::to_string() -> std::string{return R"(/[ ^ a b ]/xx)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2151,10 +1982,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2162,19 +1994,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_14_matcher::to_string() -> std::string{return R"(/[ ^ a b ]/xx)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_14_matcher<CharT>::to_string() -> std::string{return R"(/[ ^ a b ]/xx)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2189,10 +2021,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2200,19 +2033,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_15_matcher::to_string() -> std::string{return R"(/[ ^ a b ]/xx)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_15_matcher<CharT>::to_string() -> std::string{return R"(/[ ^ a b ]/xx)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2227,10 +2060,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2238,19 +2072,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_16_matcher::to_string() -> std::string{return R"(/(?x:[a b])/xx)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_16_matcher<CharT>::to_string() -> std::string{return R"(/(?x:[a b])/xx)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2265,10 +2099,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2276,19 +2111,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_17_matcher::to_string() -> std::string{return R"(/(?xx:[a b])/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_17_matcher<CharT>::to_string() -> std::string{return R"(/(?xx:[a b])/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2303,10 +2138,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2314,19 +2150,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_18_matcher::to_string() -> std::string{return R"(/(?x)[a b]/xx)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_18_matcher<CharT>::to_string() -> std::string{return R"(/(?x)[a b]/xx)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2341,10 +2177,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2352,19 +2189,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_19_matcher::to_string() -> std::string{return R"(/(?xx)[a b]/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_19_matcher<CharT>::to_string() -> std::string{return R"(/(?xx)[a b]/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2379,10 +2216,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2390,19 +2228,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_20_matcher::to_string() -> std::string{return R"(/(?-x:[a b])/xx)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_20_matcher<CharT>::to_string() -> std::string{return R"(/(?-x:[a b])/xx)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2417,11 +2255,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2435,11 +2274,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2453,10 +2293,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2464,19 +2305,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher::to_string() -> std::string{return R"(/\N{1}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_21_matcher<CharT>::to_string() -> std::string{return R"(/\N{1}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2491,11 +2332,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2509,11 +2351,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2527,10 +2370,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2538,19 +2382,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher::to_string() -> std::string{return R"(/\N{1}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_22_matcher<CharT>::to_string() -> std::string{return R"(/\N{1}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2565,11 +2409,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2583,11 +2428,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2601,10 +2447,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2612,19 +2459,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher::to_string() -> std::string{return R"(/\N{1}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_23_matcher<CharT>::to_string() -> std::string{return R"(/\N{1}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2639,11 +2486,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2657,11 +2505,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2675,10 +2524,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2686,19 +2536,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_24_matcher<CharT>::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2713,11 +2563,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2731,11 +2582,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2749,10 +2601,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2760,19 +2613,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_25_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_25_matcher<CharT>::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2787,11 +2640,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2805,11 +2659,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2823,10 +2678,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2834,19 +2690,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_26_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_26_matcher<CharT>::to_string() -> std::string{return R"(/\N{3,4}/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_27_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_27_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2889,10 +2745,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_27_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_27_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2900,19 +2757,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_27_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_27_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_27_matcher::to_string() -> std::string{return R"(/a\Nc/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_27_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_27_matcher<CharT>::to_string() -> std::string{return R"(/a\Nc/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2927,11 +2784,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2959,11 +2817,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2991,10 +2850,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3002,19 +2862,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher::to_string() -> std::string{return R"(/a\N*c/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_28_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_28_matcher<CharT>::to_string() -> std::string{return R"(/a\N*c/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3029,11 +2889,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3061,11 +2922,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3093,10 +2955,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3104,19 +2967,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher::to_string() -> std::string{return R"(/a\N*c/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_29_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_29_matcher<CharT>::to_string() -> std::string{return R"(/a\N*c/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_30_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_30_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3131,10 +2994,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_30_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_30_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3142,19 +3006,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_30_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_30_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_30_matcher::to_string() -> std::string{return R"(/[#]/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_30_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_30_matcher<CharT>::to_string() -> std::string{return R"(/[#]/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_31_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_31_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3183,10 +3047,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_31_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_31_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3194,19 +3059,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_31_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_31_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_31_matcher::to_string() -> std::string{return R"(/[#]b/)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_31_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_31_matcher<CharT>::to_string() -> std::string{return R"(/[#]b/)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_32_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_32_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3221,10 +3086,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_32_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_32_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3232,19 +3098,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_32_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_32_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_32_matcher::to_string() -> std::string{return R"(/[#]/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_32_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_32_matcher<CharT>::to_string() -> std::string{return R"(/[#]/x)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_33_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_33_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3273,10 +3139,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_33_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_33_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3284,15 +3151,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_33_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_33_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_33_matcher::to_string() -> std::string{return R"(/[#]b/x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_16_perl_syntax_modifier::regex_33_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_16_perl_syntax_modifier::regex_33_matcher<CharT>::to_string() -> std::string{return R"(/[#]b/x)"; }
 
 
-#line 237 "pure2-regex_16_perl_syntax_modifier.cpp2"
+#line 238 "pure2-regex_16_perl_syntax_modifier.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_16_perl_syntax_modifier());
 }

--- a/regression-tests/test-results/pure2-regex_17_comments.cpp
+++ b/regression-tests/test-results/pure2-regex_17_comments.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_17_comments.cpp2"
 
-#line 165 "pure2-regex_17_comments.cpp2"
+#line 166 "pure2-regex_17_comments.cpp2"
 class test_tests_17_comments;
   
 
@@ -18,47 +18,41 @@ class test_tests_17_comments;
 #line 1 "pure2-regex_17_comments.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_17_comments.cpp2"
+#line 113 "pure2-regex_17_comments.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_17_comments.cpp2"
+#line 125 "pure2-regex_17_comments.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_17_comments.cpp2"
+#line 166 "pure2-regex_17_comments.cpp2"
 class test_tests_17_comments {
 
-#line 169 "pure2-regex_17_comments.cpp2"
+#line 170 "pure2-regex_17_comments.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -66,35 +60,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -102,25 +90,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -128,13 +110,13 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; 
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; 
   public: test_tests_17_comments() = default;
   public: test_tests_17_comments(test_tests_17_comments const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_17_comments const&) -> void = delete;
 
 
-#line 176 "pure2-regex_17_comments.cpp2"
+#line 177 "pure2-regex_17_comments.cpp2"
 };
 auto main() -> int;
 
@@ -238,6 +220,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -253,7 +236,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_17_comments.cpp2"
+#line 113 "pure2-regex_17_comments.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -266,7 +249,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_17_comments.cpp2"
+#line 125 "pure2-regex_17_comments.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -307,7 +290,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 169 "pure2-regex_17_comments.cpp2"
+#line 170 "pure2-regex_17_comments.cpp2"
   auto test_tests_17_comments::run() const& -> void{
     std::cout << "Running tests_17_comments:" << std::endl;
     test(regex_01, "01", R"(^a(?#xxx){3}c)", "aaac", "y", R"($&)", "aaac");
@@ -319,110 +302,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,1 + 1> str_tmp_0 {"a"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-  if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = cpp2::regex::range_token_matcher<char,3,3,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
-
-  auto r {ctx.pass(cur)}; 
-  do {
-
-  std::array<char,1 + 1> str_tmp_1 {"c"}; 
-  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
-  r.matched = false;
-  break;
-  }
-{
-int i{0};
-  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
-  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
-  }
-}
-  if (r.matched) {r.pos += 1;}
-  else {break;}
-  }
-   while ( 
-  false
-  );
-  if (r.matched) {
-  r = other(r.pos, ctx);
-  }
-  else {
-  r.pos = ctx.end;
-  }
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
-  ctx.set_group_start(0, cur);
-
-  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
-  if (r.matched) {ctx.set_group_end(0, r.pos);}
-  return r; 
-  }
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
-  static_cast<void>(name);
-  return -1; 
-  }
-
-  [[nodiscard]] auto test_tests_17_comments::regex_01_matcher::to_string() -> std::string{return R"(^a(?#xxx){3}c)"; }
-
-
-
-
-
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -450,11 +330,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -469,11 +350,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -501,10 +383,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -512,19 +395,124 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_17_comments::regex_02_matcher::to_string() -> std::string{return R"('^a(?#xxx)(?#yyy){3}c'x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_17_comments::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_01_matcher<CharT>::to_string() -> std::string{return R"(^a(?#xxx){3}c)"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,3,3,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"c"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_17_comments::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_02_matcher<CharT>::to_string() -> std::string{return R"('^a(?#xxx)(?#yyy){3}c'x)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -552,10 +540,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_17_comments::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -563,15 +552,16 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_17_comments::regex_03_matcher::to_string() -> std::string{return R"('foo'x)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_17_comments::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_17_comments::regex_03_matcher<CharT>::to_string() -> std::string{return R"('foo'x)"; }
 
 
-#line 177 "pure2-regex_17_comments.cpp2"
+#line 178 "pure2-regex_17_comments.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_17_comments());
 }

--- a/regression-tests/test-results/pure2-regex_18_branch_reset.cpp
+++ b/regression-tests/test-results/pure2-regex_18_branch_reset.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_18_branch_reset.cpp2"
 
-#line 165 "pure2-regex_18_branch_reset.cpp2"
+#line 166 "pure2-regex_18_branch_reset.cpp2"
 class test_tests_18_branch_reset;
   
 
@@ -18,37 +18,31 @@ class test_tests_18_branch_reset;
 #line 1 "pure2-regex_18_branch_reset.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_18_branch_reset.cpp2"
+#line 113 "pure2-regex_18_branch_reset.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_18_branch_reset.cpp2"
+#line 125 "pure2-regex_18_branch_reset.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_18_branch_reset.cpp2"
+#line 166 "pure2-regex_18_branch_reset.cpp2"
 class test_tests_18_branch_reset {
 
-#line 181 "pure2-regex_18_branch_reset.cpp2"
+#line 182 "pure2-regex_18_branch_reset.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -56,11 +50,10 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -70,7 +63,7 @@ public: class func_1 {
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -80,7 +73,7 @@ public: class func_1 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -90,26 +83,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -117,11 +105,10 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -131,7 +118,7 @@ public: class func_1 {
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -141,7 +128,7 @@ public: class func_1 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -151,26 +138,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -178,11 +160,10 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,4>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,4>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -192,7 +173,7 @@ public: class func_1 {
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -202,7 +183,7 @@ public: class func_1 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -212,26 +193,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -239,11 +215,10 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -253,7 +228,7 @@ public: class func_2 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -263,12 +238,12 @@ public: class func_2 {
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -278,7 +253,7 @@ public: class func_2 {
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -288,7 +263,7 @@ public: class func_2 {
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -298,12 +273,12 @@ public: class func_2 {
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -313,26 +288,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -340,11 +310,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -354,7 +323,7 @@ public: class func_2 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -364,12 +333,12 @@ public: class func_2 {
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -379,7 +348,7 @@ public: class func_2 {
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -389,7 +358,7 @@ public: class func_2 {
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -399,12 +368,12 @@ public: class func_2 {
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -414,26 +383,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -441,11 +405,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -455,7 +418,7 @@ public: class func_2 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -465,12 +428,12 @@ public: class func_2 {
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -480,7 +443,7 @@ public: class func_2 {
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -490,7 +453,7 @@ public: class func_2 {
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -500,12 +463,12 @@ public: class func_2 {
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -515,26 +478,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -542,11 +500,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -556,7 +513,7 @@ public: class func_2 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -566,12 +523,12 @@ public: class func_2 {
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -581,7 +538,7 @@ public: class func_2 {
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -591,7 +548,7 @@ public: class func_2 {
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -601,12 +558,12 @@ public: class func_2 {
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -616,26 +573,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -643,11 +595,10 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,5>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,5>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -657,7 +608,7 @@ public: class func_1 {
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -667,26 +618,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -694,11 +640,10 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,5>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,5>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -708,7 +653,7 @@ public: class func_1 {
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -718,26 +663,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -745,25 +685,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -771,11 +705,10 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -785,7 +718,7 @@ public: class func_1 {
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -795,26 +728,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -822,11 +750,10 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -836,7 +763,7 @@ public: class func_1 {
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -846,26 +773,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -873,25 +795,19 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -899,11 +815,10 @@ public: class func_0 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,182>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,182>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -913,7 +828,7 @@ public: class func_1 {
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -923,26 +838,21 @@ public: class func_1 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -950,13 +860,13 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; 
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; 
   public: test_tests_18_branch_reset() = default;
   public: test_tests_18_branch_reset(test_tests_18_branch_reset const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_18_branch_reset const&) -> void = delete;
 
 
-#line 200 "pure2-regex_18_branch_reset.cpp2"
+#line 201 "pure2-regex_18_branch_reset.cpp2"
 };
 auto main() -> int;
 
@@ -1060,6 +970,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -1075,7 +986,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_18_branch_reset.cpp2"
+#line 113 "pure2-regex_18_branch_reset.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -1088,7 +999,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_18_branch_reset.cpp2"
+#line 125 "pure2-regex_18_branch_reset.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -1129,7 +1040,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 181 "pure2-regex_18_branch_reset.cpp2"
+#line 182 "pure2-regex_18_branch_reset.cpp2"
   auto test_tests_18_branch_reset::run() const& -> void{
     std::cout << "Running tests_18_branch_reset:" << std::endl;
     test(regex_01, "01", R"((?|(a)))", "a", "y", R"($1-$+)", "a-a");
@@ -1153,8 +1064,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1195,10 +1105,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1206,19 +1117,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_01_matcher::to_string() -> std::string{return R"((?|(a)))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_01_matcher<CharT>::to_string() -> std::string{return R"((?|(a)))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1274,16 +1185,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_02_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1367,17 +1279,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_02_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1447,17 +1360,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::reset_2::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_02_matcher<CharT>::reset_2::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1471,11 +1385,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1503,10 +1418,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1514,19 +1430,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher::to_string() -> std::string{return R"((?|a(.)b|d(.(o).)d|i(.)(.)j)(.))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_02_matcher<CharT>::to_string() -> std::string{return R"((?|a(.)b|d(.(o).)d|i(.)(.)j)(.))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1582,16 +1498,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_03_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1675,17 +1592,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_03_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1755,17 +1673,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::reset_2::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_03_matcher<CharT>::reset_2::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1779,11 +1698,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1811,10 +1731,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -1822,19 +1743,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher::to_string() -> std::string{return R"((?|a(.)b|d(.(o).)d|i(.)(.)j)(.))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_03_matcher<CharT>::to_string() -> std::string{return R"((?|a(.)b|d(.(o).)d|i(.)(.)j)(.))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1890,16 +1811,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_04_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -1983,17 +1905,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_04_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2063,17 +1986,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::reset_2::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_04_matcher<CharT>::reset_2::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2087,11 +2011,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2119,10 +2044,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2130,19 +2056,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher::to_string() -> std::string{return R"((?|a(.)b|d(.(o).)d|i(.)(.)j)(.))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_04_matcher<CharT>::to_string() -> std::string{return R"((?|a(.)b|d(.(o).)d|i(.)(.)j)(.))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2183,16 +2109,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_05_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2233,16 +2160,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_05_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2256,11 +2184,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2274,16 +2203,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::reset_2::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_05_matcher<CharT>::reset_2::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2324,16 +2254,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::reset_3::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_05_matcher<CharT>::reset_3::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2374,16 +2305,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::reset_4::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_05_matcher<CharT>::reset_4::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2397,11 +2329,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2415,16 +2348,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::reset_5::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_05_matcher<CharT>::reset_5::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2438,11 +2372,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2456,10 +2391,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2467,19 +2403,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher::to_string() -> std::string{return R"((?|(?|(a)|(b))|(?|(c)|(d))))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_05_matcher<CharT>::to_string() -> std::string{return R"((?|(?|(a)|(b))|(?|(c)|(d))))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2520,16 +2456,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_06_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2570,16 +2507,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_06_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2593,11 +2531,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2611,16 +2550,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::reset_2::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_06_matcher<CharT>::reset_2::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2661,16 +2601,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::reset_3::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_06_matcher<CharT>::reset_3::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2711,16 +2652,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::reset_4::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_06_matcher<CharT>::reset_4::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2734,11 +2676,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2752,16 +2695,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::reset_5::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_06_matcher<CharT>::reset_5::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2775,11 +2719,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2793,10 +2738,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2804,19 +2750,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher::to_string() -> std::string{return R"((?|(?|(a)|(b))|(?|(c)|(d))))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_06_matcher<CharT>::to_string() -> std::string{return R"((?|(?|(a)|(b))|(?|(c)|(d))))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2857,16 +2803,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_07_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2907,16 +2854,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_07_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2930,11 +2878,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2948,16 +2897,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::reset_2::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_07_matcher<CharT>::reset_2::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2998,16 +2948,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::reset_3::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_07_matcher<CharT>::reset_3::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3048,16 +2999,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::reset_4::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_07_matcher<CharT>::reset_4::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3071,11 +3023,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3089,16 +3042,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::reset_5::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_07_matcher<CharT>::reset_5::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3112,11 +3066,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3130,10 +3085,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3141,19 +3097,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher::to_string() -> std::string{return R"((?|(?|(a)|(b))|(?|(c)|(d))))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_07_matcher<CharT>::to_string() -> std::string{return R"((?|(?|(a)|(b))|(?|(c)|(d))))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3194,16 +3150,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_08_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3244,16 +3201,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_08_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3267,11 +3225,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3285,16 +3244,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::reset_2::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_08_matcher<CharT>::reset_2::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3335,16 +3295,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::reset_3::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_08_matcher<CharT>::reset_3::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3385,16 +3346,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::reset_4::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_08_matcher<CharT>::reset_4::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3408,11 +3370,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3426,16 +3389,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::reset_5::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_08_matcher<CharT>::reset_5::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3449,11 +3413,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3467,10 +3432,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3478,19 +3444,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher::to_string() -> std::string{return R"((?|(?|(a)|(b))|(?|(c)|(d))))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_08_matcher<CharT>::to_string() -> std::string{return R"((?|(?|(a)|(b))|(?|(c)|(d))))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3546,17 +3512,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_09_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_09_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   ctx.set_group_invalid(3);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3598,16 +3565,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_09_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_09_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3635,11 +3603,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3667,10 +3636,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3678,19 +3648,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher::to_string() -> std::string{return R"((.)(?|(.)(.)x|(.)d)(.))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_09_matcher<CharT>::to_string() -> std::string{return R"((.)(?|(.)(.)x|(.)d)(.))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3746,17 +3716,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_10_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_10_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   ctx.set_group_invalid(3);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3798,16 +3769,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_10_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_10_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3835,11 +3807,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3867,10 +3840,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3878,19 +3852,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher::to_string() -> std::string{return R"((\N)(?|(\N)(\N)x|(\N)d)(\N))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_10_matcher<CharT>::to_string() -> std::string{return R"((\N)(?|(\N)(\N)x|(\N)d)(\N))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3931,10 +3905,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3942,18 +3917,18 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "foo") {return 1; }else {return -1; }
   }
 
-  [[nodiscard]] auto test_tests_18_branch_reset::regex_11_matcher::to_string() -> std::string{return R"((?|(?<foo>x)))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_11_matcher<CharT>::to_string() -> std::string{return R"((?|(?<foo>x)))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3994,16 +3969,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_12_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_12_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4044,16 +4020,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_12_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_18_branch_reset::regex_12_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4067,11 +4044,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4085,10 +4063,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4096,20 +4075,20 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   if (name == "bar") {return 1; }else {if (name == "foo") {return 1; }else {return -1; }
 #line 1 "pure2-regex_18_branch_reset.cpp2"
 }
 }
 
-[[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher::to_string() -> std::string{return R"((?|(?<foo>x)|(?<bar>y)))"; }
+template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_12_matcher<CharT>::to_string() -> std::string{return R"((?|(?<foo>x)|(?<bar>y)))"; }
 
 
 
 
 
-
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
 auto r {ctx.pass(cur)}; 
 do {
@@ -4150,16 +4129,17 @@ r = other(r.pos, ctx);
 else {
 r.pos = ctx.end;
 }
+static_cast<void>(CPP2_FORWARD(ctx));
 return r; 
 }
 
 
-template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_13_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+template <typename CharT> auto test_tests_18_branch_reset::regex_13_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
 ctx.set_group_invalid(1);
 }
 
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
 auto r {ctx.pass(cur)}; 
 do {
@@ -4200,16 +4180,17 @@ r = other(r.pos, ctx);
 else {
 r.pos = ctx.end;
 }
+static_cast<void>(CPP2_FORWARD(ctx));
 return r; 
 }
 
 
-template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_13_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+template <typename CharT> auto test_tests_18_branch_reset::regex_13_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
 ctx.set_group_invalid(1);
 }
 
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
 auto r {ctx.pass(cur)}; 
 do {
@@ -4223,11 +4204,12 @@ r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_
 else {
 r.pos = ctx.end;
 }
+static_cast<void>(CPP2_FORWARD(ctx));
 return r; 
 }
 
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
 auto r {ctx.pass(cur)}; 
 do {
@@ -4241,10 +4223,11 @@ r = other(r.pos, ctx);
 else {
 r.pos = ctx.end;
 }
+static_cast<void>(CPP2_FORWARD(ctx));
 return r; 
 }
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
 ctx.set_group_start(0, cur);
 
 auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4252,18 +4235,18 @@ if (r.matched) {ctx.set_group_end(0, r.pos);}
 return r; 
 }
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
 if (name == "bar") {return 1; }else {if (name == "foo") {return 1; }else {return -1; }}
 }
 
-[[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher::to_string() -> std::string{return R"((?|(?<bar>y)|(?<foo>x)))"; }
+template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_13_matcher<CharT>::to_string() -> std::string{return R"((?|(?<bar>y)|(?<foo>x)))"; }
 
 
 
 
 
-
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
 auto r {ctx.pass(cur)}; 
 do {
@@ -4317,10 +4300,11 @@ r = other(r.pos, ctx);
 else {
 r.pos = ctx.end;
 }
+static_cast<void>(CPP2_FORWARD(ctx));
 return r; 
 }
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
 ctx.set_group_start(0, cur);
 
 auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4328,18 +4312,18 @@ if (r.matched) {ctx.set_group_end(0, r.pos);}
 return r; 
 }
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
 if (name == "bar") {return 1; }else {if (name == "foo") {return 2; }else {return -1; }}
 }
 
-[[nodiscard]] auto test_tests_18_branch_reset::regex_14_matcher::to_string() -> std::string{return R"((?<bar>)(?|(?<foo>x)))"; }
+template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_14_matcher<CharT>::to_string() -> std::string{return R"((?<bar>)(?|(?<foo>x)))"; }
 
 
 
 
 
-
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
 auto r {ctx.pass(cur)}; 
 do {
@@ -4380,16 +4364,17 @@ r = other(r.pos, ctx);
 else {
 r.pos = ctx.end;
 }
+static_cast<void>(CPP2_FORWARD(ctx));
 return r; 
 }
 
 
-template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_15_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+template <typename CharT> auto test_tests_18_branch_reset::regex_15_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
 ctx.set_group_invalid(1);
 }
 
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
 auto r {ctx.pass(cur)}; 
 do {
@@ -6770,11 +6755,12 @@ r = other(r.pos, ctx);
 else {
 r.pos = ctx.end;
 }
+static_cast<void>(CPP2_FORWARD(ctx));
 return r; 
 }
 
 
-template <typename Iter, typename CharT> auto test_tests_18_branch_reset::regex_15_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+template <typename CharT> auto test_tests_18_branch_reset::regex_15_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
 ctx.set_group_invalid(1);
 ctx.set_group_invalid(2);
 ctx.set_group_invalid(3);
@@ -6959,7 +6945,7 @@ ctx.set_group_invalid(181);
 }
 
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
 auto r {ctx.pass(cur)}; 
 do {
@@ -6973,11 +6959,12 @@ r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_
 else {
 r.pos = ctx.end;
 }
+static_cast<void>(CPP2_FORWARD(ctx));
 return r; 
 }
 
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
 auto r {ctx.pass(cur)}; 
 do {
@@ -6991,10 +6978,11 @@ r = other(r.pos, ctx);
 else {
 r.pos = ctx.end;
 }
+static_cast<void>(CPP2_FORWARD(ctx));
 return r; 
 }
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
 ctx.set_group_start(0, cur);
 
 auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7002,15 +6990,16 @@ if (r.matched) {ctx.set_group_end(0, r.pos);}
 return r; 
 }
 
-template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
 static_cast<void>(name);
 return -1; 
 }
 
-[[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher::to_string() -> std::string{return R"((?|(b)|()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()(a)))"; }
+template <typename CharT> [[nodiscard]] constexpr auto test_tests_18_branch_reset::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_18_branch_reset::regex_15_matcher<CharT>::to_string() -> std::string{return R"((?|(b)|()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()()(a)))"; }
 
 
-#line 201 "pure2-regex_18_branch_reset.cpp2"
+#line 202 "pure2-regex_18_branch_reset.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_18_branch_reset());
 }

--- a/regression-tests/test-results/pure2-regex_19_lookahead.cpp
+++ b/regression-tests/test-results/pure2-regex_19_lookahead.cpp
@@ -9,7 +9,7 @@
 
 #line 1 "pure2-regex_19_lookahead.cpp2"
 
-#line 165 "pure2-regex_19_lookahead.cpp2"
+#line 166 "pure2-regex_19_lookahead.cpp2"
 class test_tests_19_lookahead;
   
 
@@ -18,42 +18,36 @@ class test_tests_19_lookahead;
 #line 1 "pure2-regex_19_lookahead.cpp2"
 [[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
 
-#line 112 "pure2-regex_19_lookahead.cpp2"
+#line 113 "pure2-regex_19_lookahead.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string;
 
-#line 124 "pure2-regex_19_lookahead.cpp2"
+#line 125 "pure2-regex_19_lookahead.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void;
 
-#line 165 "pure2-regex_19_lookahead.cpp2"
+#line 166 "pure2-regex_19_lookahead.cpp2"
 class test_tests_19_lookahead {
 
-#line 211 "pure2-regex_19_lookahead.cpp2"
+#line 222 "pure2-regex_19_lookahead.cpp2"
   public: auto run() const& -> void;
-  public: class regex_01_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_01_matcher() = default;
         public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -61,30 +55,24 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_01_matcher> regex_01 {}; public: class regex_02_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_02_matcher() = default;
         public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -92,30 +80,24 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_02_matcher> regex_02 {}; public: class regex_03_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_03_matcher() = default;
         public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -123,45 +105,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_03_matcher> regex_03 {}; public: class regex_04_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_04_matcher() = default;
         public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -169,21 +145,20 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_04_matcher> regex_04 {}; public: class regex_05_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -193,12 +168,12 @@ public: class func_2 {
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -208,26 +183,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_05_matcher() = default;
         public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -235,40 +205,34 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_05_matcher> regex_05 {}; public: class regex_06_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_06_matcher() = default;
         public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -276,40 +240,34 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_06_matcher> regex_06 {}; public: class regex_07_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; public: template<typename CharT> class regex_07_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_07_matcher() = default;
         public: regex_07_matcher(regex_07_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -317,40 +275,34 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_07_matcher> regex_07 {}; public: class regex_08_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_07_matcher<char>> regex_07 {}; public: template<typename CharT> class regex_08_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_08_matcher() = default;
         public: regex_08_matcher(regex_08_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -358,40 +310,34 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_08_matcher> regex_08 {}; public: class regex_09_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_08_matcher<char>> regex_08 {}; public: template<typename CharT> class regex_09_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_09_matcher() = default;
         public: regex_09_matcher(regex_09_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -399,40 +345,34 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_09_matcher> regex_09 {}; public: class regex_10_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_09_matcher<char>> regex_09 {}; public: template<typename CharT> class regex_10_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_10_matcher() = default;
         public: regex_10_matcher(regex_10_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -440,40 +380,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_10_matcher> regex_10 {}; public: class regex_11_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_10_matcher<char>> regex_10 {}; public: template<typename CharT> class regex_11_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_11_matcher() = default;
         public: regex_11_matcher(regex_11_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -481,55 +415,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_11_matcher> regex_11 {}; public: class regex_12_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_11_matcher<char>> regex_11 {}; public: template<typename CharT> class regex_12_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_12_matcher() = default;
         public: regex_12_matcher(regex_12_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -537,55 +465,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_12_matcher> regex_12 {}; public: class regex_13_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_12_matcher<char>> regex_12 {}; public: template<typename CharT> class regex_13_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_13_matcher() = default;
         public: regex_13_matcher(regex_13_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -593,55 +515,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_13_matcher> regex_13 {}; public: class regex_14_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_13_matcher<char>> regex_13 {}; public: template<typename CharT> class regex_14_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_14_matcher() = default;
         public: regex_14_matcher(regex_14_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -649,55 +565,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_14_matcher> regex_14 {}; public: class regex_15_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_14_matcher<char>> regex_14 {}; public: template<typename CharT> class regex_15_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_15_matcher() = default;
         public: regex_15_matcher(regex_15_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -705,40 +615,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_15_matcher> regex_15 {}; public: class regex_16_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_15_matcher<char>> regex_15 {}; public: template<typename CharT> class regex_16_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_16_matcher() = default;
         public: regex_16_matcher(regex_16_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -746,40 +650,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_16_matcher> regex_16 {}; public: class regex_17_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_16_matcher<char>> regex_16 {}; public: template<typename CharT> class regex_17_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_17_matcher() = default;
         public: regex_17_matcher(regex_17_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -787,40 +685,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_17_matcher> regex_17 {}; public: class regex_18_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_17_matcher<char>> regex_17 {}; public: template<typename CharT> class regex_18_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_18_matcher() = default;
         public: regex_18_matcher(regex_18_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -828,40 +720,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_18_matcher> regex_18 {}; public: class regex_19_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_18_matcher<char>> regex_18 {}; public: template<typename CharT> class regex_19_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_19_matcher() = default;
         public: regex_19_matcher(regex_19_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -869,55 +755,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_19_matcher> regex_19 {}; public: class regex_20_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_19_matcher<char>> regex_19 {}; public: template<typename CharT> class regex_20_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_20_matcher() = default;
         public: regex_20_matcher(regex_20_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -925,55 +805,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_20_matcher> regex_20 {}; public: class regex_21_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_20_matcher<char>> regex_20 {}; public: template<typename CharT> class regex_21_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_21_matcher() = default;
         public: regex_21_matcher(regex_21_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -981,55 +855,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_21_matcher> regex_21 {}; public: class regex_22_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_21_matcher<char>> regex_21 {}; public: template<typename CharT> class regex_22_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_22_matcher() = default;
         public: regex_22_matcher(regex_22_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1037,55 +905,49 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_22_matcher> regex_22 {}; public: class regex_23_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_22_matcher<char>> regex_22 {}; public: template<typename CharT> class regex_23_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_23_matcher() = default;
         public: regex_23_matcher(regex_23_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1093,40 +955,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_23_matcher> regex_23 {}; public: class regex_24_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_23_matcher<char>> regex_23 {}; public: template<typename CharT> class regex_24_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_24_matcher() = default;
         public: regex_24_matcher(regex_24_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1134,40 +990,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_24_matcher> regex_24 {}; public: class regex_25_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_24_matcher<char>> regex_24 {}; public: template<typename CharT> class regex_25_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_25_matcher() = default;
         public: regex_25_matcher(regex_25_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1175,36 +1025,35 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_25_matcher> regex_25 {}; public: class regex_26_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_25_matcher<char>> regex_25 {}; public: template<typename CharT> class regex_26_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1214,36 +1063,31 @@ public: class func_1 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_26_matcher() = default;
         public: regex_26_matcher(regex_26_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1251,35 +1095,29 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_26_matcher> regex_26 {}; public: class regex_27_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_26_matcher<char>> regex_26 {}; public: template<typename CharT> class regex_27_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_27_matcher() = default;
         public: regex_27_matcher(regex_27_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1287,35 +1125,29 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_27_matcher> regex_27 {}; public: class regex_28_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_27_matcher<char>> regex_27 {}; public: template<typename CharT> class regex_28_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_28_matcher() = default;
         public: regex_28_matcher(regex_28_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1323,26 +1155,265 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_28_matcher> regex_28 {}; public: class regex_37_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
-public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: cpp2::regex::regular_expression<char,regex_28_matcher<char>> regex_28 {}; public: template<typename CharT> class regex_29_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_29_matcher() = default;
+        public: regex_29_matcher(regex_29_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_29_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_29_matcher<char>> regex_29 {}; public: template<typename CharT> class regex_30_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_30_matcher() = default;
+        public: regex_30_matcher(regex_30_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_30_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_30_matcher<char>> regex_30 {}; public: template<typename CharT> class regex_31_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_31_matcher() = default;
+        public: regex_31_matcher(regex_31_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_31_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_31_matcher<char>> regex_31 {}; public: template<typename CharT> class regex_32_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_32_matcher() = default;
+        public: regex_32_matcher(regex_32_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_32_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_32_matcher<char>> regex_32 {}; public: template<typename CharT> class regex_33_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_33_matcher() = default;
+        public: regex_33_matcher(regex_33_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_33_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_33_matcher<char>> regex_33 {}; public: template<typename CharT> class regex_34_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_34_matcher() = default;
+        public: regex_34_matcher(regex_34_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_34_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_34_matcher<char>> regex_34 {}; public: template<typename CharT> class regex_35_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_35_matcher() = default;
+        public: regex_35_matcher(regex_35_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_35_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_35_matcher<char>> regex_35 {}; public: template<typename CharT> class regex_36_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_36_matcher() = default;
+        public: regex_36_matcher(regex_36_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_36_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_36_matcher<char>> regex_36 {}; public: template<typename CharT> class regex_37_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1352,17 +1423,17 @@ public: class func_2 {
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1372,26 +1443,21 @@ public: class func_2 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_37_matcher() = default;
         public: regex_37_matcher(regex_37_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1399,40 +1465,34 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_37_matcher> regex_37 {}; public: class regex_38_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_37_matcher<char>> regex_37 {}; public: template<typename CharT> class regex_38_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_38_matcher() = default;
         public: regex_38_matcher(regex_38_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1440,30 +1500,24 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_38_matcher> regex_38 {}; public: class regex_39_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_38_matcher<char>> regex_38 {}; public: template<typename CharT> class regex_39_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_39_matcher() = default;
         public: regex_39_matcher(regex_39_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1471,40 +1525,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_39_matcher> regex_39 {}; public: class regex_40_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_39_matcher<char>> regex_39 {}; public: template<typename CharT> class regex_40_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_40_matcher() = default;
         public: regex_40_matcher(regex_40_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1512,36 +1560,35 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_40_matcher> regex_40 {}; public: class regex_41_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_40_matcher<char>> regex_40 {}; public: template<typename CharT> class regex_41_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1551,41 +1598,36 @@ public: class func_1 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_10 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_41_matcher() = default;
         public: regex_41_matcher(regex_41_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1593,36 +1635,35 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_41_matcher> regex_41 {}; public: class regex_42_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_41_matcher<char>> regex_41 {}; public: template<typename CharT> class regex_42_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1632,31 +1673,26 @@ public: class func_1 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_42_matcher() = default;
         public: regex_42_matcher(regex_42_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1664,41 +1700,40 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_42_matcher> regex_42 {}; public: class regex_43_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_42_matcher<char>> regex_42 {}; public: template<typename CharT> class regex_43_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1708,26 +1743,21 @@ public: class func_3 {
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_43_matcher() = default;
         public: regex_43_matcher(regex_43_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1735,56 +1765,55 @@ public: class func_3 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_43_matcher> regex_43 {}; public: class regex_44_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_43_matcher<char>> regex_43 {}; public: template<typename CharT> class regex_44_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_10 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_11 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1794,31 +1823,26 @@ public: class func_1 {
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_12 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_44_matcher() = default;
         public: regex_44_matcher(regex_44_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1826,45 +1850,39 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_44_matcher> regex_44 {}; public: class regex_45_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_44_matcher<char>> regex_44 {}; public: template<typename CharT> class regex_45_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_45_matcher() = default;
         public: regex_45_matcher(regex_45_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1872,31 +1890,30 @@ public: class func_4 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_45_matcher> regex_45 {}; public: class regex_46_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,3>;
+  public: cpp2::regex::regular_expression<char,regex_45_matcher<char>> regex_45 {}; public: template<typename CharT> class regex_46_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,3>;
 public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_6 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_5 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_7 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1906,22 +1923,22 @@ public: class func_2 {
   };
 
   public: class func_4 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_11 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_10 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_12 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
@@ -1931,51 +1948,46 @@ public: class func_2 {
   };
 
   public: class func_9 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_13 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_8 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_14 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_15 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_46_matcher() = default;
         public: regex_46_matcher(regex_46_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -1983,30 +1995,24 @@ public: class func_2 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_46_matcher> regex_46 {}; public: class regex_47_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_46_matcher<char>> regex_46 {}; public: template<typename CharT> class regex_47_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_47_matcher() = default;
         public: regex_47_matcher(regex_47_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2014,30 +2020,24 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_47_matcher> regex_47 {}; public: class regex_48_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_47_matcher<char>> regex_47 {}; public: template<typename CharT> class regex_48_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_48_matcher() = default;
         public: regex_48_matcher(regex_48_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2045,30 +2045,24 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_48_matcher> regex_48 {}; public: class regex_49_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_48_matcher<char>> regex_48 {}; public: template<typename CharT> class regex_49_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_49_matcher() = default;
         public: regex_49_matcher(regex_49_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2076,30 +2070,24 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_49_matcher> regex_49 {}; public: class regex_50_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_49_matcher<char>> regex_49 {}; public: template<typename CharT> class regex_50_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_50_matcher() = default;
         public: regex_50_matcher(regex_50_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2107,30 +2095,24 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_50_matcher> regex_50 {}; public: class regex_51_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_50_matcher<char>> regex_50 {}; public: template<typename CharT> class regex_51_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_51_matcher() = default;
         public: regex_51_matcher(regex_51_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2138,30 +2120,24 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_51_matcher> regex_51 {}; public: class regex_52_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,2>;
+  public: cpp2::regex::regular_expression<char,regex_51_matcher<char>> regex_51 {}; public: template<typename CharT> class regex_52_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_52_matcher() = default;
         public: regex_52_matcher(regex_52_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2169,40 +2145,34 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_52_matcher> regex_52 {}; public: class regex_53_matcher {
-  public: template<typename Iter, typename CharT> class wrap {
-  public: using context = cpp2::regex::match_context<CharT,Iter,1>;
+  public: cpp2::regex::regular_expression<char,regex_52_matcher<char>> regex_52 {}; public: template<typename CharT> class regex_53_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
 public: class func_1 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_0 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_3 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
   public: class func_2 {
-  public: [[nodiscard]] auto operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
 
   };
 
-  public: [[nodiscard]] static auto entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>;
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
 
   public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
 
-  public: wrap() = default;
-  public: wrap(wrap const&) = delete; /* No 'that' constructor, suppress copy */
-  public: auto operator=(wrap const&) -> void = delete;
-
-  };
-
-  public: [[nodiscard]] static auto to_string() -> std::string;
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
 
         public: regex_53_matcher() = default;
         public: regex_53_matcher(regex_53_matcher const&) = delete; /* No 'that' constructor, suppress copy */
@@ -2210,13 +2180,53 @@ public: class func_1 {
 
   };
 
-  public: cpp2::regex::regular_expression<char,regex_53_matcher> regex_53 {}; 
+  public: cpp2::regex::regular_expression<char,regex_53_matcher<char>> regex_53 {}; public: template<typename CharT> class regex_54_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_54_matcher() = default;
+        public: regex_54_matcher(regex_54_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_54_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_54_matcher<char>> regex_54 {}; public: template<typename CharT> class regex_55_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_55_matcher() = default;
+        public: regex_55_matcher(regex_55_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_55_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_55_matcher<char>> regex_55 {}; 
   public: test_tests_19_lookahead() = default;
   public: test_tests_19_lookahead(test_tests_19_lookahead const&) = delete; /* No 'that' constructor, suppress copy */
   public: auto operator=(test_tests_19_lookahead const&) -> void = delete;
 
 
-#line 260 "pure2-regex_19_lookahead.cpp2"
+#line 281 "pure2-regex_19_lookahead.cpp2"
 };
 auto main() -> int;
 
@@ -2320,6 +2330,7 @@ auto main() -> int;
             }
             result +=  std::to_string(cpp2::move(pos));
           }
+          ++next;
         }
         else {
           std::cerr << "Not implemented";
@@ -2335,7 +2346,7 @@ auto main() -> int;
   return result; 
 }
 
-#line 112 "pure2-regex_19_lookahead.cpp2"
+#line 113 "pure2-regex_19_lookahead.cpp2"
 [[nodiscard]] auto sanitize(std::string str) -> std::string
 {
   str = cpp2::string_util::replace_all(str, "\a", "\\a");
@@ -2348,7 +2359,7 @@ auto main() -> int;
   return cpp2::move(str); 
 }
 
-#line 124 "pure2-regex_19_lookahead.cpp2"
+#line 125 "pure2-regex_19_lookahead.cpp2"
 template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
            cpp2::impl::in<std::string> resultExpected) -> void{
 
@@ -2389,7 +2400,7 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
   std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
 }
 
-#line 211 "pure2-regex_19_lookahead.cpp2"
+#line 222 "pure2-regex_19_lookahead.cpp2"
   auto test_tests_19_lookahead::run() const& -> void{
     std::cout << "Running tests_19_lookahead:" << std::endl;
     test(regex_01, "01", R"(a(?!b).)", "abad", "y", R"($&)", "ad");
@@ -2420,6 +2431,14 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
     test(regex_26, "26", R"(^(a*?)(?!(aa|aaaa)*$)(?=a\z))", "aaaaaaaa", "y", R"($1)", "aaaaaaa");
     test(regex_27, "27", R"(a(?!b(?!c))(..))", "abababc", "y", R"($1)", "bc");
     test(regex_28, "28", R"(a(?!b(?=a))(..))", "abababc", "y", R"($1)", "bc");
+    test(regex_29, "29", R"((?=foo))", "foo", "y", R"(@+)", "0");
+    test(regex_30, "30", R"((?=foo))", "XfooY", "y", R"(@+)", "1");
+    test(regex_31, "31", R"(.*(?=foo))", "XfooY", "y", R"(@+)", "1");
+    test(regex_32, "32", R"((?=.*P)P)", "aP", "y", R"(@+)", "2");
+    test(regex_33, "33", R"(X(?=foo)f)", "..XfooY..", "y", R"(@+)", "4");
+    test(regex_34, "34", R"(X(?=foo))", "..XfooY..", "y", R"(@+)", "3");
+    test(regex_35, "35", R"((?=XY*foo))", "Xfoo", "y", R"(@+)", "0");
+    test(regex_36, "36", R"(^(?=XY*foo))", "Xfoo", "y", R"(@+)", "0");
     test(regex_37, "37", R"(X(\w+)(?=\s)|X(\w+))", "Xab", "y", R"([$1-$2])", "[-ab]");
     test(regex_38, "38", R"(^a*(?=b)b)", "ab", "y", R"($&)", "ab");
     test(regex_39, "39", R"('(?!\A)x'm)", "a\nxb\n", "y", R"(-)", "-");
@@ -2437,14 +2456,15 @@ template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, c
     test(regex_51, "51", R"(((?s)b.)c(?!\N))", "a\nb\nc\n", "y", R"($1:$&)", "b\n:b\nc");
     test(regex_52, "52", R"('(b.)c(?!\N)'s)", "a\nb\nc\n", "y", R"($1:$&)", "b\n:b\nc");
     test(regex_53, "53", R"(a*(?!))", "aaaab", "n", R"(-)", "-");
+    test(regex_54, "54", R"((?<bar>)foo)", "bar>ABCfoo", "y", R"($&)", "foo");
+    test(regex_55, "55", R"((?<bar>ABC)foo)", "bar>ABCfoo", "y", R"($&)", "ABCfoo");
     std::cout << std::endl;
   }
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2472,11 +2492,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2506,10 +2527,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2517,19 +2539,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher::to_string() -> std::string{return R"(a(?!b).)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_01_matcher<CharT>::to_string() -> std::string{return R"(a(?!b).)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2543,11 +2565,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2576,10 +2599,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2587,19 +2611,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher::to_string() -> std::string{return R"((?=)a)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_02_matcher<CharT>::to_string() -> std::string{return R"((?=)a)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2627,11 +2651,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2661,10 +2686,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2672,19 +2698,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher::to_string() -> std::string{return R"(a(?=d).)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_03_matcher<CharT>::to_string() -> std::string{return R"(a(?=d).)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2712,11 +2738,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2744,11 +2771,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2762,11 +2790,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2780,11 +2809,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2814,10 +2844,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -2825,19 +2856,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher::to_string() -> std::string{return R"(a(?=c|d).)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_04_matcher<CharT>::to_string() -> std::string{return R"(a(?=c|d).)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2865,11 +2896,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2897,11 +2929,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2930,16 +2963,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_05_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2953,11 +2987,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2971,16 +3006,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_05_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -2995,15 +3031,16 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -3014,10 +3051,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3025,19 +3063,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher::to_string() -> std::string{return R"(^(?:b|a(?=(.)))*\1)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_05_matcher<CharT>::to_string() -> std::string{return R"(^(?:b|a(?=(.)))*\1)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3065,11 +3103,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3084,11 +3123,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3114,17 +3154,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
   if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
   ctx.set_group_start(2, r.pos);
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
 
   std::array<char,2 + 1> str_tmp_2 {"ab"}; 
   if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
@@ -3161,10 +3202,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3172,19 +3214,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher::to_string() -> std::string{return R"((?=(a+?))(\1ab))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_06_matcher<CharT>::to_string() -> std::string{return R"((?=(a+?))(\1ab))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3212,11 +3254,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3231,11 +3274,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3261,17 +3305,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
   if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
   if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
 
   std::array<char,2 + 1> str_tmp_2 {"ab"}; 
   if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
@@ -3296,10 +3341,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3307,19 +3353,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher::to_string() -> std::string{return R"(^(?=(a+?))\1ab)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_07_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_07_matcher<CharT>::to_string() -> std::string{return R"(^(?=(a+?))\1ab)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3347,11 +3393,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3366,11 +3413,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3396,17 +3444,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
   if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
   ctx.set_group_start(2, r.pos);
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
 
   std::array<char,2 + 1> str_tmp_2 {"ab"}; 
   if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
@@ -3443,10 +3492,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3454,19 +3504,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher::to_string() -> std::string{return R"((?=(a+?))(\1ab))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_08_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_08_matcher<CharT>::to_string() -> std::string{return R"((?=(a+?))(\1ab))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3494,11 +3544,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3513,11 +3564,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3543,17 +3595,18 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
   if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
   if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,false,false>(r.pos, ctx))) {r.matched = false;break;}
 
   std::array<char,2 + 1> str_tmp_2 {"ab"}; 
   if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
@@ -3578,10 +3631,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3589,19 +3643,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher::to_string() -> std::string{return R"(^(?=(a+?))\1ab)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_09_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_09_matcher<CharT>::to_string() -> std::string{return R"(^(?=(a+?))\1ab)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3616,11 +3670,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3635,11 +3690,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3667,11 +3723,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3698,10 +3755,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3709,19 +3767,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher::to_string() -> std::string{return R"((.*)(?=c))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_10_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_10_matcher<CharT>::to_string() -> std::string{return R"((.*)(?=c))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3736,11 +3794,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3755,11 +3814,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3787,11 +3847,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3832,10 +3893,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -3843,19 +3905,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher::to_string() -> std::string{return R"((.*)(?=c)c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_11_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_11_matcher<CharT>::to_string() -> std::string{return R"((.*)(?=c)c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3870,11 +3932,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3889,11 +3952,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3921,11 +3985,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3953,11 +4018,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3971,11 +4037,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -3989,11 +4056,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4020,10 +4088,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4031,19 +4100,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher::to_string() -> std::string{return R"((.*)(?=b|c))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_12_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_12_matcher<CharT>::to_string() -> std::string{return R"((.*)(?=b|c))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4058,11 +4127,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4077,11 +4147,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4109,11 +4180,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4141,11 +4213,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4159,11 +4232,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4177,11 +4251,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4222,10 +4297,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4233,19 +4309,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher::to_string() -> std::string{return R"((.*)(?=b|c)c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_13_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_13_matcher<CharT>::to_string() -> std::string{return R"((.*)(?=b|c)c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4260,11 +4336,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4279,11 +4356,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4311,11 +4389,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4343,11 +4422,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4361,11 +4441,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4379,11 +4460,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4410,10 +4492,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4421,19 +4504,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher::to_string() -> std::string{return R"((.*)(?=c|b))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_14_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_14_matcher<CharT>::to_string() -> std::string{return R"((.*)(?=c|b))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4448,11 +4531,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4467,11 +4551,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4499,11 +4584,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4531,11 +4617,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4549,11 +4636,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4567,11 +4655,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4612,10 +4701,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4623,19 +4713,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher::to_string() -> std::string{return R"((.*)(?=c|b)c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_15_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_15_matcher<CharT>::to_string() -> std::string{return R"((.*)(?=c|b)c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4650,11 +4740,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4669,11 +4760,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4688,11 +4780,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4719,10 +4812,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4730,19 +4824,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher::to_string() -> std::string{return R"((.*)(?=[bc]))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_16_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_16_matcher<CharT>::to_string() -> std::string{return R"((.*)(?=[bc]))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4757,11 +4851,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4776,11 +4871,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4795,11 +4891,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4840,10 +4937,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4851,19 +4949,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher::to_string() -> std::string{return R"((.*)(?=[bc])c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_17_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_17_matcher<CharT>::to_string() -> std::string{return R"((.*)(?=[bc])c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4878,11 +4976,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4897,11 +4996,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4929,11 +5029,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4960,10 +5061,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -4971,19 +5073,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher::to_string() -> std::string{return R"((.*?)(?=c))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_18_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_18_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?=c))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -4998,11 +5100,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5017,11 +5120,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5049,11 +5153,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5094,10 +5199,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5105,19 +5211,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher::to_string() -> std::string{return R"((.*?)(?=c)c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_19_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_19_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?=c)c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5132,11 +5238,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5151,11 +5258,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5183,11 +5291,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5215,11 +5324,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5233,11 +5343,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5251,11 +5362,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5282,10 +5394,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5293,19 +5406,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher::to_string() -> std::string{return R"((.*?)(?=b|c))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_20_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_20_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?=b|c))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5320,11 +5433,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5339,11 +5453,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5371,11 +5486,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5403,11 +5519,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5421,11 +5538,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5439,11 +5557,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5484,10 +5603,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5495,19 +5615,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher::to_string() -> std::string{return R"((.*?)(?=b|c)c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_21_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_21_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?=b|c)c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5522,11 +5642,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5541,11 +5662,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5573,11 +5695,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5605,11 +5728,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5623,11 +5747,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5641,11 +5766,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5672,10 +5798,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5683,19 +5810,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher::to_string() -> std::string{return R"((.*?)(?=c|b))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_22_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_22_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?=c|b))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5710,11 +5837,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5729,11 +5857,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5761,11 +5890,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5793,11 +5923,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5811,11 +5942,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5829,11 +5961,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5874,10 +6007,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5885,19 +6019,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher::to_string() -> std::string{return R"((.*?)(?=c|b)c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_23_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_23_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?=c|b)c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5912,11 +6046,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5931,11 +6066,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5950,11 +6086,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -5981,10 +6118,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -5992,19 +6130,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher::to_string() -> std::string{return R"((.*?)(?=[bc]))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_24_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_24_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?=[bc]))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6019,11 +6157,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6038,11 +6177,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6057,11 +6197,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6102,10 +6243,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6113,19 +6255,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher::to_string() -> std::string{return R"((.*?)(?=[bc])c)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_25_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_25_matcher<CharT>::to_string() -> std::string{return R"((.*?)(?=[bc])c)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6153,11 +6295,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6173,11 +6316,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6205,11 +6349,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6237,11 +6382,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6256,11 +6402,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6286,16 +6433,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_26_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6309,11 +6457,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6328,11 +6477,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6361,11 +6511,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6393,10 +6544,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6404,19 +6556,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher::to_string() -> std::string{return R"(^(a*?)(?!(aa|aaaa)*$)(?=a\z))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_26_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_26_matcher<CharT>::to_string() -> std::string{return R"(^(a*?)(?!(aa|aaaa)*$)(?=a\z))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6444,11 +6596,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6477,11 +6630,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6525,10 +6679,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6536,19 +6691,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher::to_string() -> std::string{return R"(a(?!b(?!c))(..))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_27_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_27_matcher<CharT>::to_string() -> std::string{return R"(a(?!b(?!c))(..))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6576,11 +6731,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6609,11 +6765,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6657,10 +6814,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6668,19 +6826,862 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher::to_string() -> std::string{return R"(a(?!b(?=a))(..))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_28_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_28_matcher<CharT>::to_string() -> std::string{return R"(a(?!b(?=a))(..))"; }
 
 
 
 
 
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_29_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_29_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_29_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_29_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_29_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_29_matcher<CharT>::to_string() -> std::string{return R"((?=foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_30_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_30_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_30_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_30_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_30_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_30_matcher<CharT>::to_string() -> std::string{return R"((?=foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_31_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_31_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_2());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_31_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_0 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_31_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_3()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_31_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_31_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_31_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_31_matcher<CharT>::to_string() -> std::string{return R"(.*(?=foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_32_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::any_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_32_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_32_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"P"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_32_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_1 {"P"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_32_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_32_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_32_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_32_matcher<CharT>::to_string() -> std::string{return R"((?=.*P)P)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_33_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_1 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_33_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"X"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+
+  std::array<char,1 + 1> str_tmp_2 {"f"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_33_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_33_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_33_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_33_matcher<CharT>::to_string() -> std::string{return R"(X(?=foo)f)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_34_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_1 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_34_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"X"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_34_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_34_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_34_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_34_matcher<CharT>::to_string() -> std::string{return R"(X(?=foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_35_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"Y"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_35_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"X"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_35_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_2 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_35_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_35_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_35_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_35_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_35_matcher<CharT>::to_string() -> std::string{return R"((?=XY*foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_36_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"Y"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_36_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"X"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_36_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,3 + 1> str_tmp_2 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_36_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::lookahead_token_matcher<char,true>(r.pos, ctx, func_1()))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_36_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_36_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_36_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_36_matcher<CharT>::to_string() -> std::string{return R"(^(?=XY*foo))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6695,11 +7696,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6728,11 +7730,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6747,11 +7750,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6778,16 +7782,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_37_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6802,11 +7807,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6835,11 +7841,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6865,16 +7872,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_37_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6888,11 +7896,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6906,10 +7915,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -6917,19 +7927,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher::to_string() -> std::string{return R"(X(\w+)(?=\s)|X(\w+))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_37_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_37_matcher<CharT>::to_string() -> std::string{return R"(X(\w+)(?=\s)|X(\w+))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6957,11 +7967,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -6976,11 +7987,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7008,11 +8020,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7041,10 +8054,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7052,19 +8066,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher::to_string() -> std::string{return R"(^a*(?=b)b)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_38_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_38_matcher<CharT>::to_string() -> std::string{return R"(^a*(?=b)b)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7079,11 +8093,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7112,10 +8127,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7123,19 +8139,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher::to_string() -> std::string{return R"('(?!\A)x'm)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_39_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_39_matcher<CharT>::to_string() -> std::string{return R"('(?!\A)x'm)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7150,11 +8166,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7168,15 +8185,16 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
-  if (!(cpp2::regex::group_ref_token_matcher<char,1,true>(r.pos, ctx))) {r.matched = false;break;}
+  if (!(cpp2::regex::group_ref_token_matcher<char,1,true,false>(r.pos, ctx))) {r.matched = false;break;}
   }
    while ( 
   false
@@ -7187,11 +8205,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7236,10 +8255,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7247,19 +8267,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher::to_string() -> std::string{return R"('^(o)(?!.*\1)'i)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_40_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_40_matcher<CharT>::to_string() -> std::string{return R"('^(o)(?!.*\1)'i)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7274,11 +8294,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7292,11 +8313,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7324,11 +8346,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7356,11 +8379,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7375,11 +8399,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7405,16 +8430,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_41_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7428,11 +8454,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7460,11 +8487,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7479,11 +8507,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7512,11 +8541,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::func_10::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::func_10::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7544,10 +8574,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7555,19 +8586,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher::to_string() -> std::string{return R"(.*a(?!(b|cd)*e).*f)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_41_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_41_matcher<CharT>::to_string() -> std::string{return R"(.*a(?!(b|cd)*e).*f)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7595,11 +8626,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7615,11 +8647,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7647,11 +8680,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7679,11 +8713,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7698,11 +8733,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7728,16 +8764,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_42_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7751,11 +8788,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7770,11 +8808,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7801,10 +8840,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -7812,19 +8852,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher::to_string() -> std::string{return R"(^(a*?)(?!(aa|aaaa)*$))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_42_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_42_matcher<CharT>::to_string() -> std::string{return R"(^(a*?)(?!(aa|aaaa)*$))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7838,11 +8878,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7857,11 +8898,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7875,11 +8917,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7893,11 +8936,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7912,11 +8956,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7931,11 +8976,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7961,16 +9007,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_43_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -7984,11 +9031,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8002,10 +9050,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8013,19 +9062,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher::to_string() -> std::string{return R"((?!)+?|(.{2,4}))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_43_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_43_matcher<CharT>::to_string() -> std::string{return R"((?!)+?|(.{2,4}))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8053,11 +9102,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8073,11 +9123,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8105,11 +9156,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8123,11 +9175,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8141,11 +9194,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8173,11 +9227,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8191,11 +9246,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_10::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_10::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8209,11 +9265,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8228,11 +9285,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_11::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_11::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8258,16 +9316,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_44_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8281,11 +9340,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_12::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_12::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8300,11 +9360,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8331,10 +9392,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8342,19 +9404,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher::to_string() -> std::string{return R"(^(a*?)(?!(a{6}|a{5})*$))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_44_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_44_matcher<CharT>::to_string() -> std::string{return R"(^(a*?)(?!(a{6}|a{5})*$))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8382,11 +9444,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8415,11 +9478,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8448,11 +9512,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8481,11 +9546,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8531,10 +9597,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8542,19 +9609,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher::to_string() -> std::string{return R"(a(?!b(?!c(?!d(?!e))))...(.))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_45_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_45_matcher<CharT>::to_string() -> std::string{return R"(a(?!b(?!c(?!d(?!e))))...(.))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8582,11 +9649,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8600,11 +9668,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_6::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8632,11 +9701,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_5::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8651,11 +9721,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_7::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8681,16 +9752,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_46_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(1);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_4::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8704,11 +9776,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_11::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_11::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8736,11 +9809,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_10::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_10::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8755,11 +9829,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_12::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_12::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8785,16 +9860,17 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::reset_1::operator()(auto& ctx) const& -> void{
+  template <typename CharT> auto test_tests_19_lookahead::regex_46_matcher<CharT>::reset_1::operator()(auto& ctx) const& -> void{
   ctx.set_group_invalid(2);
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_9::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8808,11 +9884,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_13::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_13::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8840,11 +9917,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_8::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8859,11 +9937,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8878,11 +9957,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_14::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_14::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8897,11 +9977,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8930,11 +10011,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::func_15::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::func_15::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -8962,10 +10044,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -8973,19 +10056,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher::to_string() -> std::string{return R"(X(?!b+(?!(c+)*(?!(c+)*d))).*X)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_46_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_46_matcher<CharT>::to_string() -> std::string{return R"(X(?!b+(?!(c+)*(?!(c+)*d))).*X)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9000,11 +10083,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9047,10 +10131,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9058,19 +10143,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher::to_string() -> std::string{return R"(((?s).)c(?!.))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_47_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_47_matcher<CharT>::to_string() -> std::string{return R"(((?s).)c(?!.))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9085,11 +10170,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9132,10 +10218,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9143,19 +10230,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher::to_string() -> std::string{return R"(((?s).)c(?!.))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_48_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_48_matcher<CharT>::to_string() -> std::string{return R"(((?s).)c(?!.))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9170,11 +10257,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9231,10 +10319,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9242,19 +10331,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher::to_string() -> std::string{return R"(((?s)b.)c(?!.))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_49_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_49_matcher<CharT>::to_string() -> std::string{return R"(((?s)b.)c(?!.))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9269,11 +10358,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9330,10 +10420,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9341,19 +10432,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher::to_string() -> std::string{return R"(((?s)b.)c(?!.))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_50_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_50_matcher<CharT>::to_string() -> std::string{return R"(((?s)b.)c(?!.))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9368,11 +10459,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9429,10 +10521,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9440,19 +10533,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher::to_string() -> std::string{return R"(((?s)b.)c(?!\N))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_51_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_51_matcher<CharT>::to_string() -> std::string{return R"(((?s)b.)c(?!\N))"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9467,11 +10560,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9528,10 +10622,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9539,19 +10634,19 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher::to_string() -> std::string{return R"('(b.)c(?!\N)'s)"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_52_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_52_matcher<CharT>::to_string() -> std::string{return R"('(b.)c(?!\N)'s)"; }
 
 
 
 
 
-
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher::wrap<Iter,CharT>::func_1::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9579,11 +10674,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher::wrap<Iter,CharT>::func_0::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9597,11 +10693,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher::wrap<Iter,CharT>::func_3::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9615,11 +10712,12 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher::wrap<Iter,CharT>::func_2::operator()(cpp2::impl::in<Iter> cur, context& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
 
   auto r {ctx.pass(cur)}; 
   do {
@@ -9634,10 +10732,11 @@ int i{0};
   else {
   r.pos = ctx.end;
   }
+  static_cast<void>(CPP2_FORWARD(ctx));
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher::wrap<Iter,CharT>::entry(cpp2::impl::in<Iter> cur, context& ctx) -> cpp2::regex::match_return<Iter>{
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
   ctx.set_group_start(0, cur);
 
   auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
@@ -9645,15 +10744,158 @@ int i{0};
   return r; 
   }
 
-  template <typename Iter, typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher::wrap<Iter,CharT>::get_named_group_index(auto const& name) -> int{
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher<CharT>::get_named_group_index(auto const& name) -> int{
   static_cast<void>(name);
   return -1; 
   }
 
-  [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher::to_string() -> std::string{return R"(a*(?!))"; }
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_53_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_53_matcher<CharT>::to_string() -> std::string{return R"(a*(?!))"; }
 
 
-#line 261 "pure2-regex_19_lookahead.cpp2"
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_54_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_0_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_0 {cpp2::regex::make_on_return(cpp2::move(tmp_0_func))}; 
+  static_cast<void>(cpp2::move(tmp_0));
+
+  std::array<char,3 + 1> str_tmp_1 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_54_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_54_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  if (name == "bar") {return 1; }else {return -1; }
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_54_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_54_matcher<CharT>::to_string() -> std::string{return R"((?<bar>)foo)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_55_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+
+  std::array<char,3 + 1> str_tmp_0 {"ABC"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_1_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
+  static_cast<void>(cpp2::move(tmp_1));
+
+  std::array<char,3 + 1> str_tmp_2 {"foo"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),3)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,3); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 3;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_19_lookahead::regex_55_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_55_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  if (name == "bar") {return 1; }else {return -1; }
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_19_lookahead::regex_55_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_19_lookahead::regex_55_matcher<CharT>::to_string() -> std::string{return R"((?<bar>ABC)foo)"; }
+
+
+#line 282 "pure2-regex_19_lookahead.cpp2"
 auto main() -> int{
     CPP2_UFCS(run)(test_tests_19_lookahead());
 }

--- a/regression-tests/test-results/pure2-regex_20_lookbehind.cpp.output
+++ b/regression-tests/test-results/pure2-regex_20_lookbehind.cpp.output
@@ -1,0 +1,3 @@
+pure2-regex_20_lookbehind.cpp...
+pure2-regex_20_lookbehind.cpp: error: source filename must end with .cpp2 or .h2: pure2-regex_20_lookbehind.cpp
+

--- a/regression-tests/test-results/pure2-regex_21_atomic_patterns.cpp
+++ b/regression-tests/test-results/pure2-regex_21_atomic_patterns.cpp
@@ -1,0 +1,1616 @@
+
+#define CPP2_IMPORT_STD          Yes
+#include "cpp2regex.h"
+
+//=== Cpp2 type declarations ====================================================
+
+
+#include "cpp2util.h"
+
+#line 1 "pure2-regex_21_atomic_patterns.cpp2"
+
+#line 166 "pure2-regex_21_atomic_patterns.cpp2"
+class test_tests_21_atomic_patterns;
+  
+
+//=== Cpp2 type definitions and function declarations ===========================
+
+#line 1 "pure2-regex_21_atomic_patterns.cpp2"
+[[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string;
+
+#line 113 "pure2-regex_21_atomic_patterns.cpp2"
+[[nodiscard]] auto sanitize(std::string str) -> std::string;
+
+#line 125 "pure2-regex_21_atomic_patterns.cpp2"
+template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
+           cpp2::impl::in<std::string> resultExpected) -> void;
+
+#line 166 "pure2-regex_21_atomic_patterns.cpp2"
+class test_tests_21_atomic_patterns {
+
+#line 173 "pure2-regex_21_atomic_patterns.cpp2"
+  public: auto run() const& -> void;
+  public: template<typename CharT> class regex_01_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,1>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_01_matcher() = default;
+        public: regex_01_matcher(regex_01_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_01_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_01_matcher<char>> regex_01 {}; public: template<typename CharT> class regex_02_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_02_matcher() = default;
+        public: regex_02_matcher(regex_02_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_02_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_02_matcher<char>> regex_02 {}; public: template<typename CharT> class regex_03_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_03_matcher() = default;
+        public: regex_03_matcher(regex_03_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_03_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_03_matcher<char>> regex_03 {}; public: template<typename CharT> class regex_04_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_8 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_7 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_9 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_10 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class reset_0 {
+  public: auto operator()(auto& ctx) const& -> void;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_11 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_04_matcher() = default;
+        public: regex_04_matcher(regex_04_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_04_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_04_matcher<char>> regex_04 {}; public: template<typename CharT> class regex_05_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_05_matcher() = default;
+        public: regex_05_matcher(regex_05_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_05_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_05_matcher<char>> regex_05 {}; public: template<typename CharT> class regex_06_matcher {
+  public: template<typename Iter> using context = cpp2::regex::match_context<CharT,Iter,2>;
+public: class func_3 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_2 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_4 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_1 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_5 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_0 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: class func_6 {
+  public: template<typename Iter> [[nodiscard]] auto operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>;
+
+  };
+
+  public: template<typename Iter> [[nodiscard]] static auto entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>;
+
+  public: [[nodiscard]] static auto get_named_group_index(auto const& name) -> int;
+
+  public: [[nodiscard]] constexpr static auto is_start_match() -> bool;
+public: [[nodiscard]] static auto to_string() -> std::string;
+
+        public: regex_06_matcher() = default;
+        public: regex_06_matcher(regex_06_matcher const&) = delete; /* No 'that' constructor, suppress copy */
+        public: auto operator=(regex_06_matcher const&) -> void = delete;
+
+  };
+
+  public: cpp2::regex::regular_expression<char,regex_06_matcher<char>> regex_06 {}; 
+  public: test_tests_21_atomic_patterns() = default;
+  public: test_tests_21_atomic_patterns(test_tests_21_atomic_patterns const&) = delete; /* No 'that' constructor, suppress copy */
+  public: auto operator=(test_tests_21_atomic_patterns const&) -> void = delete;
+
+
+#line 183 "pure2-regex_21_atomic_patterns.cpp2"
+};
+auto main() -> int;
+
+//=== Cpp2 function definitions =================================================
+
+#line 1 "pure2-regex_21_atomic_patterns.cpp2"
+[[nodiscard]] auto create_result(cpp2::impl::in<std::string> resultExpr, auto const& r) -> std::string{
+#line 2 "pure2-regex_21_atomic_patterns.cpp2"
+  std::string result {""}; 
+
+  auto get_next {[_0 = (&resultExpr)](auto const& iter) mutable -> auto{
+  auto start {std::distance(CPP2_UFCS(cbegin)((*cpp2::impl::assert_not_null(_0))), iter)}; 
+    auto firstDollar {CPP2_UFCS(find)((*cpp2::impl::assert_not_null(_0)), "$", start)}; 
+    auto firstAt {CPP2_UFCS(find)((*cpp2::impl::assert_not_null(_0)), "@", cpp2::move(start))}; 
+
+  auto end {std::min(cpp2::move(firstDollar), cpp2::move(firstAt))}; 
+  if (end != std::string::npos) {
+   return CPP2_UFCS(cbegin)((*cpp2::impl::assert_not_null(_0))) + cpp2::move(end); 
+  }
+  else {
+   return CPP2_UFCS(cend)((*cpp2::impl::assert_not_null(_0))); 
+  }
+  }}; 
+  auto extract_group_and_advance {[](auto& iter) -> auto{
+    auto start {iter}; 
+
+    for( ; std::isdigit(*cpp2::impl::assert_not_null(iter)); ++iter ) {}
+
+    return std::stoi(std::string(cpp2::move(start), iter)); 
+  }}; 
+  auto extract_until {[](auto& iter, cpp2::impl::in<char> to) -> auto{
+    auto start {iter}; 
+
+    for( ; (to != *cpp2::impl::assert_not_null(iter)); ++iter ) {}// TODO: Without bracket: error: postfix unary * (dereference) cannot be immediately followed by a (, identifier, or literal - add whitespace before * here if you meant binary * (multiplication)
+
+    return std::string(cpp2::move(start), iter); 
+  }}; 
+
+  auto iter {CPP2_UFCS(begin)(resultExpr)}; 
+
+  while( iter != CPP2_UFCS(end)(resultExpr) ) {
+    auto next {get_next(iter)}; 
+
+    if (next != iter) {
+      result += std::string(iter, next);
+    }
+    if (next != CPP2_UFCS(end)(resultExpr)) {
+      if (*cpp2::impl::assert_not_null(next) == '$') {
+        ++next;
+
+        if (*cpp2::impl::assert_not_null(next) == '&') {
+          ++next;
+          result += CPP2_UFCS(group)(r, 0);
+        }
+        else {if (*cpp2::impl::assert_not_null(next) == '-' || *cpp2::impl::assert_not_null(next) == '+') {
+          auto is_start {*cpp2::impl::assert_not_null(next) == '-'}; 
+          ++next;
+          if (*cpp2::impl::assert_not_null(next) == '{') {
+            ++next; // Skip {
+            auto group {extract_until(next, '}')}; 
+            ++next; // Skip }
+            result += CPP2_UFCS(group)(r, cpp2::move(group));
+          }
+          else {if (*cpp2::impl::assert_not_null(next) == '[') {
+            ++next; // Skip [
+            auto group {extract_group_and_advance(next)}; 
+            ++next; // Skip ]
+
+            if (cpp2::move(is_start)) {
+              result += std::to_string(CPP2_UFCS(group_start)(r, cpp2::move(group)));
+            }
+            else {
+              result += std::to_string(CPP2_UFCS(group_end)(r, cpp2::move(group)));
+            }
+          }
+          else {
+            // Return max group
+            result += CPP2_UFCS(group)(r, CPP2_UFCS(group_number)(r) - 1);
+          }}
+        }
+        else {if (std::isdigit(*cpp2::impl::assert_not_null(next))) {
+          auto group {extract_group_and_advance(next)}; 
+          result += CPP2_UFCS(group)(r, cpp2::move(group));
+        }
+        else {
+          std::cerr << "Not implemented";
+        }}}
+      }
+      else {if (*cpp2::impl::assert_not_null(next) == '@') {
+        ++next;
+
+        if (*cpp2::impl::assert_not_null(next) == '-' || *cpp2::impl::assert_not_null(next) == '+') {
+          auto i {0}; 
+          for( ; cpp2::impl::cmp_less(i,cpp2::unchecked_narrow<int>(CPP2_UFCS(group_number)(r))); ++i ) {
+            auto pos {0}; 
+            if (*cpp2::impl::assert_not_null(next) == '-') {
+              pos = CPP2_UFCS(group_start)(r, i);
+            }
+            else {
+              pos = CPP2_UFCS(group_end)(r, i);
+            }
+            result +=  std::to_string(cpp2::move(pos));
+          }
+          ++next;
+        }
+        else {
+          std::cerr << "Not implemented";
+        }
+      }
+      else {
+        std::cerr << "Not implemented.";
+      }}
+    }
+    iter = cpp2::move(next);
+  }
+
+  return result; 
+}
+
+#line 113 "pure2-regex_21_atomic_patterns.cpp2"
+[[nodiscard]] auto sanitize(std::string str) -> std::string
+{
+  str = cpp2::string_util::replace_all(str, "\a", "\\a");
+  str = cpp2::string_util::replace_all(str, "\f", "\\f");
+  str = cpp2::string_util::replace_all(str, "\x1b", "\\e");
+  str = cpp2::string_util::replace_all(str, "\n", "\\n");
+  str = cpp2::string_util::replace_all(str, "\r", "\\r");
+  str = cpp2::string_util::replace_all(str, "\t", "\\t");
+
+  return cpp2::move(str); 
+}
+
+#line 125 "pure2-regex_21_atomic_patterns.cpp2"
+template<typename M> auto test(M const& regex, cpp2::impl::in<std::string> id, cpp2::impl::in<std::string> regex_str, cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> kind, cpp2::impl::in<std::string> resultExpr, 
+           cpp2::impl::in<std::string> resultExpected) -> void{
+
+  std::string warning {""}; 
+  if (CPP2_UFCS(to_string)(regex) != regex_str) {
+    warning = "Warning: Parsed regex does not match.";
+  }
+
+  std::string status {"OK"}; 
+
+  auto r {CPP2_UFCS(search)(regex, str)}; 
+
+  if ("y" == kind || "yM" == kind || "yS" == kind || "yB" == kind) {
+    if (!(r.matched)) {
+      status = "Failure: Regex should apply.";
+    }
+    else {
+      // Have a match check the result
+
+      auto result {create_result(resultExpr, cpp2::move(r))}; 
+
+      if (result != resultExpected) {
+        status = "Failure: Result is wrong. (is: " + cpp2::to_string(sanitize(cpp2::move(result))) + ")";
+      }
+    }
+  }
+  else {if ("n" == kind) {
+    if (r.matched) {
+      status = "Failure: Regex should not apply. Result is '" + cpp2::to_string(CPP2_UFCS(group)(cpp2::move(r), 0)) + "'";
+    }
+  }else {
+    status = "Unknown kind '" + cpp2::to_string(kind) + "'";
+  }}
+
+  if (!(CPP2_UFCS(empty)(warning))) {
+    warning += " ";
+  }
+  std::cout << "" + cpp2::to_string(id) + "_" + cpp2::to_string(kind) + ": " + cpp2::to_string(cpp2::move(status)) + " " + cpp2::to_string(cpp2::move(warning)) + "regex: " + cpp2::to_string(regex_str) + " parsed_regex: " + cpp2::to_string(CPP2_UFCS(to_string)(regex)) + " str: " + cpp2::to_string(sanitize(str)) + " result_expr: " + cpp2::to_string(resultExpr) + " expected_results " + cpp2::to_string(sanitize(resultExpected)) + "" << std::endl;
+}
+
+#line 173 "pure2-regex_21_atomic_patterns.cpp2"
+  auto test_tests_21_atomic_patterns::run() const& -> void{
+    std::cout << "Running tests_21_atomic_patterns:" << std::endl;
+    test(regex_01, "01", R"((?>a+)b)", "aaab", "y", R"(-)", "-");
+    test(regex_02, "02", R"(((?>a+)b))", "aaab", "y", R"($1)", "aaab");
+    test(regex_03, "03", R"((?>(a+))b)", "aaab", "y", R"($1)", "aaa");
+    test(regex_04, "04", R"(((?>[^()]+)|\([^()]*\))+)", "((abc(ade)ufh()()x", "y", R"($&)", "abc(ade)ufh()()x");
+    test(regex_05, "05", R"(round\(((?>[^()]+))\))", "_I(round(xs * sz),1)", "y", R"($1)", "xs * sz");
+    test(regex_06, "06", R"(^((?>(?:aa)?b)?))", "aab", "y", R"($1)", "aab");
+    std::cout << std::endl;
+  }
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_01_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_01_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,-1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_01_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_01_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::atomic_group_matcher<char>(r.pos, ctx, func_1(), other, func_4());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_01_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_01_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_01_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_21_atomic_patterns::regex_01_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_01_matcher<CharT>::to_string() -> std::string{return R"((?>a+)b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_02_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_02_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,-1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_02_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_02_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::atomic_group_matcher<char>(r.pos, ctx, func_1(), other, func_4());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_02_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_02_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_02_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_21_atomic_patterns::regex_02_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_02_matcher<CharT>::to_string() -> std::string{return R"(((?>a+)b))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_03_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"a"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_03_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,-1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_03_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_1_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
+  static_cast<void>(cpp2::move(tmp_1));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_03_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::atomic_group_matcher<char>(r.pos, ctx, func_1(), other, func_4());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_03_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_2 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_03_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_03_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_21_atomic_patterns::regex_03_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_03_matcher<CharT>::to_string() -> std::string{return R"((?>(a+))b)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,true,false,::cpp2::regex::single_class_entry<char,'('>,::cpp2::regex::single_class_entry<char,')'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,-1,2>::match(r.pos, ctx, func_4(), cpp2::regex::no_reset(), other, func_5());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::atomic_group_matcher<char>(r.pos, ctx, func_3(), other, func_6());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_8::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,true,false,::cpp2::regex::single_class_entry<char,'('>,::cpp2::regex::single_class_entry<char,')'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_7::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_0 {"("}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,-1,2>::match(r.pos, ctx, func_8(), cpp2::regex::no_reset(), other, func_9());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_9::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {")"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::alternative_token_matcher<char>::match(r.pos, ctx, other, func_10(), func_2(), cpp2::regex::no_reset(), func_7(), cpp2::regex::no_reset());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_10::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::reset_0::operator()(auto& ctx) const& -> void{
+  ctx.set_group_invalid(1);
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,-1,2>::match(r.pos, ctx, func_1(), reset_0(), other, func_11());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::func_11::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_04_matcher<CharT>::to_string() -> std::string{return R"(((?>[^()]+)|\([^()]*\))+)"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_05_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::class_token_matcher<char,true,false,::cpp2::regex::single_class_entry<char,'('>,::cpp2::regex::single_class_entry<char,')'>>::match(r.pos, ctx))) {r.matched = false;break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_05_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,1,-1,2>::match(r.pos, ctx, func_2(), cpp2::regex::no_reset(), other, func_3());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_05_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_05_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,6 + 1> str_tmp_0 {"round("}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),6)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,6); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 6;}
+  else {break;}
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::atomic_group_matcher<char>(r.pos, ctx, func_1(), other, func_4());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_05_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_1_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_1 {cpp2::regex::make_on_return(cpp2::move(tmp_1_func))}; 
+  static_cast<void>(cpp2::move(tmp_1));
+
+  std::array<char,1 + 1> str_tmp_2 {")"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_2, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_05_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_05_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_21_atomic_patterns::regex_05_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_05_matcher<CharT>::to_string() -> std::string{return R"(round\(((?>[^()]+))\))"; }
+
+
+
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::func_3::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,2 + 1> str_tmp_0 {"aa"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),2)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,2); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_0, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 2;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::func_2::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_3(), cpp2::regex::no_reset(), other, func_4());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::func_4::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+
+  std::array<char,1 + 1> str_tmp_1 {"b"}; 
+  if (cpp2::impl::cmp_less(std::distance(r.pos, ctx.end),1)) {
+  r.matched = false;
+  break;
+  }
+{
+int i{0};
+  for( ; cpp2::impl::cmp_less(i,1); (i += 1) ) {
+  if (CPP2_ASSERT_IN_BOUNDS(str_tmp_1, i) != CPP2_ASSERT_IN_BOUNDS(r.pos, i)) {r.matched = false;}
+  }
+}
+  if (r.matched) {r.pos += 1;}
+  else {break;}
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::func_1::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::atomic_group_matcher<char>(r.pos, ctx, func_2(), other, func_5());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::func_5::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::func_0::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  if (!(cpp2::regex::line_start_token_matcher<char,false>(r.pos, ctx))) {r.matched = false;break;}
+  ctx.set_group_start(1, r.pos);
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = cpp2::regex::range_token_matcher<char,0,1,2>::match(r.pos, ctx, func_1(), cpp2::regex::no_reset(), other, func_6());
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::func_6::operator()(Iter const& cur, auto&& ctx, auto const& other) const& -> cpp2::regex::match_return<Iter>{
+
+  auto r {ctx.pass(cur)}; 
+  do {
+  ctx.set_group_end(1, r.pos);
+
+  auto tmp_2_func {
+[&, _1 = (&r), _2 = (&ctx)]() mutable -> void{
+  if (!((*cpp2::impl::assert_not_null(_1)).matched)) {
+  (*cpp2::impl::assert_not_null(_2)).set_group_invalid(1);
+  }
+  }
+  }; 
+
+  auto tmp_2 {cpp2::regex::make_on_return(cpp2::move(tmp_2_func))}; 
+  static_cast<void>(cpp2::move(tmp_2));
+  }
+   while ( 
+  false
+  );
+  if (r.matched) {
+  r = other(r.pos, ctx);
+  }
+  else {
+  r.pos = ctx.end;
+  }
+  static_cast<void>(CPP2_FORWARD(ctx));
+  return r; 
+  }
+
+  template <typename CharT> template<typename Iter> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::entry(Iter const& cur, context<Iter>& ctx) -> cpp2::regex::match_return<Iter>{
+  ctx.set_group_start(0, cur);
+
+  auto r {func_0()(cur, ctx, cpp2::regex::true_end_func())}; 
+  if (r.matched) {ctx.set_group_end(0, r.pos);}
+  return r; 
+  }
+
+  template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::get_named_group_index(auto const& name) -> int{
+  static_cast<void>(name);
+  return -1; 
+  }
+
+  template <typename CharT> [[nodiscard]] constexpr auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::is_start_match() -> bool { return false; }
+template <typename CharT> [[nodiscard]] auto test_tests_21_atomic_patterns::regex_06_matcher<CharT>::to_string() -> std::string{return R"(^((?>(?:aa)?b)?))"; }
+
+
+#line 184 "pure2-regex_21_atomic_patterns.cpp2"
+auto main() -> int{
+    CPP2_UFCS(run)(test_tests_21_atomic_patterns());
+}
+

--- a/regression-tests/test-results/pure2-regex_21_atomic_patterns.cpp2.output
+++ b/regression-tests/test-results/pure2-regex_21_atomic_patterns.cpp2.output
@@ -1,0 +1,2 @@
+pure2-regex_21_atomic_patterns.cpp2... ok (all Cpp2, passes safety checks)
+

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -79,40 +79,40 @@ class generation_function_context;
 #line 2326 "reflect.h2"
 class generation_context;
 
-#line 2524 "reflect.h2"
+#line 2525 "reflect.h2"
 class alternative_token;
 
-#line 2539 "reflect.h2"
+#line 2540 "reflect.h2"
 class alternative_token_gen;
 
-#line 2604 "reflect.h2"
+#line 2605 "reflect.h2"
 class any_token;
 
-#line 2622 "reflect.h2"
+#line 2623 "reflect.h2"
 class char_token;
 
-#line 2737 "reflect.h2"
+#line 2738 "reflect.h2"
 class class_token;
 
-#line 2961 "reflect.h2"
+#line 2962 "reflect.h2"
 class group_ref_token;
 
-#line 3098 "reflect.h2"
+#line 3099 "reflect.h2"
 class group_token;
 
-#line 3423 "reflect.h2"
+#line 3424 "reflect.h2"
 class lookahead_lookbehind_token;
 
-#line 3515 "reflect.h2"
+#line 3519 "reflect.h2"
 class range_token;
 
-#line 3673 "reflect.h2"
+#line 3677 "reflect.h2"
 class special_range_token;
 
-#line 3759 "reflect.h2"
+#line 3763 "reflect.h2"
 template<typename Error_out> class regex_generator;
 
-#line 4007 "reflect.h2"
+#line 4011 "reflect.h2"
 }
 
 }
@@ -1058,51 +1058,51 @@ class generation_context
 #line 2380 "reflect.h2"
     protected: auto end_func_statefull(cpp2::impl::in<std::string> s) & -> void;
 
-#line 2399 "reflect.h2"
+#line 2400 "reflect.h2"
     //  Generate the function for a token.
     public: [[nodiscard]] auto generate_func(cpp2::impl::in<token_ptr> token) & -> std::string;
 
-#line 2409 "reflect.h2"
+#line 2410 "reflect.h2"
     //  Generate the reset for a list of group identifiers.
     public: [[nodiscard]] auto generate_reset(cpp2::impl::in<std::set<int>> groups) & -> std::string;
 
-#line 2432 "reflect.h2"
+#line 2433 "reflect.h2"
     //  Name generation
     //
     protected: [[nodiscard]] auto gen_func_name() & -> std::string;
 
-#line 2440 "reflect.h2"
+#line 2441 "reflect.h2"
     public: [[nodiscard]] auto next_func_name() & -> std::string;
 
-#line 2444 "reflect.h2"
+#line 2445 "reflect.h2"
     protected: [[nodiscard]] auto gen_reset_func_name() & -> std::string;
 
-#line 2450 "reflect.h2"
+#line 2451 "reflect.h2"
     public: [[nodiscard]] auto gen_temp() & -> std::string;
 
-#line 2456 "reflect.h2"
+#line 2457 "reflect.h2"
     //  Context management
     //
     public: [[nodiscard]] auto new_context() & -> generation_function_context*;
 
-#line 2466 "reflect.h2"
+#line 2467 "reflect.h2"
     public: auto finish_context() & -> void;
 
-#line 2474 "reflect.h2"
+#line 2475 "reflect.h2"
     //  Misc functions
     //
     private: [[nodiscard]] auto get_current() & -> generation_function_context*;
 
-#line 2480 "reflect.h2"
+#line 2481 "reflect.h2"
     private: [[nodiscard]] auto get_base() & -> generation_function_context*;
 
-#line 2484 "reflect.h2"
+#line 2485 "reflect.h2"
     public: [[nodiscard]] auto get_entry_func() const& -> std::string;
 
-#line 2488 "reflect.h2"
+#line 2489 "reflect.h2"
     public: [[nodiscard]] auto create_named_group_lookup(cpp2::impl::in<std::map<std::string,int>> named_groups) const& -> std::string;
 
-#line 2512 "reflect.h2"
+#line 2513 "reflect.h2"
     //  Run the generation for the token.
     public: [[nodiscard]] auto run(cpp2::impl::in<token_ptr> token) & -> std::string;
     public: generation_context() = default;
@@ -1110,7 +1110,7 @@ class generation_context
     public: auto operator=(generation_context const&) -> void = delete;
 
 
-#line 2518 "reflect.h2"
+#line 2519 "reflect.h2"
 };
 
 //  Regex syntax: |  Example: ab|ba
@@ -1130,27 +1130,27 @@ class alternative_token
     public: auto operator=(alternative_token const&) -> void = delete;
 
 
-#line 2537 "reflect.h2"
+#line 2538 "reflect.h2"
 };
 
 class alternative_token_gen
 : public regex_token {
 
-#line 2543 "reflect.h2"
+#line 2544 "reflect.h2"
     private: token_vec alternatives; 
 
     public: explicit alternative_token_gen(cpp2::impl::in<token_vec> a);
 
-#line 2550 "reflect.h2"
+#line 2551 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2567 "reflect.h2"
+#line 2568 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
 
-#line 2574 "reflect.h2"
+#line 2575 "reflect.h2"
     public: [[nodiscard]] static auto gen_string(cpp2::impl::in<token_vec> a) -> std::string;
 
-#line 2587 "reflect.h2"
+#line 2588 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
     public: virtual ~alternative_token_gen() noexcept;
 
@@ -1158,19 +1158,19 @@ class alternative_token_gen
     public: auto operator=(alternative_token_gen const&) -> void = delete;
 
 
-#line 2599 "reflect.h2"
+#line 2600 "reflect.h2"
 };
 
-#line 2602 "reflect.h2"
+#line 2603 "reflect.h2"
 //  Regex syntax: .
 //
 class any_token
 : public regex_token_check {
 
-#line 2608 "reflect.h2"
+#line 2609 "reflect.h2"
     public: explicit any_token(cpp2::impl::in<bool> single_line);
 
-#line 2612 "reflect.h2"
+#line 2613 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
     public: virtual ~any_token() noexcept;
 
@@ -1178,43 +1178,43 @@ class any_token
     public: auto operator=(any_token const&) -> void = delete;
 
 
-#line 2617 "reflect.h2"
+#line 2618 "reflect.h2"
 };
 
-#line 2620 "reflect.h2"
+#line 2621 "reflect.h2"
 //  Regex syntax: a
 //
 class char_token
 : public regex_token {
 
-#line 2626 "reflect.h2"
+#line 2627 "reflect.h2"
     private: std::string token; 
     private: bool ignore_case; 
 
     public: explicit char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_);
 
-#line 2635 "reflect.h2"
+#line 2636 "reflect.h2"
     public: explicit char_token(cpp2::impl::in<std::string> t, cpp2::impl::in<bool> ignore_case_);
 
-#line 2641 "reflect.h2"
+#line 2642 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 2645 "reflect.h2"
+#line 2646 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2668 "reflect.h2"
+#line 2669 "reflect.h2"
     public: auto gen_case_insensitive(cpp2::impl::in<std::string> lower, cpp2::impl::in<std::string> upper, generation_context& ctx) const& -> void;
 
-#line 2689 "reflect.h2"
+#line 2690 "reflect.h2"
     public: auto gen_case_sensitive(generation_context& ctx) const& -> void;
 
-#line 2707 "reflect.h2"
+#line 2708 "reflect.h2"
     public: [[nodiscard]] auto add_escapes(std::string str) const& -> std::string;
 
-#line 2722 "reflect.h2"
+#line 2723 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 2728 "reflect.h2"
+#line 2729 "reflect.h2"
     public: auto append(char_token const& that) & -> void;
     public: virtual ~char_token() noexcept;
 
@@ -1222,33 +1222,33 @@ class char_token
     public: auto operator=(char_token const&) -> void = delete;
 
 
-#line 2732 "reflect.h2"
+#line 2733 "reflect.h2"
 };
 
-#line 2735 "reflect.h2"
+#line 2736 "reflect.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 class class_token
 : public regex_token {
 
-#line 2741 "reflect.h2"
+#line 2742 "reflect.h2"
     private: bool negate; 
     private: bool case_insensitive; 
     private: std::string class_str; 
 
     public: explicit class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str);
 
-#line 2753 "reflect.h2"
+#line 2754 "reflect.h2"
     //  TODO: Rework class generation: Generate check functions for classes.
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 2879 "reflect.h2"
+#line 2880 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 2888 "reflect.h2"
+#line 2889 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2893 "reflect.h2"
+#line 2894 "reflect.h2"
     private: [[nodiscard]] static auto create_matcher(cpp2::impl::in<std::string> name, cpp2::impl::in<std::string> template_arguments) -> std::string;
     public: virtual ~class_token() noexcept;
 
@@ -1256,20 +1256,20 @@ class class_token
     public: auto operator=(class_token const&) -> void = delete;
 
 
-#line 2900 "reflect.h2"
+#line 2901 "reflect.h2"
 };
 
-#line 2903 "reflect.h2"
+#line 2904 "reflect.h2"
 //  Regex syntax: \a or \n or \[
 //
 [[nodiscard]] auto escape_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 2944 "reflect.h2"
+#line 2945 "reflect.h2"
 //  Regex syntax: \K Example: ab\Kcd
 //
 [[nodiscard]] auto global_group_reset_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 2955 "reflect.h2"
+#line 2956 "reflect.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -1279,20 +1279,20 @@ class class_token
 class group_ref_token
 : public regex_token {
 
-#line 2965 "reflect.h2"
+#line 2966 "reflect.h2"
     private: int id; 
     private: bool case_insensitive; 
     private: bool reverse_eval; 
 
     public: explicit group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<bool> reverse_, cpp2::impl::in<std::string> str);
 
-#line 2977 "reflect.h2"
+#line 2978 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3078 "reflect.h2"
+#line 3079 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3082 "reflect.h2"
+#line 3083 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
     public: virtual ~group_ref_token() noexcept;
 
@@ -1300,10 +1300,10 @@ class group_ref_token
     public: auto operator=(group_ref_token const&) -> void = delete;
 
 
-#line 3085 "reflect.h2"
+#line 3086 "reflect.h2"
 };
 
-#line 3088 "reflect.h2"
+#line 3089 "reflect.h2"
 //  Regex syntax: (<tokens>)      Example: (abc)
 //                (?<modifiers)            (?i)
 //                (?<modifiers>:<tokens>)  (?i:abc)
@@ -1317,26 +1317,26 @@ class group_ref_token
 class group_token
 : public regex_token {
 
-#line 3102 "reflect.h2"
+#line 3103 "reflect.h2"
     private: int number {-1}; 
     private: bool reverse_eval {false}; 
     private: token_ptr inner {nullptr}; 
 
     public: [[nodiscard]] static auto parse_lookahead_lookbehind(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> lookahead, cpp2::impl::in<bool> positive) -> token_ptr;
 
-#line 3124 "reflect.h2"
+#line 3125 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3275 "reflect.h2"
+#line 3276 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3283 "reflect.h2"
+#line 3284 "reflect.h2"
     public: [[nodiscard]] static auto gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string;
 
-#line 3301 "reflect.h2"
+#line 3302 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3332 "reflect.h2"
+#line 3333 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~group_token() noexcept;
 
@@ -1345,25 +1345,25 @@ class group_token
     public: auto operator=(group_token const&) -> void = delete;
 
 
-#line 3339 "reflect.h2"
+#line 3340 "reflect.h2"
 };
 
-#line 3342 "reflect.h2"
+#line 3343 "reflect.h2"
 //  Regex syntax: \x<number> or \x{<number>}  Example: \x{62}
 //
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3383 "reflect.h2"
+#line 3384 "reflect.h2"
 //  Regex syntax: $  Example: aa$
 //
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3403 "reflect.h2"
+#line 3404 "reflect.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3419 "reflect.h2"
+#line 3420 "reflect.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
@@ -1371,20 +1371,20 @@ class group_token
 class lookahead_lookbehind_token
 : public regex_token {
 
-#line 3427 "reflect.h2"
+#line 3428 "reflect.h2"
     protected: bool lookahead; 
     protected: bool positive; 
     public:   token_ptr inner {nullptr}; 
 
     public: explicit lookahead_lookbehind_token(cpp2::impl::in<bool> lookahead_, cpp2::impl::in<bool> positive_);
 
-#line 3436 "reflect.h2"
+#line 3437 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3447 "reflect.h2"
+#line 3448 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3451 "reflect.h2"
+#line 3455 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~lookahead_lookbehind_token() noexcept;
 
@@ -1392,26 +1392,26 @@ class lookahead_lookbehind_token
     public: auto operator=(lookahead_lookbehind_token const&) -> void = delete;
 
 
-#line 3454 "reflect.h2"
+#line 3458 "reflect.h2"
 };
 
-#line 3457 "reflect.h2"
+#line 3461 "reflect.h2"
 // Named character classes
 //
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3485 "reflect.h2"
+#line 3489 "reflect.h2"
 //  Regex syntax: \o{<number>}  Example: \o{142}
 //
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3513 "reflect.h2"
+#line 3517 "reflect.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 class range_token
 : public regex_token {
 
-#line 3519 "reflect.h2"
+#line 3523 "reflect.h2"
               protected: int min_count {-1}; 
               protected: int max_count {-1}; 
               protected: int kind {range_flags::greedy}; 
@@ -1421,22 +1421,22 @@ class range_token
 
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3599 "reflect.h2"
+#line 3603 "reflect.h2"
     public: auto parse_modifier(parse_context& ctx) & -> void;
 
-#line 3611 "reflect.h2"
+#line 3615 "reflect.h2"
     public: [[nodiscard]] auto gen_mod_string() const& -> std::string;
 
-#line 3624 "reflect.h2"
+#line 3628 "reflect.h2"
     public: [[nodiscard]] auto gen_range_string() const& -> std::string;
 
-#line 3643 "reflect.h2"
+#line 3647 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3653 "reflect.h2"
+#line 3657 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3664 "reflect.h2"
+#line 3668 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~range_token() noexcept;
 
@@ -1444,16 +1444,16 @@ class range_token
     public: auto operator=(range_token const&) -> void = delete;
 
 
-#line 3668 "reflect.h2"
+#line 3672 "reflect.h2"
 };
 
-#line 3671 "reflect.h2"
+#line 3675 "reflect.h2"
 //  Regex syntax: *, +, or ?  Example: aa*
 //
 class special_range_token
 : public range_token {
 
-#line 3677 "reflect.h2"
+#line 3681 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
     public: virtual ~special_range_token() noexcept;
 
@@ -1462,7 +1462,7 @@ class special_range_token
     public: auto operator=(special_range_token const&) -> void = delete;
 
 
-#line 3707 "reflect.h2"
+#line 3711 "reflect.h2"
 };
 
 //  Regex syntax: \G  Example: \Gaa
@@ -1471,14 +1471,14 @@ class special_range_token
 //
 [[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr;
 
-#line 3729 "reflect.h2"
+#line 3733 "reflect.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3751 "reflect.h2"
+#line 3755 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  Parser for regular expression.
@@ -1499,24 +1499,24 @@ template<typename Error_out> class regex_generator
 
     public: explicit regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e);
 
-#line 3774 "reflect.h2"
+#line 3778 "reflect.h2"
     public: [[nodiscard]] auto parse() & -> std::string;
 
-#line 3809 "reflect.h2"
+#line 3813 "reflect.h2"
     private: auto extract_modifiers() & -> void;
     public: regex_generator(regex_generator const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_generator const&) -> void = delete;
 
 
-#line 3823 "reflect.h2"
+#line 3827 "reflect.h2"
 };
 
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string;
 
-#line 3835 "reflect.h2"
+#line 3839 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void;
 
-#line 3890 "reflect.h2"
+#line 3894 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  apply_metafunctions
@@ -1527,7 +1527,7 @@ auto regex_gen(meta::type_declaration& t) -> void;
     auto const& error
     ) -> bool;
 
-#line 4007 "reflect.h2"
+#line 4011 "reflect.h2"
 }
 
 }
@@ -4167,7 +4167,7 @@ generation_function_context::generation_function_context(){}
         auto cur {new_context()}; 
 
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + cpp2::to_string(name) + ": @struct<noforward> type = {\n";
-        (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "  operator(): <Iter> (this, cur: Iter, inout ctx, other) -> cpp2::regex::match_return<Iter> = {\n";
+        (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "  operator(): <Iter> (this, cur: Iter, forward ctx, other) -> cpp2::regex::match_return<Iter> = {\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    r := ctx..pass(cur);\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    do {\n";
         (*cpp2::impl::assert_not_null(cpp2::move(cur))).add_tabs(3);
@@ -4194,6 +4194,7 @@ generation_function_context::generation_function_context(){}
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    else {\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "      r.pos = ctx.end;\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    }\n";
+        (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    _ = ctx;\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    return r;\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "  }\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "}\n";
@@ -4201,7 +4202,7 @@ generation_function_context::generation_function_context(){}
         finish_context();
     }
 
-#line 2400 "reflect.h2"
+#line 2401 "reflect.h2"
     [[nodiscard]] auto generation_context::generate_func(cpp2::impl::in<token_ptr> token) & -> std::string
     {
         auto name {start_func()}; 
@@ -4211,7 +4212,7 @@ generation_function_context::generation_function_context(){}
         return name; 
     }
 
-#line 2410 "reflect.h2"
+#line 2411 "reflect.h2"
     [[nodiscard]] auto generation_context::generate_reset(cpp2::impl::in<std::set<int>> groups) & -> std::string
     {
         if (groups.empty()) {
@@ -4234,33 +4235,33 @@ generation_function_context::generation_function_context(){}
         return cpp2::move(name) + "()"; 
     }
 
-#line 2434 "reflect.h2"
+#line 2435 "reflect.h2"
     [[nodiscard]] auto generation_context::gen_func_name() & -> std::string{
         auto cur_id {matcher_func}; 
         matcher_func += 1;
         return "func_" + cpp2::to_string(cpp2::move(cur_id)) + ""; 
     }
 
-#line 2440 "reflect.h2"
+#line 2441 "reflect.h2"
     [[nodiscard]] auto generation_context::next_func_name() & -> std::string{
         return gen_func_name() + "()"; 
     }
 
-#line 2444 "reflect.h2"
+#line 2445 "reflect.h2"
     [[nodiscard]] auto generation_context::gen_reset_func_name() & -> std::string{
         auto cur_id {reset_func}; 
         reset_func += 1;
         return "reset_" + cpp2::to_string(cpp2::move(cur_id)) + ""; 
     }
 
-#line 2450 "reflect.h2"
+#line 2451 "reflect.h2"
     [[nodiscard]] auto generation_context::gen_temp() & -> std::string{
         auto cur_id {temp_name}; 
         temp_name += 1;
         return "tmp_" + cpp2::to_string(cpp2::move(cur_id)) + ""; 
     }
 
-#line 2458 "reflect.h2"
+#line 2459 "reflect.h2"
     [[nodiscard]] auto generation_context::new_context() & -> generation_function_context*{
         gen_stack.push_back(generation_function_context());
         auto cur {get_current()}; 
@@ -4269,7 +4270,7 @@ generation_function_context::generation_function_context(){}
         return cur; 
     }
 
-#line 2466 "reflect.h2"
+#line 2467 "reflect.h2"
     auto generation_context::finish_context() & -> void{
         auto cur {get_current()}; 
         auto base {get_base()}; 
@@ -4278,22 +4279,22 @@ generation_function_context::generation_function_context(){}
         gen_stack.pop_back();
     }
 
-#line 2476 "reflect.h2"
+#line 2477 "reflect.h2"
     [[nodiscard]] auto generation_context::get_current() & -> generation_function_context*{
         return &gen_stack.back(); 
     }
 
-#line 2480 "reflect.h2"
+#line 2481 "reflect.h2"
     [[nodiscard]] auto generation_context::get_base() & -> generation_function_context*{
         return &CPP2_ASSERT_IN_BOUNDS_LITERAL(gen_stack, 0); 
     }
 
-#line 2484 "reflect.h2"
+#line 2485 "reflect.h2"
     [[nodiscard]] auto generation_context::get_entry_func() const& -> std::string{
         return entry_func; 
     }
 
-#line 2488 "reflect.h2"
+#line 2489 "reflect.h2"
     [[nodiscard]] auto generation_context::create_named_group_lookup(cpp2::impl::in<std::map<std::string,int>> named_groups) const& -> std::string
     {
         std::string res {"get_named_group_index: (name) -> int = {\n"}; 
@@ -4317,18 +4318,18 @@ generation_function_context::generation_function_context(){}
         return res; 
     }
 
-#line 2513 "reflect.h2"
+#line 2514 "reflect.h2"
     [[nodiscard]] auto generation_context::run(cpp2::impl::in<token_ptr> token) & -> std::string{
         entry_func = generate_func(token);
 
         return (*cpp2::impl::assert_not_null(get_base())).code; 
     }
 
-#line 2528 "reflect.h2"
+#line 2529 "reflect.h2"
     alternative_token::alternative_token()
                             : regex_token_empty{ "" }{}
 
-#line 2530 "reflect.h2"
+#line 2531 "reflect.h2"
     [[nodiscard]] auto alternative_token::parse(parse_context& ctx) -> token_ptr{
         if (ctx.current() != '|') {return nullptr; }
 
@@ -4339,15 +4340,15 @@ generation_function_context::generation_function_context(){}
 
     alternative_token::~alternative_token() noexcept{}
 
-#line 2545 "reflect.h2"
+#line 2546 "reflect.h2"
     alternative_token_gen::alternative_token_gen(cpp2::impl::in<token_vec> a)
         : regex_token{ gen_string(a) }
         , alternatives{ a }{
 
-#line 2548 "reflect.h2"
+#line 2549 "reflect.h2"
     }
 
-#line 2550 "reflect.h2"
+#line 2551 "reflect.h2"
     auto alternative_token_gen::generate_code(generation_context& ctx) const -> void
     {
         std::string functions {""}; 
@@ -4365,7 +4366,7 @@ generation_function_context::generation_function_context(){}
         ctx.add_statefull(next_name, "cpp2::regex::alternative_token_matcher<char>::match(" + cpp2::to_string(ctx.match_parameters()) + ", other, " + cpp2::to_string(next_name) + " " + cpp2::to_string(cpp2::move(functions)) + ")");
     }
 
-#line 2567 "reflect.h2"
+#line 2568 "reflect.h2"
     auto alternative_token_gen::add_groups(std::set<int>& groups) const -> void
     {
         for ( auto const& cur : alternatives ) {
@@ -4373,7 +4374,7 @@ generation_function_context::generation_function_context(){}
         }
     }
 
-#line 2574 "reflect.h2"
+#line 2575 "reflect.h2"
     [[nodiscard]] auto alternative_token_gen::gen_string(cpp2::impl::in<token_vec> a) -> std::string
     {
         std::string r {""}; 
@@ -4387,7 +4388,7 @@ generation_function_context::generation_function_context(){}
         return r; 
     }
 
-#line 2587 "reflect.h2"
+#line 2588 "reflect.h2"
     [[nodiscard]] auto alternative_token_gen::reverse() const -> token_ptr{
         int s {cpp2::unchecked_narrow<int>(alternatives.size())}; 
 
@@ -4403,14 +4404,14 @@ generation_function_context::generation_function_context(){}
 
     alternative_token_gen::~alternative_token_gen() noexcept{}
 
-#line 2608 "reflect.h2"
+#line 2609 "reflect.h2"
     any_token::any_token(cpp2::impl::in<bool> single_line)
         : regex_token_check{ ".", "any_token_matcher<char, " + cpp2::to_string(single_line) + ">" }{
 
-#line 2610 "reflect.h2"
+#line 2611 "reflect.h2"
     }
 
-#line 2612 "reflect.h2"
+#line 2613 "reflect.h2"
     [[nodiscard]] auto any_token::parse(parse_context& ctx) -> token_ptr{
         if ('.' != ctx.current()) {return nullptr; }
 
@@ -4419,30 +4420,30 @@ generation_function_context::generation_function_context(){}
 
     any_token::~any_token() noexcept{}
 
-#line 2629 "reflect.h2"
+#line 2630 "reflect.h2"
     char_token::char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_)
         : regex_token{ std::string(1, t) }
         , token{ t }
         , ignore_case{ ignore_case_ }{
 
-#line 2633 "reflect.h2"
+#line 2634 "reflect.h2"
     }
 
-#line 2635 "reflect.h2"
+#line 2636 "reflect.h2"
     char_token::char_token(cpp2::impl::in<std::string> t, cpp2::impl::in<bool> ignore_case_)
         : regex_token{ t }
         , token{ t }
         , ignore_case{ ignore_case_ }{
 
-#line 2639 "reflect.h2"
+#line 2640 "reflect.h2"
     }
 
-#line 2641 "reflect.h2"
+#line 2642 "reflect.h2"
     [[nodiscard]] auto char_token::parse(parse_context& ctx) -> token_ptr{
         return CPP2_UFCS_TEMPLATE(cpp2_new<char_token>)(cpp2::shared, ctx.current(), ctx.get_modifiers().has(expression_flags::case_insensitive)); 
     }
 
-#line 2645 "reflect.h2"
+#line 2646 "reflect.h2"
     auto char_token::generate_code(generation_context& ctx) const -> void
     {
         if (ignore_case) {
@@ -4451,14 +4452,14 @@ generation_function_context::generation_function_context(){}
 {
 size_t i{0};
 
-#line 2651 "reflect.h2"
+#line 2652 "reflect.h2"
             for( ; cpp2::impl::cmp_less(i,token.size()); i += 1 ) {
                 CPP2_ASSERT_IN_BOUNDS(lower, i) = string_util::safe_tolower(CPP2_ASSERT_IN_BOUNDS(token, i));
                 CPP2_ASSERT_IN_BOUNDS(upper, i) = string_util::safe_toupper(CPP2_ASSERT_IN_BOUNDS(token, i));
             }
 }
 
-#line 2656 "reflect.h2"
+#line 2657 "reflect.h2"
             if (upper != lower) {
                 gen_case_insensitive(cpp2::move(lower), cpp2::move(upper), ctx);
             }
@@ -4471,7 +4472,7 @@ size_t i{0};
         }
     }
 
-#line 2668 "reflect.h2"
+#line 2669 "reflect.h2"
     auto char_token::gen_case_insensitive(cpp2::impl::in<std::string> lower, cpp2::impl::in<std::string> upper, generation_context& ctx) const& -> void
     {
         std::string name {"str_" + cpp2::to_string(ctx.gen_temp()) + ""}; 
@@ -4493,7 +4494,7 @@ size_t i{0};
         ctx.add("else { break; }");
     }
 
-#line 2689 "reflect.h2"
+#line 2690 "reflect.h2"
     auto char_token::gen_case_sensitive(generation_context& ctx) const& -> void
     {
         std::string name {"str_" + cpp2::to_string(ctx.gen_temp()) + ""}; 
@@ -4512,7 +4513,7 @@ size_t i{0};
         ctx.add("else { break; }");
     }
 
-#line 2707 "reflect.h2"
+#line 2708 "reflect.h2"
     [[nodiscard]] auto char_token::add_escapes(std::string str) const& -> std::string
     {
         str = string_util::replace_all(str, "\\", "\\\\");
@@ -4528,14 +4529,14 @@ size_t i{0};
         return cpp2::move(str); 
     }
 
-#line 2722 "reflect.h2"
+#line 2723 "reflect.h2"
     [[nodiscard]] auto char_token::reverse() const -> token_ptr{
         std::string reverse_str {token}; 
         std::reverse(reverse_str.begin(), reverse_str.end());
         return CPP2_UFCS_TEMPLATE(cpp2_new<char_token>)(cpp2::shared, cpp2::move(reverse_str), ignore_case); 
     }
 
-#line 2728 "reflect.h2"
+#line 2729 "reflect.h2"
     auto char_token::append(char_token const& that) & -> void{
         (*this).token += that.token;
         (*this).string_rep += that.string_rep;
@@ -4543,19 +4544,19 @@ size_t i{0};
 
     char_token::~char_token() noexcept{}
 
-#line 2745 "reflect.h2"
+#line 2746 "reflect.h2"
     class_token::class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str)
         : regex_token{ str }
         , negate{ negate_ }
         , case_insensitive{ case_insensitive_ }
         , class_str{ class_str_ }
-#line 2746 "reflect.h2"
+#line 2747 "reflect.h2"
     {
 
-#line 2751 "reflect.h2"
+#line 2752 "reflect.h2"
     }
 
-#line 2754 "reflect.h2"
+#line 2755 "reflect.h2"
     [[nodiscard]] auto class_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '[') {return nullptr; }
@@ -4681,7 +4682,7 @@ size_t i{0};
             ); 
     }
 
-#line 2879 "reflect.h2"
+#line 2880 "reflect.h2"
     [[nodiscard]] auto class_token::reverse() const -> token_ptr{
         return CPP2_UFCS_TEMPLATE(cpp2_new<class_token>)(cpp2::shared, 
             negate, 
@@ -4691,13 +4692,13 @@ size_t i{0};
             ); 
     }
 
-#line 2888 "reflect.h2"
+#line 2889 "reflect.h2"
     auto class_token::generate_code(generation_context& ctx) const -> void
     {
         ctx.add_check("class_token_matcher<char, " + cpp2::to_string(negate) + ", " + cpp2::to_string(case_insensitive) + ", " + cpp2::to_string(class_str) + ">::match(" + cpp2::to_string(ctx.match_parameters()) + ")");
     }
 
-#line 2893 "reflect.h2"
+#line 2894 "reflect.h2"
     [[nodiscard]] auto class_token::create_matcher(cpp2::impl::in<std::string> name, cpp2::impl::in<std::string> template_arguments) -> std::string
     {
         auto sep {", "}; 
@@ -4708,12 +4709,12 @@ size_t i{0};
 
     class_token::~class_token() noexcept{}
 
-#line 2905 "reflect.h2"
+#line 2906 "reflect.h2"
 [[nodiscard]] auto escape_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
 
-#line 2910 "reflect.h2"
+#line 2911 "reflect.h2"
     if (std::string::npos == std::string("afenrt^.[]()*{}?+|\\").find(ctx.peek())) {
         return nullptr; 
     }
@@ -4747,7 +4748,7 @@ size_t i{0};
 
 }
 
-#line 2946 "reflect.h2"
+#line 2947 "reflect.h2"
 [[nodiscard]] auto global_group_reset_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'K'))) {return nullptr; }
@@ -4756,19 +4757,19 @@ size_t i{0};
     return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_code>)(cpp2::shared, "\\K", "ctx..set_group_start(0, r.pos);"); 
 }
 
-#line 2969 "reflect.h2"
+#line 2970 "reflect.h2"
     group_ref_token::group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<bool> reverse_, cpp2::impl::in<std::string> str)
         : regex_token{ str }
         , id{ id_ }
         , case_insensitive{ case_insensitive_ }
         , reverse_eval{ reverse_ }
-#line 2970 "reflect.h2"
+#line 2971 "reflect.h2"
     {
 
-#line 2975 "reflect.h2"
+#line 2976 "reflect.h2"
     }
 
-#line 2977 "reflect.h2"
+#line 2978 "reflect.h2"
     [[nodiscard]] auto group_ref_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '\\') {return nullptr; }
@@ -4870,19 +4871,19 @@ size_t i{0};
         return CPP2_UFCS_TEMPLATE(cpp2_new<group_ref_token>)(cpp2::shared, cpp2::move(group_id), ctx.get_modifiers().has(expression_flags::case_insensitive), false, cpp2::move(str)); 
     }
 
-#line 3078 "reflect.h2"
+#line 3079 "reflect.h2"
     [[nodiscard]] auto group_ref_token::reverse() const -> token_ptr{
         return CPP2_UFCS_TEMPLATE(cpp2_new<group_ref_token>)(cpp2::shared, id, case_insensitive, !(reverse_eval), to_string()); 
     }
 
-#line 3082 "reflect.h2"
+#line 3083 "reflect.h2"
     auto group_ref_token::generate_code(generation_context& ctx) const -> void{
         ctx.add_check("group_ref_token_matcher<char, " + cpp2::to_string(id) + ", " + cpp2::to_string(case_insensitive) + ", " + cpp2::to_string(reverse_eval) + ">(" + cpp2::to_string(ctx.match_parameters()) + ")");
     }
 
     group_ref_token::~group_ref_token() noexcept{}
 
-#line 3106 "reflect.h2"
+#line 3107 "reflect.h2"
     [[nodiscard]] auto group_token::parse_lookahead_lookbehind(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> lookahead, cpp2::impl::in<bool> positive) -> token_ptr
     {
         static_cast<void>(ctx.next());// Skip last token defining the syntax
@@ -4901,7 +4902,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3124 "reflect.h2"
+#line 3125 "reflect.h2"
     [[nodiscard]] auto group_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '(') {return nullptr; }
@@ -5053,7 +5054,7 @@ size_t i{0};
         }
     }
 
-#line 3275 "reflect.h2"
+#line 3276 "reflect.h2"
     [[nodiscard]] auto group_token::reverse() const -> token_ptr{
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<group_token>)(cpp2::shared)}; 
         (*cpp2::impl::assert_not_null(r)).number = number;
@@ -5062,7 +5063,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3283 "reflect.h2"
+#line 3284 "reflect.h2"
     [[nodiscard]] auto group_token::gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string
     {
         std::string start {"("}; 
@@ -5081,7 +5082,7 @@ size_t i{0};
         return cpp2::move(start) + (*cpp2::impl::assert_not_null(inner_)).to_string() + ")"; 
     }
 
-#line 3301 "reflect.h2"
+#line 3302 "reflect.h2"
     auto group_token::generate_code(generation_context& ctx) const -> void
     {
         if (-1 != number) {
@@ -5113,7 +5114,7 @@ size_t i{0};
         }
     }
 
-#line 3332 "reflect.h2"
+#line 3333 "reflect.h2"
     auto group_token::add_groups(std::set<int>& groups) const -> void
     {
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
@@ -5124,7 +5125,7 @@ size_t i{0};
 
     group_token::~group_token() noexcept{}
 
-#line 3344 "reflect.h2"
+#line 3345 "reflect.h2"
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'x'))) {return nullptr; }
@@ -5163,7 +5164,7 @@ size_t i{0};
     return r; 
 }
 
-#line 3385 "reflect.h2"
+#line 3386 "reflect.h2"
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() == '$' || (ctx.current() == '\\' && ctx.peek() == '$')) {
@@ -5181,7 +5182,7 @@ size_t i{0};
     }}
 }
 
-#line 3405 "reflect.h2"
+#line 3406 "reflect.h2"
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '^' && !((ctx.current() == '\\' && ctx.peek() == 'A'))) {return nullptr; }
@@ -5195,16 +5196,16 @@ size_t i{0};
     }
 }
 
-#line 3431 "reflect.h2"
+#line 3432 "reflect.h2"
     lookahead_lookbehind_token::lookahead_lookbehind_token(cpp2::impl::in<bool> lookahead_, cpp2::impl::in<bool> positive_)
         : regex_token{ "" }
         , lookahead{ lookahead_ }
         , positive{ positive_ }{
 
-#line 3434 "reflect.h2"
+#line 3435 "reflect.h2"
     }
 
-#line 3436 "reflect.h2"
+#line 3437 "reflect.h2"
     auto lookahead_lookbehind_token::generate_code(generation_context& ctx) const -> void{
         auto inner_name {ctx.generate_func(inner)}; 
 
@@ -5216,19 +5217,22 @@ size_t i{0};
         }
     }
 
-#line 3447 "reflect.h2"
+#line 3448 "reflect.h2"
     [[nodiscard]] auto lookahead_lookbehind_token::reverse() const -> token_ptr{
-        return nullptr; // TODO: 1) Implement error, 2) implement functionality.
+        auto r {CPP2_UFCS_TEMPLATE(cpp2_new<lookahead_lookbehind_token>)(cpp2::shared, lookahead, positive)}; 
+        (*cpp2::impl::assert_not_null(r)).inner = inner;// We do not reverse here. Nested lookahead and lookbehind stay as they are.
+
+        return r; 
     }
 
-#line 3451 "reflect.h2"
+#line 3455 "reflect.h2"
     auto lookahead_lookbehind_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
     }
 
     lookahead_lookbehind_token::~lookahead_lookbehind_token() noexcept{}
 
-#line 3459 "reflect.h2"
+#line 3463 "reflect.h2"
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5254,7 +5258,7 @@ size_t i{0};
     return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_check>)(cpp2::shared, "\\" + cpp2::to_string(ctx.current()) + "", "" + cpp2::to_string(cpp2::move(name)) + "<char, " + cpp2::to_string(ctx.get_modifiers().has(expression_flags::case_insensitive)) + ">::match"); 
 }
 
-#line 3487 "reflect.h2"
+#line 3491 "reflect.h2"
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'o'))) {return nullptr; }
@@ -5280,11 +5284,11 @@ size_t i{0};
     return r; 
 }
 
-#line 3524 "reflect.h2"
+#line 3528 "reflect.h2"
     range_token::range_token()
                              : regex_token{ "" }{}
 
-#line 3526 "reflect.h2"
+#line 3530 "reflect.h2"
     [[nodiscard]] auto range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<range_token>)(cpp2::shared)}; 
@@ -5358,7 +5362,7 @@ size_t i{0};
         return nullptr; 
     }
 
-#line 3599 "reflect.h2"
+#line 3603 "reflect.h2"
     auto range_token::parse_modifier(parse_context& ctx) & -> void
     {
         if (ctx.peek() == '?') {
@@ -5371,7 +5375,7 @@ size_t i{0};
         }}
     }
 
-#line 3611 "reflect.h2"
+#line 3615 "reflect.h2"
     [[nodiscard]] auto range_token::gen_mod_string() const& -> std::string
     {
         if (kind == range_flags::not_greedy) {
@@ -5385,7 +5389,7 @@ size_t i{0};
         }}
     }
 
-#line 3624 "reflect.h2"
+#line 3628 "reflect.h2"
     [[nodiscard]] auto range_token::gen_range_string() const& -> std::string
     {
         std::string r {""}; 
@@ -5405,7 +5409,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3643 "reflect.h2"
+#line 3647 "reflect.h2"
     [[nodiscard]] auto range_token::reverse() const -> token_ptr{
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<range_token>)(cpp2::shared)}; 
         (*cpp2::impl::assert_not_null(r)).min_count = min_count;
@@ -5416,7 +5420,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3653 "reflect.h2"
+#line 3657 "reflect.h2"
     auto range_token::generate_code(generation_context& ctx) const -> void
     {
         auto inner_name {ctx.generate_func(inner_token)}; 
@@ -5428,14 +5432,14 @@ size_t i{0};
         ctx.add_statefull(next_name, "cpp2::regex::range_token_matcher<char, " + cpp2::to_string(min_count) + ", " + cpp2::to_string(max_count) + ", " + cpp2::to_string(kind) + ">::match(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ", " + cpp2::to_string(cpp2::move(reset_name)) + ", other, " + cpp2::to_string(next_name) + ")");
     }
 
-#line 3664 "reflect.h2"
+#line 3668 "reflect.h2"
     auto range_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner_token)).add_groups(groups);
     }
 
     range_token::~range_token() noexcept{}
 
-#line 3677 "reflect.h2"
+#line 3681 "reflect.h2"
     [[nodiscard]] auto special_range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<special_range_token>)(cpp2::shared)}; 
@@ -5459,7 +5463,7 @@ size_t i{0};
 
         if (!(ctx.has_token())) {return ctx.error("'" + cpp2::to_string(ctx.current()) + "' without previous element."); }
 
-#line 3701 "reflect.h2"
+#line 3705 "reflect.h2"
         (*cpp2::impl::assert_not_null(r)).parse_modifier(ctx);
 
         (*cpp2::impl::assert_not_null(r)).inner_token = ctx.pop_token();
@@ -5469,7 +5473,7 @@ size_t i{0};
 
     special_range_token::~special_range_token() noexcept{}
 
-#line 3713 "reflect.h2"
+#line 3717 "reflect.h2"
 [[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5485,7 +5489,7 @@ size_t i{0};
     }
 }
 
-#line 3733 "reflect.h2"
+#line 3737 "reflect.h2"
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5503,15 +5507,15 @@ size_t i{0};
     }}
 }
 
-#line 3769 "reflect.h2"
+#line 3773 "reflect.h2"
     template <typename Error_out> regex_generator<Error_out>::regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e)
         : regex{ r }
         , error_out{ e }{
 
-#line 3772 "reflect.h2"
+#line 3776 "reflect.h2"
     }
 
-#line 3774 "reflect.h2"
+#line 3778 "reflect.h2"
     template <typename Error_out> [[nodiscard]] auto regex_generator<Error_out>::parse() & -> std::string
     {
         // Extract modifiers and adapt regex.
@@ -5547,7 +5551,7 @@ size_t i{0};
         return source; 
     }
 
-#line 3809 "reflect.h2"
+#line 3813 "reflect.h2"
     template <typename Error_out> auto regex_generator<Error_out>::extract_modifiers() & -> void
     {
         if (regex.find_first_of("'/") == 0) {
@@ -5563,7 +5567,7 @@ size_t i{0};
         }
     }
 
-#line 3825 "reflect.h2"
+#line 3829 "reflect.h2"
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string
 {
     regex_generator<Err> parser {regex, err}; 
@@ -5572,7 +5576,7 @@ template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::str
     return r; 
 }
 
-#line 3835 "reflect.h2"
+#line 3839 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void
 {
     auto has_default {false}; 
@@ -5627,7 +5631,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     CPP2_UFCS(add_runtime_support_include)(t, "cpp2regex.h");
 }
 
-#line 3894 "reflect.h2"
+#line 3898 "reflect.h2"
 [[nodiscard]] auto apply_metafunctions(
     declaration_node& n, 
     type_declaration& rtype, 
@@ -5740,7 +5744,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     return true; 
 }
 
-#line 4007 "reflect.h2"
+#line 4011 "reflect.h2"
 }
 
 }

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -88,31 +88,34 @@ class alternative_token_gen;
 #line 2605 "reflect.h2"
 class any_token;
 
-#line 2623 "reflect.h2"
+#line 2622 "reflect.h2"
+class atomic_group_token;
+
+#line 2652 "reflect.h2"
 class char_token;
 
-#line 2738 "reflect.h2"
+#line 2767 "reflect.h2"
 class class_token;
 
-#line 2962 "reflect.h2"
+#line 2991 "reflect.h2"
 class group_ref_token;
 
-#line 3099 "reflect.h2"
+#line 3128 "reflect.h2"
 class group_token;
 
-#line 3424 "reflect.h2"
+#line 3475 "reflect.h2"
 class lookahead_lookbehind_token;
 
-#line 3519 "reflect.h2"
+#line 3570 "reflect.h2"
 class range_token;
 
-#line 3677 "reflect.h2"
+#line 3727 "reflect.h2"
 class special_range_token;
 
-#line 3763 "reflect.h2"
+#line 3813 "reflect.h2"
 template<typename Error_out> class regex_generator;
 
-#line 4011 "reflect.h2"
+#line 4061 "reflect.h2"
 }
 
 }
@@ -1181,40 +1184,65 @@ class any_token
 #line 2618 "reflect.h2"
 };
 
-#line 2621 "reflect.h2"
+//  Regex syntax: (?><matcher>)  Example: a(?>bc|c)c
+//
+class atomic_group_token
+: public regex_token {
+
+#line 2626 "reflect.h2"
+            public: token_ptr inner_token {nullptr}; 
+
+    public: explicit atomic_group_token();
+
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
+
+#line 2637 "reflect.h2"
+    public: auto generate_code(generation_context& ctx) const -> void override;
+
+#line 2645 "reflect.h2"
+    public: auto add_groups(std::set<int>& groups) const -> void override;
+    public: virtual ~atomic_group_token() noexcept;
+
+    public: atomic_group_token(atomic_group_token const&) = delete; /* No 'that' constructor, suppress copy */
+    public: auto operator=(atomic_group_token const&) -> void = delete;
+
+
+#line 2648 "reflect.h2"
+};
+
 //  Regex syntax: a
 //
 class char_token
 : public regex_token {
 
-#line 2627 "reflect.h2"
+#line 2656 "reflect.h2"
     private: std::string token; 
     private: bool ignore_case; 
 
     public: explicit char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_);
 
-#line 2636 "reflect.h2"
+#line 2665 "reflect.h2"
     public: explicit char_token(cpp2::impl::in<std::string> t, cpp2::impl::in<bool> ignore_case_);
 
-#line 2642 "reflect.h2"
+#line 2671 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 2646 "reflect.h2"
+#line 2675 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2669 "reflect.h2"
+#line 2698 "reflect.h2"
     public: auto gen_case_insensitive(cpp2::impl::in<std::string> lower, cpp2::impl::in<std::string> upper, generation_context& ctx) const& -> void;
 
-#line 2690 "reflect.h2"
+#line 2719 "reflect.h2"
     public: auto gen_case_sensitive(generation_context& ctx) const& -> void;
 
-#line 2708 "reflect.h2"
+#line 2737 "reflect.h2"
     public: [[nodiscard]] auto add_escapes(std::string str) const& -> std::string;
 
-#line 2723 "reflect.h2"
+#line 2752 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 2729 "reflect.h2"
+#line 2758 "reflect.h2"
     public: auto append(char_token const& that) & -> void;
     public: virtual ~char_token() noexcept;
 
@@ -1222,33 +1250,33 @@ class char_token
     public: auto operator=(char_token const&) -> void = delete;
 
 
-#line 2733 "reflect.h2"
+#line 2762 "reflect.h2"
 };
 
-#line 2736 "reflect.h2"
+#line 2765 "reflect.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 class class_token
 : public regex_token {
 
-#line 2742 "reflect.h2"
+#line 2771 "reflect.h2"
     private: bool negate; 
     private: bool case_insensitive; 
     private: std::string class_str; 
 
     public: explicit class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str);
 
-#line 2754 "reflect.h2"
+#line 2783 "reflect.h2"
     //  TODO: Rework class generation: Generate check functions for classes.
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 2880 "reflect.h2"
+#line 2909 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 2889 "reflect.h2"
+#line 2918 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2894 "reflect.h2"
+#line 2923 "reflect.h2"
     private: [[nodiscard]] static auto create_matcher(cpp2::impl::in<std::string> name, cpp2::impl::in<std::string> template_arguments) -> std::string;
     public: virtual ~class_token() noexcept;
 
@@ -1256,20 +1284,20 @@ class class_token
     public: auto operator=(class_token const&) -> void = delete;
 
 
-#line 2901 "reflect.h2"
+#line 2930 "reflect.h2"
 };
 
-#line 2904 "reflect.h2"
+#line 2933 "reflect.h2"
 //  Regex syntax: \a or \n or \[
 //
 [[nodiscard]] auto escape_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 2945 "reflect.h2"
+#line 2974 "reflect.h2"
 //  Regex syntax: \K Example: ab\Kcd
 //
 [[nodiscard]] auto global_group_reset_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 2956 "reflect.h2"
+#line 2985 "reflect.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -1279,20 +1307,20 @@ class class_token
 class group_ref_token
 : public regex_token {
 
-#line 2966 "reflect.h2"
+#line 2995 "reflect.h2"
     private: int id; 
     private: bool case_insensitive; 
     private: bool reverse_eval; 
 
     public: explicit group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<bool> reverse_, cpp2::impl::in<std::string> str);
 
-#line 2978 "reflect.h2"
+#line 3007 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3079 "reflect.h2"
+#line 3108 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3083 "reflect.h2"
+#line 3112 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
     public: virtual ~group_ref_token() noexcept;
 
@@ -1300,10 +1328,10 @@ class group_ref_token
     public: auto operator=(group_ref_token const&) -> void = delete;
 
 
-#line 3086 "reflect.h2"
+#line 3115 "reflect.h2"
 };
 
-#line 3089 "reflect.h2"
+#line 3118 "reflect.h2"
 //  Regex syntax: (<tokens>)      Example: (abc)
 //                (?<modifiers)            (?i)
 //                (?<modifiers>:<tokens>)  (?i:abc)
@@ -1317,26 +1345,29 @@ class group_ref_token
 class group_token
 : public regex_token {
 
-#line 3103 "reflect.h2"
+#line 3132 "reflect.h2"
     private: int number {-1}; 
     private: bool reverse_eval {false}; 
     private: token_ptr inner {nullptr}; 
 
     public: [[nodiscard]] static auto parse_lookahead_lookbehind(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> lookahead, cpp2::impl::in<bool> positive) -> token_ptr;
 
-#line 3125 "reflect.h2"
+#line 3154 "reflect.h2"
+    public: [[nodiscard]] static auto parse_atomic_pattern(parse_context& ctx, cpp2::impl::in<std::string> syntax) -> token_ptr;
+
+#line 3168 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3276 "reflect.h2"
+#line 3327 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3284 "reflect.h2"
+#line 3335 "reflect.h2"
     public: [[nodiscard]] static auto gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string;
 
-#line 3302 "reflect.h2"
+#line 3353 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3333 "reflect.h2"
+#line 3384 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~group_token() noexcept;
 
@@ -1345,25 +1376,25 @@ class group_token
     public: auto operator=(group_token const&) -> void = delete;
 
 
-#line 3340 "reflect.h2"
+#line 3391 "reflect.h2"
 };
 
-#line 3343 "reflect.h2"
+#line 3394 "reflect.h2"
 //  Regex syntax: \x<number> or \x{<number>}  Example: \x{62}
 //
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3384 "reflect.h2"
+#line 3435 "reflect.h2"
 //  Regex syntax: $  Example: aa$
 //
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3404 "reflect.h2"
+#line 3455 "reflect.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3420 "reflect.h2"
+#line 3471 "reflect.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
@@ -1371,20 +1402,20 @@ class group_token
 class lookahead_lookbehind_token
 : public regex_token {
 
-#line 3428 "reflect.h2"
+#line 3479 "reflect.h2"
     protected: bool lookahead; 
     protected: bool positive; 
     public:   token_ptr inner {nullptr}; 
 
     public: explicit lookahead_lookbehind_token(cpp2::impl::in<bool> lookahead_, cpp2::impl::in<bool> positive_);
 
-#line 3437 "reflect.h2"
+#line 3488 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3448 "reflect.h2"
+#line 3499 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3455 "reflect.h2"
+#line 3506 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~lookahead_lookbehind_token() noexcept;
 
@@ -1392,26 +1423,26 @@ class lookahead_lookbehind_token
     public: auto operator=(lookahead_lookbehind_token const&) -> void = delete;
 
 
-#line 3458 "reflect.h2"
+#line 3509 "reflect.h2"
 };
 
-#line 3461 "reflect.h2"
+#line 3512 "reflect.h2"
 // Named character classes
 //
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3489 "reflect.h2"
+#line 3540 "reflect.h2"
 //  Regex syntax: \o{<number>}  Example: \o{142}
 //
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3517 "reflect.h2"
+#line 3568 "reflect.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 class range_token
 : public regex_token {
 
-#line 3523 "reflect.h2"
+#line 3574 "reflect.h2"
               protected: int min_count {-1}; 
               protected: int max_count {-1}; 
               protected: int kind {range_flags::greedy}; 
@@ -1421,22 +1452,22 @@ class range_token
 
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3603 "reflect.h2"
+#line 3654 "reflect.h2"
     public: auto parse_modifier(parse_context& ctx) & -> void;
 
-#line 3615 "reflect.h2"
+#line 3666 "reflect.h2"
     public: [[nodiscard]] auto gen_mod_string() const& -> std::string;
 
-#line 3628 "reflect.h2"
+#line 3679 "reflect.h2"
     public: [[nodiscard]] auto gen_range_string() const& -> std::string;
 
-#line 3647 "reflect.h2"
+#line 3698 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3657 "reflect.h2"
+#line 3708 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3668 "reflect.h2"
+#line 3719 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~range_token() noexcept;
 
@@ -1444,16 +1475,16 @@ class range_token
     public: auto operator=(range_token const&) -> void = delete;
 
 
-#line 3672 "reflect.h2"
+#line 3722 "reflect.h2"
 };
 
-#line 3675 "reflect.h2"
+#line 3725 "reflect.h2"
 //  Regex syntax: *, +, or ?  Example: aa*
 //
 class special_range_token
 : public range_token {
 
-#line 3681 "reflect.h2"
+#line 3731 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
     public: virtual ~special_range_token() noexcept;
 
@@ -1462,7 +1493,7 @@ class special_range_token
     public: auto operator=(special_range_token const&) -> void = delete;
 
 
-#line 3711 "reflect.h2"
+#line 3761 "reflect.h2"
 };
 
 //  Regex syntax: \G  Example: \Gaa
@@ -1471,14 +1502,14 @@ class special_range_token
 //
 [[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr;
 
-#line 3733 "reflect.h2"
+#line 3783 "reflect.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3755 "reflect.h2"
+#line 3805 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  Parser for regular expression.
@@ -1499,24 +1530,24 @@ template<typename Error_out> class regex_generator
 
     public: explicit regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e);
 
-#line 3778 "reflect.h2"
+#line 3828 "reflect.h2"
     public: [[nodiscard]] auto parse() & -> std::string;
 
-#line 3813 "reflect.h2"
+#line 3863 "reflect.h2"
     private: auto extract_modifiers() & -> void;
     public: regex_generator(regex_generator const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_generator const&) -> void = delete;
 
 
-#line 3827 "reflect.h2"
+#line 3877 "reflect.h2"
 };
 
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string;
 
-#line 3839 "reflect.h2"
+#line 3889 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void;
 
-#line 3894 "reflect.h2"
+#line 3944 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  apply_metafunctions
@@ -1527,7 +1558,7 @@ auto regex_gen(meta::type_declaration& t) -> void;
     auto const& error
     ) -> bool;
 
-#line 4011 "reflect.h2"
+#line 4061 "reflect.h2"
 }
 
 }
@@ -4420,30 +4451,58 @@ generation_function_context::generation_function_context(){}
 
     any_token::~any_token() noexcept{}
 
+#line 2628 "reflect.h2"
+    atomic_group_token::atomic_group_token()
+                             : regex_token{ "" }{}
+
 #line 2630 "reflect.h2"
+    [[nodiscard]] auto atomic_group_token::reverse() const -> token_ptr{
+        auto r {CPP2_UFCS_TEMPLATE(cpp2_new<atomic_group_token>)(cpp2::shared)}; 
+        (*cpp2::impl::assert_not_null(r)).inner_token = CPP2_UFCS(reverse)((*cpp2::impl::assert_not_null(inner_token)));
+
+        return r; 
+    }
+
+#line 2637 "reflect.h2"
+    auto atomic_group_token::generate_code(generation_context& ctx) const -> void
+    {
+        auto inner_name {ctx.generate_func(inner_token)}; 
+
+        auto next_name {ctx.next_func_name()}; 
+        ctx.add_statefull(next_name, "cpp2::regex::atomic_group_matcher<char>(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ", other, " + cpp2::to_string(next_name) + ")");
+    }
+
+#line 2645 "reflect.h2"
+    auto atomic_group_token::add_groups(std::set<int>& groups) const -> void{
+        (*cpp2::impl::assert_not_null(inner_token)).add_groups(groups);
+    }
+
+    atomic_group_token::~atomic_group_token() noexcept{}
+
+#line 2659 "reflect.h2"
     char_token::char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_)
         : regex_token{ std::string(1, t) }
         , token{ t }
         , ignore_case{ ignore_case_ }{
 
-#line 2634 "reflect.h2"
+#line 2663 "reflect.h2"
     }
 
-#line 2636 "reflect.h2"
+#line 2665 "reflect.h2"
     char_token::char_token(cpp2::impl::in<std::string> t, cpp2::impl::in<bool> ignore_case_)
         : regex_token{ t }
         , token{ t }
         , ignore_case{ ignore_case_ }{
 
-#line 2640 "reflect.h2"
+#line 2669 "reflect.h2"
     }
 
-#line 2642 "reflect.h2"
+#line 2671 "reflect.h2"
     [[nodiscard]] auto char_token::parse(parse_context& ctx) -> token_ptr{
         return CPP2_UFCS_TEMPLATE(cpp2_new<char_token>)(cpp2::shared, ctx.current(), ctx.get_modifiers().has(expression_flags::case_insensitive)); 
     }
 
-#line 2646 "reflect.h2"
+#line 2675 "reflect.h2"
     auto char_token::generate_code(generation_context& ctx) const -> void
     {
         if (ignore_case) {
@@ -4452,14 +4511,14 @@ generation_function_context::generation_function_context(){}
 {
 size_t i{0};
 
-#line 2652 "reflect.h2"
+#line 2681 "reflect.h2"
             for( ; cpp2::impl::cmp_less(i,token.size()); i += 1 ) {
                 CPP2_ASSERT_IN_BOUNDS(lower, i) = string_util::safe_tolower(CPP2_ASSERT_IN_BOUNDS(token, i));
                 CPP2_ASSERT_IN_BOUNDS(upper, i) = string_util::safe_toupper(CPP2_ASSERT_IN_BOUNDS(token, i));
             }
 }
 
-#line 2657 "reflect.h2"
+#line 2686 "reflect.h2"
             if (upper != lower) {
                 gen_case_insensitive(cpp2::move(lower), cpp2::move(upper), ctx);
             }
@@ -4472,7 +4531,7 @@ size_t i{0};
         }
     }
 
-#line 2669 "reflect.h2"
+#line 2698 "reflect.h2"
     auto char_token::gen_case_insensitive(cpp2::impl::in<std::string> lower, cpp2::impl::in<std::string> upper, generation_context& ctx) const& -> void
     {
         std::string name {"str_" + cpp2::to_string(ctx.gen_temp()) + ""}; 
@@ -4494,7 +4553,7 @@ size_t i{0};
         ctx.add("else { break; }");
     }
 
-#line 2690 "reflect.h2"
+#line 2719 "reflect.h2"
     auto char_token::gen_case_sensitive(generation_context& ctx) const& -> void
     {
         std::string name {"str_" + cpp2::to_string(ctx.gen_temp()) + ""}; 
@@ -4513,7 +4572,7 @@ size_t i{0};
         ctx.add("else { break; }");
     }
 
-#line 2708 "reflect.h2"
+#line 2737 "reflect.h2"
     [[nodiscard]] auto char_token::add_escapes(std::string str) const& -> std::string
     {
         str = string_util::replace_all(str, "\\", "\\\\");
@@ -4529,14 +4588,14 @@ size_t i{0};
         return cpp2::move(str); 
     }
 
-#line 2723 "reflect.h2"
+#line 2752 "reflect.h2"
     [[nodiscard]] auto char_token::reverse() const -> token_ptr{
         std::string reverse_str {token}; 
         std::reverse(reverse_str.begin(), reverse_str.end());
         return CPP2_UFCS_TEMPLATE(cpp2_new<char_token>)(cpp2::shared, cpp2::move(reverse_str), ignore_case); 
     }
 
-#line 2729 "reflect.h2"
+#line 2758 "reflect.h2"
     auto char_token::append(char_token const& that) & -> void{
         (*this).token += that.token;
         (*this).string_rep += that.string_rep;
@@ -4544,19 +4603,19 @@ size_t i{0};
 
     char_token::~char_token() noexcept{}
 
-#line 2746 "reflect.h2"
+#line 2775 "reflect.h2"
     class_token::class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str)
         : regex_token{ str }
         , negate{ negate_ }
         , case_insensitive{ case_insensitive_ }
         , class_str{ class_str_ }
-#line 2747 "reflect.h2"
+#line 2776 "reflect.h2"
     {
 
-#line 2752 "reflect.h2"
+#line 2781 "reflect.h2"
     }
 
-#line 2755 "reflect.h2"
+#line 2784 "reflect.h2"
     [[nodiscard]] auto class_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '[') {return nullptr; }
@@ -4682,7 +4741,7 @@ size_t i{0};
             ); 
     }
 
-#line 2880 "reflect.h2"
+#line 2909 "reflect.h2"
     [[nodiscard]] auto class_token::reverse() const -> token_ptr{
         return CPP2_UFCS_TEMPLATE(cpp2_new<class_token>)(cpp2::shared, 
             negate, 
@@ -4692,13 +4751,13 @@ size_t i{0};
             ); 
     }
 
-#line 2889 "reflect.h2"
+#line 2918 "reflect.h2"
     auto class_token::generate_code(generation_context& ctx) const -> void
     {
         ctx.add_check("class_token_matcher<char, " + cpp2::to_string(negate) + ", " + cpp2::to_string(case_insensitive) + ", " + cpp2::to_string(class_str) + ">::match(" + cpp2::to_string(ctx.match_parameters()) + ")");
     }
 
-#line 2894 "reflect.h2"
+#line 2923 "reflect.h2"
     [[nodiscard]] auto class_token::create_matcher(cpp2::impl::in<std::string> name, cpp2::impl::in<std::string> template_arguments) -> std::string
     {
         auto sep {", "}; 
@@ -4709,12 +4768,12 @@ size_t i{0};
 
     class_token::~class_token() noexcept{}
 
-#line 2906 "reflect.h2"
+#line 2935 "reflect.h2"
 [[nodiscard]] auto escape_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
 
-#line 2911 "reflect.h2"
+#line 2940 "reflect.h2"
     if (std::string::npos == std::string("afenrt^.[]()*{}?+|\\").find(ctx.peek())) {
         return nullptr; 
     }
@@ -4748,7 +4807,7 @@ size_t i{0};
 
 }
 
-#line 2947 "reflect.h2"
+#line 2976 "reflect.h2"
 [[nodiscard]] auto global_group_reset_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'K'))) {return nullptr; }
@@ -4757,19 +4816,19 @@ size_t i{0};
     return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_code>)(cpp2::shared, "\\K", "ctx..set_group_start(0, r.pos);"); 
 }
 
-#line 2970 "reflect.h2"
+#line 2999 "reflect.h2"
     group_ref_token::group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<bool> reverse_, cpp2::impl::in<std::string> str)
         : regex_token{ str }
         , id{ id_ }
         , case_insensitive{ case_insensitive_ }
         , reverse_eval{ reverse_ }
-#line 2971 "reflect.h2"
+#line 3000 "reflect.h2"
     {
 
-#line 2976 "reflect.h2"
+#line 3005 "reflect.h2"
     }
 
-#line 2978 "reflect.h2"
+#line 3007 "reflect.h2"
     [[nodiscard]] auto group_ref_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '\\') {return nullptr; }
@@ -4871,19 +4930,19 @@ size_t i{0};
         return CPP2_UFCS_TEMPLATE(cpp2_new<group_ref_token>)(cpp2::shared, cpp2::move(group_id), ctx.get_modifiers().has(expression_flags::case_insensitive), false, cpp2::move(str)); 
     }
 
-#line 3079 "reflect.h2"
+#line 3108 "reflect.h2"
     [[nodiscard]] auto group_ref_token::reverse() const -> token_ptr{
         return CPP2_UFCS_TEMPLATE(cpp2_new<group_ref_token>)(cpp2::shared, id, case_insensitive, !(reverse_eval), to_string()); 
     }
 
-#line 3083 "reflect.h2"
+#line 3112 "reflect.h2"
     auto group_ref_token::generate_code(generation_context& ctx) const -> void{
         ctx.add_check("group_ref_token_matcher<char, " + cpp2::to_string(id) + ", " + cpp2::to_string(case_insensitive) + ", " + cpp2::to_string(reverse_eval) + ">(" + cpp2::to_string(ctx.match_parameters()) + ")");
     }
 
     group_ref_token::~group_ref_token() noexcept{}
 
-#line 3107 "reflect.h2"
+#line 3136 "reflect.h2"
     [[nodiscard]] auto group_token::parse_lookahead_lookbehind(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> lookahead, cpp2::impl::in<bool> positive) -> token_ptr
     {
         static_cast<void>(ctx.next());// Skip last token defining the syntax
@@ -4902,7 +4961,22 @@ size_t i{0};
         return r; 
     }
 
-#line 3125 "reflect.h2"
+#line 3154 "reflect.h2"
+    [[nodiscard]] auto group_token::parse_atomic_pattern(parse_context& ctx, cpp2::impl::in<std::string> syntax) -> token_ptr
+    {
+        static_cast<void>(ctx.next());// Skip last token defining the syntax
+
+        auto r {CPP2_UFCS_TEMPLATE(cpp2_new<atomic_group_token>)(cpp2::shared)}; 
+
+        auto old_state {ctx.start_group()}; 
+        if (!(ctx.parse_until(')'))) {return ctx.error("Group without a closing bracket."); }
+        (*cpp2::impl::assert_not_null(r)).inner_token = ctx.end_group(cpp2::move(old_state));
+        (*cpp2::impl::assert_not_null(r)).set_string("(" + cpp2::to_string(syntax) + cpp2::to_string((*cpp2::impl::assert_not_null((*cpp2::impl::assert_not_null(r)).inner_token)).to_string()) + ")");
+
+        return r; 
+    }
+
+#line 3168 "reflect.h2"
     [[nodiscard]] auto group_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '(') {return nullptr; }
@@ -4983,6 +5057,11 @@ size_t i{0};
                 // Lookahead
                 return parse_lookahead_lookbehind(ctx, "?" + cpp2::to_string(ctx.current()) + "", true, ctx.current() == '='); 
             }
+            else {if (ctx.current() == '>') 
+            {
+                // Atomic pattern
+                return parse_atomic_pattern(ctx, "?" + cpp2::to_string(ctx.current()) + ""); 
+            }
             else 
             {
                 //  Simple modifier
@@ -4998,7 +5077,7 @@ size_t i{0};
                 else {
                     if (!(ctx.next()))            { return ctx. error("Missing ending bracket for group.");  }/* skip ':' */
                 }
-            }}}}}
+            }}}}}}
         }
         else {if (ctx.current() == '*') 
         {
@@ -5019,9 +5098,12 @@ size_t i{0};
             else {if (name == "nlb" || name == "negative_lookbehind") {
                 return parse_lookahead_lookbehind(ctx, "*" + cpp2::to_string(cpp2::move(name)) + ":", false, false); 
             }
+            else {if (name == "atomic") {
+                return parse_atomic_pattern(ctx, "*" + cpp2::to_string(cpp2::move(name)) + ":"); 
+            }
             else {
                 return ctx.error("Unknown named group pattern: '" + cpp2::to_string(cpp2::move(name)) + "'"); 
-            }}}}
+            }}}}}
         }}
 
         if (cpp2::move(has_pattern)) 
@@ -5054,7 +5136,7 @@ size_t i{0};
         }
     }
 
-#line 3276 "reflect.h2"
+#line 3327 "reflect.h2"
     [[nodiscard]] auto group_token::reverse() const -> token_ptr{
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<group_token>)(cpp2::shared)}; 
         (*cpp2::impl::assert_not_null(r)).number = number;
@@ -5063,7 +5145,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3284 "reflect.h2"
+#line 3335 "reflect.h2"
     [[nodiscard]] auto group_token::gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string
     {
         std::string start {"("}; 
@@ -5082,7 +5164,7 @@ size_t i{0};
         return cpp2::move(start) + (*cpp2::impl::assert_not_null(inner_)).to_string() + ")"; 
     }
 
-#line 3302 "reflect.h2"
+#line 3353 "reflect.h2"
     auto group_token::generate_code(generation_context& ctx) const -> void
     {
         if (-1 != number) {
@@ -5114,7 +5196,7 @@ size_t i{0};
         }
     }
 
-#line 3333 "reflect.h2"
+#line 3384 "reflect.h2"
     auto group_token::add_groups(std::set<int>& groups) const -> void
     {
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
@@ -5125,7 +5207,7 @@ size_t i{0};
 
     group_token::~group_token() noexcept{}
 
-#line 3345 "reflect.h2"
+#line 3396 "reflect.h2"
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'x'))) {return nullptr; }
@@ -5164,7 +5246,7 @@ size_t i{0};
     return r; 
 }
 
-#line 3386 "reflect.h2"
+#line 3437 "reflect.h2"
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() == '$' || (ctx.current() == '\\' && ctx.peek() == '$')) {
@@ -5182,7 +5264,7 @@ size_t i{0};
     }}
 }
 
-#line 3406 "reflect.h2"
+#line 3457 "reflect.h2"
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '^' && !((ctx.current() == '\\' && ctx.peek() == 'A'))) {return nullptr; }
@@ -5196,16 +5278,16 @@ size_t i{0};
     }
 }
 
-#line 3432 "reflect.h2"
+#line 3483 "reflect.h2"
     lookahead_lookbehind_token::lookahead_lookbehind_token(cpp2::impl::in<bool> lookahead_, cpp2::impl::in<bool> positive_)
         : regex_token{ "" }
         , lookahead{ lookahead_ }
         , positive{ positive_ }{
 
-#line 3435 "reflect.h2"
+#line 3486 "reflect.h2"
     }
 
-#line 3437 "reflect.h2"
+#line 3488 "reflect.h2"
     auto lookahead_lookbehind_token::generate_code(generation_context& ctx) const -> void{
         auto inner_name {ctx.generate_func(inner)}; 
 
@@ -5217,7 +5299,7 @@ size_t i{0};
         }
     }
 
-#line 3448 "reflect.h2"
+#line 3499 "reflect.h2"
     [[nodiscard]] auto lookahead_lookbehind_token::reverse() const -> token_ptr{
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<lookahead_lookbehind_token>)(cpp2::shared, lookahead, positive)}; 
         (*cpp2::impl::assert_not_null(r)).inner = inner;// We do not reverse here. Nested lookahead and lookbehind stay as they are.
@@ -5225,14 +5307,14 @@ size_t i{0};
         return r; 
     }
 
-#line 3455 "reflect.h2"
+#line 3506 "reflect.h2"
     auto lookahead_lookbehind_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
     }
 
     lookahead_lookbehind_token::~lookahead_lookbehind_token() noexcept{}
 
-#line 3463 "reflect.h2"
+#line 3514 "reflect.h2"
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5258,7 +5340,7 @@ size_t i{0};
     return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_check>)(cpp2::shared, "\\" + cpp2::to_string(ctx.current()) + "", "" + cpp2::to_string(cpp2::move(name)) + "<char, " + cpp2::to_string(ctx.get_modifiers().has(expression_flags::case_insensitive)) + ">::match"); 
 }
 
-#line 3491 "reflect.h2"
+#line 3542 "reflect.h2"
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'o'))) {return nullptr; }
@@ -5284,11 +5366,11 @@ size_t i{0};
     return r; 
 }
 
-#line 3528 "reflect.h2"
+#line 3579 "reflect.h2"
     range_token::range_token()
                              : regex_token{ "" }{}
 
-#line 3530 "reflect.h2"
+#line 3581 "reflect.h2"
     [[nodiscard]] auto range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<range_token>)(cpp2::shared)}; 
@@ -5362,7 +5444,7 @@ size_t i{0};
         return nullptr; 
     }
 
-#line 3603 "reflect.h2"
+#line 3654 "reflect.h2"
     auto range_token::parse_modifier(parse_context& ctx) & -> void
     {
         if (ctx.peek() == '?') {
@@ -5375,7 +5457,7 @@ size_t i{0};
         }}
     }
 
-#line 3615 "reflect.h2"
+#line 3666 "reflect.h2"
     [[nodiscard]] auto range_token::gen_mod_string() const& -> std::string
     {
         if (kind == range_flags::not_greedy) {
@@ -5389,7 +5471,7 @@ size_t i{0};
         }}
     }
 
-#line 3628 "reflect.h2"
+#line 3679 "reflect.h2"
     [[nodiscard]] auto range_token::gen_range_string() const& -> std::string
     {
         std::string r {""}; 
@@ -5409,7 +5491,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3647 "reflect.h2"
+#line 3698 "reflect.h2"
     [[nodiscard]] auto range_token::reverse() const -> token_ptr{
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<range_token>)(cpp2::shared)}; 
         (*cpp2::impl::assert_not_null(r)).min_count = min_count;
@@ -5420,7 +5502,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3657 "reflect.h2"
+#line 3708 "reflect.h2"
     auto range_token::generate_code(generation_context& ctx) const -> void
     {
         auto inner_name {ctx.generate_func(inner_token)}; 
@@ -5432,14 +5514,14 @@ size_t i{0};
         ctx.add_statefull(next_name, "cpp2::regex::range_token_matcher<char, " + cpp2::to_string(min_count) + ", " + cpp2::to_string(max_count) + ", " + cpp2::to_string(kind) + ">::match(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ", " + cpp2::to_string(cpp2::move(reset_name)) + ", other, " + cpp2::to_string(next_name) + ")");
     }
 
-#line 3668 "reflect.h2"
+#line 3719 "reflect.h2"
     auto range_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner_token)).add_groups(groups);
     }
 
     range_token::~range_token() noexcept{}
 
-#line 3681 "reflect.h2"
+#line 3731 "reflect.h2"
     [[nodiscard]] auto special_range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<special_range_token>)(cpp2::shared)}; 
@@ -5463,7 +5545,7 @@ size_t i{0};
 
         if (!(ctx.has_token())) {return ctx.error("'" + cpp2::to_string(ctx.current()) + "' without previous element."); }
 
-#line 3705 "reflect.h2"
+#line 3755 "reflect.h2"
         (*cpp2::impl::assert_not_null(r)).parse_modifier(ctx);
 
         (*cpp2::impl::assert_not_null(r)).inner_token = ctx.pop_token();
@@ -5473,7 +5555,7 @@ size_t i{0};
 
     special_range_token::~special_range_token() noexcept{}
 
-#line 3717 "reflect.h2"
+#line 3767 "reflect.h2"
 [[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5489,7 +5571,7 @@ size_t i{0};
     }
 }
 
-#line 3737 "reflect.h2"
+#line 3787 "reflect.h2"
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5507,15 +5589,15 @@ size_t i{0};
     }}
 }
 
-#line 3773 "reflect.h2"
+#line 3823 "reflect.h2"
     template <typename Error_out> regex_generator<Error_out>::regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e)
         : regex{ r }
         , error_out{ e }{
 
-#line 3776 "reflect.h2"
+#line 3826 "reflect.h2"
     }
 
-#line 3778 "reflect.h2"
+#line 3828 "reflect.h2"
     template <typename Error_out> [[nodiscard]] auto regex_generator<Error_out>::parse() & -> std::string
     {
         // Extract modifiers and adapt regex.
@@ -5551,7 +5633,7 @@ size_t i{0};
         return source; 
     }
 
-#line 3813 "reflect.h2"
+#line 3863 "reflect.h2"
     template <typename Error_out> auto regex_generator<Error_out>::extract_modifiers() & -> void
     {
         if (regex.find_first_of("'/") == 0) {
@@ -5567,7 +5649,7 @@ size_t i{0};
         }
     }
 
-#line 3829 "reflect.h2"
+#line 3879 "reflect.h2"
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string
 {
     regex_generator<Err> parser {regex, err}; 
@@ -5576,7 +5658,7 @@ template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::str
     return r; 
 }
 
-#line 3839 "reflect.h2"
+#line 3889 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void
 {
     auto has_default {false}; 
@@ -5631,7 +5713,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     CPP2_UFCS(add_runtime_support_include)(t, "cpp2regex.h");
 }
 
-#line 3898 "reflect.h2"
+#line 3948 "reflect.h2"
 [[nodiscard]] auto apply_metafunctions(
     declaration_node& n, 
     type_declaration& rtype, 
@@ -5744,7 +5826,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     return true; 
 }
 
-#line 4011 "reflect.h2"
+#line 4061 "reflect.h2"
 }
 
 }

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -4167,7 +4167,7 @@ generation_function_context::generation_function_context(){}
         auto cur {new_context()}; 
 
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + cpp2::to_string(name) + ": @struct<noforward> type = {\n";
-        (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "  operator(): (this, cur: Iter, inout ctx: context, other) -> cpp2::regex::match_return<Iter> = {\n";
+        (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "  operator(): <Iter2> (this, cur: Iter2, inout ctx, other) -> cpp2::regex::match_return<Iter2> = {\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    r := ctx..pass(cur);\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    do {\n";
         (*cpp2::impl::assert_not_null(cpp2::move(cur))).add_tabs(3);

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -112,7 +112,7 @@ class special_range_token;
 #line 3759 "reflect.h2"
 template<typename Error_out> class regex_generator;
 
-#line 4009 "reflect.h2"
+#line 4007 "reflect.h2"
 }
 
 }
@@ -1502,21 +1502,21 @@ template<typename Error_out> class regex_generator
 #line 3774 "reflect.h2"
     public: [[nodiscard]] auto parse() & -> std::string;
 
-#line 3811 "reflect.h2"
+#line 3809 "reflect.h2"
     private: auto extract_modifiers() & -> void;
     public: regex_generator(regex_generator const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_generator const&) -> void = delete;
 
 
-#line 3825 "reflect.h2"
+#line 3823 "reflect.h2"
 };
 
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string;
 
-#line 3837 "reflect.h2"
+#line 3835 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void;
 
-#line 3892 "reflect.h2"
+#line 3890 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  apply_metafunctions
@@ -1527,7 +1527,7 @@ auto regex_gen(meta::type_declaration& t) -> void;
     auto const& error
     ) -> bool;
 
-#line 4009 "reflect.h2"
+#line 4007 "reflect.h2"
 }
 
 }
@@ -5523,7 +5523,6 @@ size_t i{0};
         }
 
         source += "{\n";
-        source += " wrap: <CharT> type = {\n"; // TODO: Remove wrapper when template template parameters are available.
         source += "  context: <Iter> type == cpp2::regex::match_context<CharT, Iter, " + cpp2::to_string(parse_ctx.get_cur_group()) + ">;";
 
         generation_context gen_ctx {}; 
@@ -5537,7 +5536,6 @@ size_t i{0};
 
         source += cpp2::move(gen_ctx).create_named_group_lookup(parse_ctx.named_groups);
         source += "  is_start_match: () -> bool == " + cpp2::to_string(parse_ctx.is_start_match) + ";";
-        source += "}\n"; // wrap end
 
         auto string {(*cpp2::impl::assert_not_null(parse_ctx.get_as_token())).to_string()}; 
         source += "  to_string: () -> std::string = { return R\"(" + cpp2::to_string(modifier_escape) + cpp2::to_string(cpp2::move(string)) + cpp2::to_string(modifier_escape) + cpp2::to_string(modifier) + ")\"; }\n";
@@ -5549,7 +5547,7 @@ size_t i{0};
         return source; 
     }
 
-#line 3811 "reflect.h2"
+#line 3809 "reflect.h2"
     template <typename Error_out> auto regex_generator<Error_out>::extract_modifiers() & -> void
     {
         if (regex.find_first_of("'/") == 0) {
@@ -5565,7 +5563,7 @@ size_t i{0};
         }
     }
 
-#line 3827 "reflect.h2"
+#line 3825 "reflect.h2"
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string
 {
     regex_generator<Err> parser {regex, err}; 
@@ -5574,7 +5572,7 @@ template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::str
     return r; 
 }
 
-#line 3837 "reflect.h2"
+#line 3835 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void
 {
     auto has_default {false}; 
@@ -5621,15 +5619,15 @@ auto regex_gen(meta::type_declaration& t) -> void
         auto regular_expression {generate_regex(expr.second, [_0 = t](auto const& message) mutable -> decltype(auto) { return CPP2_UFCS(error)(_0, message);  })}; 
 
         if (!(regular_expression.empty())) {
-            CPP2_UFCS(add_member)(t, "public " + cpp2::to_string(expr.first) + "_matcher: type = " + cpp2::to_string(cpp2::move(regular_expression)) + "");
-            CPP2_UFCS(add_member)(t, "public " + cpp2::to_string(expr.first) + ": cpp2::regex::regular_expression<char, " + cpp2::to_string(expr.first) + "_matcher> = ();");
+            CPP2_UFCS(add_member)(t, "public " + cpp2::to_string(expr.first) + "_matcher: <CharT> type = " + cpp2::to_string(cpp2::move(regular_expression)) + "");
+            CPP2_UFCS(add_member)(t, "public " + cpp2::to_string(expr.first) + ": cpp2::regex::regular_expression<char, " + cpp2::to_string(expr.first) + "_matcher<char>> = ();\n");
         }
     }
 
     CPP2_UFCS(add_runtime_support_include)(t, "cpp2regex.h");
 }
 
-#line 3896 "reflect.h2"
+#line 3894 "reflect.h2"
 [[nodiscard]] auto apply_metafunctions(
     declaration_node& n, 
     type_declaration& rtype, 
@@ -5742,7 +5740,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     return true; 
 }
 
-#line 4009 "reflect.h2"
+#line 4007 "reflect.h2"
 }
 
 }

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -51,68 +51,68 @@ class expression_flags;
 #line 1664 "reflect.h2"
 class regex_token;
 
-#line 1690 "reflect.h2"
+#line 1691 "reflect.h2"
 class regex_token_check;
 
-#line 1709 "reflect.h2"
+#line 1712 "reflect.h2"
 class regex_token_code;
 
-#line 1728 "reflect.h2"
+#line 1733 "reflect.h2"
 class regex_token_empty;
 
-#line 1744 "reflect.h2"
+#line 1751 "reflect.h2"
 class regex_token_list;
 
-#line 1783 "reflect.h2"
+#line 1803 "reflect.h2"
 class parse_context_group_state;
 
-#line 1844 "reflect.h2"
+#line 1864 "reflect.h2"
 class parse_context_branch_reset_state;
 
-#line 1887 "reflect.h2"
+#line 1907 "reflect.h2"
 class parse_context;
 
-#line 2288 "reflect.h2"
+#line 2308 "reflect.h2"
 class generation_function_context;
     
 
-#line 2306 "reflect.h2"
+#line 2326 "reflect.h2"
 class generation_context;
 
-#line 2504 "reflect.h2"
+#line 2524 "reflect.h2"
 class alternative_token;
 
-#line 2519 "reflect.h2"
+#line 2539 "reflect.h2"
 class alternative_token_gen;
 
-#line 2571 "reflect.h2"
+#line 2604 "reflect.h2"
 class any_token;
 
-#line 2589 "reflect.h2"
+#line 2622 "reflect.h2"
 class char_token;
 
-#line 2692 "reflect.h2"
+#line 2737 "reflect.h2"
 class class_token;
 
-#line 2907 "reflect.h2"
+#line 2961 "reflect.h2"
 class group_ref_token;
 
-#line 3038 "reflect.h2"
+#line 3098 "reflect.h2"
 class group_token;
 
-#line 3325 "reflect.h2"
+#line 3405 "reflect.h2"
 class lookahead_token;
 
-#line 3406 "reflect.h2"
+#line 3490 "reflect.h2"
 class range_token;
 
-#line 3554 "reflect.h2"
+#line 3648 "reflect.h2"
 class special_range_token;
 
-#line 3640 "reflect.h2"
+#line 3734 "reflect.h2"
 template<typename Error_out> class regex_generator;
 
-#line 3890 "reflect.h2"
+#line 3984 "reflect.h2"
 }
 
 }
@@ -664,6 +664,7 @@ class regex_token
 
 #line 1677 "reflect.h2"
     public: virtual auto generate_code([[maybe_unused]] generation_context& unnamed_param_2) const -> void = 0;
+    public: [[nodiscard]] virtual auto reverse() const -> std::shared_ptr<regex_token> = 0;
 
     public: virtual auto add_groups([[maybe_unused]] std::set<int>& unnamed_param_2) const -> void;
     public: [[nodiscard]] auto to_string() const& -> std::string;
@@ -673,105 +674,114 @@ class regex_token
     public: regex_token(regex_token const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_token const&) -> void = delete;
 
-#line 1682 "reflect.h2"
+#line 1683 "reflect.h2"
 };
 
 using token_ptr = std::shared_ptr<regex_token>;
 using token_vec = std::vector<token_ptr>;
 
-#line 1688 "reflect.h2"
+#line 1689 "reflect.h2"
 //  Adds a check in code generation.
 //
 class regex_token_check
 : public regex_token {
 
-#line 1694 "reflect.h2"
+#line 1695 "reflect.h2"
     private: std::string check; 
 
     public: explicit regex_token_check(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> check_);
 
-#line 1701 "reflect.h2"
+#line 1702 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
+
+#line 1706 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
     public: virtual ~regex_token_check() noexcept;
 
     public: regex_token_check(regex_token_check const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_token_check const&) -> void = delete;
 
-
-#line 1704 "reflect.h2"
+#line 1707 "reflect.h2"
 };
 
-#line 1707 "reflect.h2"
+#line 1710 "reflect.h2"
 //  Adds code in code generation.
 //
 class regex_token_code
 : public regex_token {
 
-#line 1713 "reflect.h2"
+#line 1716 "reflect.h2"
     private: std::string code; 
 
     public: explicit regex_token_code(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> code_);
 
-#line 1720 "reflect.h2"
+#line 1723 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
+
+#line 1727 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
     public: virtual ~regex_token_code() noexcept;
 
     public: regex_token_code(regex_token_code const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_token_code const&) -> void = delete;
 
-
-#line 1723 "reflect.h2"
+#line 1728 "reflect.h2"
 };
 
-#line 1726 "reflect.h2"
+#line 1731 "reflect.h2"
 //  Token that does not influence the matching. E.g. comment.
 //
 class regex_token_empty
 : public regex_token {
 
-#line 1732 "reflect.h2"
+#line 1737 "reflect.h2"
     public: explicit regex_token_empty(cpp2::impl::in<std::string> str);
 
-#line 1736 "reflect.h2"
+#line 1741 "reflect.h2"
     public: auto generate_code([[maybe_unused]] generation_context& unnamed_param_2) const -> void override;
+
+#line 1745 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
     public: virtual ~regex_token_empty() noexcept;
 
     public: regex_token_empty(regex_token_empty const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_token_empty const&) -> void = delete;
 
-
-#line 1739 "reflect.h2"
+#line 1746 "reflect.h2"
 };
 
-#line 1742 "reflect.h2"
+#line 1749 "reflect.h2"
 //  Represents a list of regex tokens as one token.
 //
 class regex_token_list
 : public regex_token {
 
-#line 1748 "reflect.h2"
+#line 1755 "reflect.h2"
     public: token_vec tokens; 
 
     public: explicit regex_token_list(cpp2::impl::in<token_vec> t);
 
-#line 1755 "reflect.h2"
+#line 1762 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 1761 "reflect.h2"
+#line 1768 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
 
-#line 1767 "reflect.h2"
+#line 1774 "reflect.h2"
     public: [[nodiscard]] static auto gen_string(cpp2::impl::in<token_vec> vec) -> std::string;
+
+#line 1782 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
     public: virtual ~regex_token_list() noexcept;
 
     public: regex_token_list(regex_token_list const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_token_list const&) -> void = delete;
 
 
-#line 1774 "reflect.h2"
+#line 1794 "reflect.h2"
 };
 
-#line 1777 "reflect.h2"
+#line 1797 "reflect.h2"
 //
 //  Parse and generation context.
 //
@@ -787,33 +797,33 @@ class parse_context_group_state
     //  Start a new alternative.
     public: auto next_alternative() & -> void;
 
-#line 1797 "reflect.h2"
+#line 1817 "reflect.h2"
     //  Swap this state with the other one. NOLINTNEXTLINE(performance-noexcept-swap)
     public: auto swap(parse_context_group_state& t) & -> void;
 
-#line 1804 "reflect.h2"
+#line 1824 "reflect.h2"
     //  Convert this state into a regex token.
     public: [[nodiscard]] auto get_as_token() & -> token_ptr;
 
-#line 1816 "reflect.h2"
+#line 1836 "reflect.h2"
     //  Add a token to the current matcher list.
     public: auto add(cpp2::impl::in<token_ptr> token) & -> void;
 
-#line 1821 "reflect.h2"
+#line 1841 "reflect.h2"
     //  True if current matcher list is empty.
     public: [[nodiscard]] auto empty() const& -> bool;
 
-#line 1825 "reflect.h2"
+#line 1845 "reflect.h2"
     //  Apply optimizations to the matcher list.
     public: static auto post_process_list(token_vec& list) -> void;
     public: parse_context_group_state(auto const& cur_match_list_, auto const& alternate_match_lists_, auto const& modifiers_);
 public: parse_context_group_state();
 
 
-#line 1839 "reflect.h2"
+#line 1859 "reflect.h2"
 };
 
-#line 1842 "reflect.h2"
+#line 1862 "reflect.h2"
 //  State for the branch reset. Takes care of the group numbering. See '(|<pattern>)'.
 //
 class parse_context_branch_reset_state
@@ -826,25 +836,25 @@ class parse_context_branch_reset_state
     //  Next group identifier.
     public: [[nodiscard]] auto next() & -> int;
 
-#line 1860 "reflect.h2"
+#line 1880 "reflect.h2"
     //  Set next group identifier.
     public: auto set_next(cpp2::impl::in<int> g) & -> void;
 
-#line 1866 "reflect.h2"
+#line 1886 "reflect.h2"
     //  Start a new alternative branch.
     public: auto next_alternative() & -> void;
 
-#line 1873 "reflect.h2"
+#line 1893 "reflect.h2"
     //  Initialize for a branch reset group.
     public: auto set_active_reset(cpp2::impl::in<int> restart) & -> void;
     public: parse_context_branch_reset_state(auto const& is_active_, auto const& cur_group_, auto const& max_group_, auto const& from_);
 public: parse_context_branch_reset_state();
 
 
-#line 1880 "reflect.h2"
+#line 1900 "reflect.h2"
 };
 
-#line 1883 "reflect.h2"
+#line 1903 "reflect.h2"
 //  Context during parsing of the regular expressions.
 // 
 //  Keeps track of the distributed group identifiers, current parsed group and branch resets.
@@ -860,7 +870,7 @@ class parse_context
     private: parse_context_group_state cur_group_state {}; 
     private: parse_context_branch_reset_state cur_branch_reset_state {}; 
 
-#line 1899 "reflect.h2"
+#line 1919 "reflect.h2"
            public: std::map<std::string,int> named_groups {}; 
 
     private: error_func error_out; // TODO: Declaring std::function<void(std::string)> fails for cpp2.
@@ -868,64 +878,64 @@ class parse_context
 
     public: explicit parse_context(cpp2::impl::in<std::string_view> r, auto const& e);
 
-#line 1910 "reflect.h2"
+#line 1930 "reflect.h2"
     //  State management functions
     //
 
     //  Returned group state needs to be stored and provided in `end_group`.
     public: [[nodiscard]] auto start_group() & -> parse_context_group_state;
 
-#line 1923 "reflect.h2"
+#line 1943 "reflect.h2"
     //  `old_state` argument needs to be from start group.
     public: [[nodiscard]] auto end_group(cpp2::impl::in<parse_context_group_state> old_state) & -> token_ptr;
 
-#line 1931 "reflect.h2"
+#line 1951 "reflect.h2"
     public: [[nodiscard]] auto get_modifiers() const& -> expression_flags;
 
-#line 1935 "reflect.h2"
+#line 1955 "reflect.h2"
     public: auto set_modifiers(cpp2::impl::in<expression_flags> mod) & -> void;
 
-#line 1939 "reflect.h2"
+#line 1959 "reflect.h2"
     //  Branch reset management functions
     //
 
     public: [[nodiscard]] auto branch_reset_new_state() & -> parse_context_branch_reset_state;
 
-#line 1951 "reflect.h2"
+#line 1971 "reflect.h2"
     public: auto branch_reset_restore_state(cpp2::impl::in<parse_context_branch_reset_state> old_state) & -> void;
 
-#line 1958 "reflect.h2"
+#line 1978 "reflect.h2"
     public: auto next_alternative() & -> void;
 
-#line 1964 "reflect.h2"
+#line 1984 "reflect.h2"
     //  Regex token management
     //
     public: auto add_token(cpp2::impl::in<token_ptr> token) & -> void;
 
-#line 1970 "reflect.h2"
+#line 1990 "reflect.h2"
     public: [[nodiscard]] auto has_token() const& -> bool;
 
-#line 1974 "reflect.h2"
+#line 1994 "reflect.h2"
     public: [[nodiscard]] auto pop_token() & -> token_ptr;
 
-#line 1985 "reflect.h2"
+#line 2005 "reflect.h2"
     public: [[nodiscard]] auto get_as_token() & -> token_ptr;
 
-#line 1989 "reflect.h2"
+#line 2009 "reflect.h2"
     //  Group management
     //
     public: [[nodiscard]] auto get_cur_group() const& -> int;
 
-#line 1995 "reflect.h2"
+#line 2015 "reflect.h2"
     public: [[nodiscard]] auto next_group() & -> int;
 
-#line 1999 "reflect.h2"
+#line 2019 "reflect.h2"
     public: auto set_named_group(cpp2::impl::in<std::string> name, cpp2::impl::in<int> id) & -> void;
 
-#line 2006 "reflect.h2"
+#line 2026 "reflect.h2"
     public: [[nodiscard]] auto get_named_group(cpp2::impl::in<std::string> name) const& -> int;
 
-#line 2017 "reflect.h2"
+#line 2037 "reflect.h2"
     //  Position management functions
     //
     public: [[nodiscard]] auto current() const& -> char;
@@ -933,51 +943,51 @@ class parse_context
     //  Get the next token in the regex, skipping spaces according to the parameters. See `x` and `xx` modifiers.
     private: [[nodiscard]] auto get_next_position(cpp2::impl::in<bool> in_class, cpp2::impl::in<bool> no_skip) const& -> size_t;
 
-#line 2061 "reflect.h2"
+#line 2081 "reflect.h2"
     //  Return true if next token is available.
     private: [[nodiscard]] auto next_impl(cpp2::impl::in<bool> in_class, cpp2::impl::in<bool> no_skip) & -> bool;
 
-#line 2073 "reflect.h2"
+#line 2093 "reflect.h2"
     public: [[nodiscard]] auto next() & -> decltype(auto);
     public: [[nodiscard]] auto next_in_class() & -> decltype(auto);
     public: [[nodiscard]] auto next_no_skip() & -> decltype(auto);
 
     public: [[nodiscard]] auto next_n(cpp2::impl::in<int> n) & -> bool;
 
-#line 2086 "reflect.h2"
+#line 2106 "reflect.h2"
     public: [[nodiscard]] auto has_next() const& -> bool;
 
     private: [[nodiscard]] auto grab_until_impl(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r, cpp2::impl::in<bool> any) & -> bool;
 
-#line 2109 "reflect.h2"
+#line 2129 "reflect.h2"
     public: [[nodiscard]] auto grab_until(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r) & -> decltype(auto);
     public: [[nodiscard]] auto grab_until(cpp2::impl::in<char> e, cpp2::impl::out<std::string> r) & -> decltype(auto);
     public: [[nodiscard]] auto grab_until_one_of(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r) & -> decltype(auto);
 
     public: [[nodiscard]] auto grab_n(cpp2::impl::in<int> n, cpp2::impl::out<std::string> r) & -> bool;
 
-#line 2126 "reflect.h2"
+#line 2146 "reflect.h2"
     public: [[nodiscard]] auto grab_number() & -> std::string;
 
-#line 2147 "reflect.h2"
+#line 2167 "reflect.h2"
     private: [[nodiscard]] auto peek_impl(cpp2::impl::in<bool> in_class) const& -> char;
 
-#line 2157 "reflect.h2"
+#line 2177 "reflect.h2"
     public: [[nodiscard]] auto peek() const& -> decltype(auto);
     public: [[nodiscard]] auto peek_in_class() const& -> decltype(auto);
 
-#line 2161 "reflect.h2"
+#line 2181 "reflect.h2"
     //  Parsing functions
     //
     public: [[nodiscard]] auto parser_group_modifiers(cpp2::impl::in<std::string> change_str, expression_flags& parser_modifiers) & -> bool;
 
-#line 2217 "reflect.h2"
+#line 2237 "reflect.h2"
     public: [[nodiscard]] auto parse_until(cpp2::impl::in<char> term) & -> bool;
 
-#line 2256 "reflect.h2"
+#line 2276 "reflect.h2"
     public: [[nodiscard]] auto parse(cpp2::impl::in<std::string> modifiers) & -> bool;
 
-#line 2271 "reflect.h2"
+#line 2291 "reflect.h2"
     //  Misc functions
 
     public: [[nodiscard]] auto get_pos() const& -> decltype(auto);
@@ -989,10 +999,10 @@ class parse_context
     public: auto operator=(parse_context const&) -> void = delete;
 
 
-#line 2282 "reflect.h2"
+#line 2302 "reflect.h2"
 };
 
-#line 2285 "reflect.h2"
+#line 2305 "reflect.h2"
 //  Context for one function generation. Generation of functions can be interleaved,
 //  therefore we buffer the code for one function here.
 //
@@ -1002,16 +1012,16 @@ class generation_function_context {
 
     public: auto add_tabs(cpp2::impl::in<int> c) & -> void;
 
-#line 2299 "reflect.h2"
+#line 2319 "reflect.h2"
     public: auto remove_tabs(cpp2::impl::in<int> c) & -> void;
     public: generation_function_context(auto const& code_, auto const& tabs_);
 public: generation_function_context();
 
 
-#line 2302 "reflect.h2"
+#line 2322 "reflect.h2"
 };
 
-#line 2305 "reflect.h2"
+#line 2325 "reflect.h2"
 //  Context for generating the state machine.
 class generation_context
  {
@@ -1031,68 +1041,68 @@ class generation_context
     //  Add code line.
     public: auto add(cpp2::impl::in<std::string> s) & -> void;
 
-#line 2327 "reflect.h2"
+#line 2347 "reflect.h2"
     //  Add check for token. The check needs to be a function call that returns a boolean.
     public: auto add_check(cpp2::impl::in<std::string> check) & -> void;
 
-#line 2333 "reflect.h2"
+#line 2353 "reflect.h2"
     //  Add a stateful check. The check needs to return a `match_return`.
     public: auto add_statefull(cpp2::impl::in<std::string> next_func, cpp2::impl::in<std::string> check) & -> void;
 
-#line 2342 "reflect.h2"
+#line 2362 "reflect.h2"
     protected: auto start_func_named(cpp2::impl::in<std::string> name) & -> void;
 
-#line 2353 "reflect.h2"
+#line 2373 "reflect.h2"
     protected: [[nodiscard]] auto start_func() & -> std::string;
 
-#line 2360 "reflect.h2"
+#line 2380 "reflect.h2"
     protected: auto end_func_statefull(cpp2::impl::in<std::string> s) & -> void;
 
-#line 2379 "reflect.h2"
+#line 2399 "reflect.h2"
     //  Generate the function for a token.
     public: [[nodiscard]] auto generate_func(cpp2::impl::in<token_ptr> token) & -> std::string;
 
-#line 2389 "reflect.h2"
+#line 2409 "reflect.h2"
     //  Generate the reset for a list of group identifiers.
     public: [[nodiscard]] auto generate_reset(cpp2::impl::in<std::set<int>> groups) & -> std::string;
 
-#line 2412 "reflect.h2"
+#line 2432 "reflect.h2"
     //  Name generation
     //
     protected: [[nodiscard]] auto gen_func_name() & -> std::string;
 
-#line 2420 "reflect.h2"
+#line 2440 "reflect.h2"
     public: [[nodiscard]] auto next_func_name() & -> std::string;
 
-#line 2424 "reflect.h2"
+#line 2444 "reflect.h2"
     protected: [[nodiscard]] auto gen_reset_func_name() & -> std::string;
 
-#line 2430 "reflect.h2"
+#line 2450 "reflect.h2"
     public: [[nodiscard]] auto gen_temp() & -> std::string;
 
-#line 2436 "reflect.h2"
+#line 2456 "reflect.h2"
     //  Context management
     //
     public: [[nodiscard]] auto new_context() & -> generation_function_context*;
 
-#line 2446 "reflect.h2"
+#line 2466 "reflect.h2"
     public: auto finish_context() & -> void;
 
-#line 2454 "reflect.h2"
+#line 2474 "reflect.h2"
     //  Misc functions
     //
     private: [[nodiscard]] auto get_current() & -> generation_function_context*;
 
-#line 2460 "reflect.h2"
+#line 2480 "reflect.h2"
     private: [[nodiscard]] auto get_base() & -> generation_function_context*;
 
-#line 2464 "reflect.h2"
+#line 2484 "reflect.h2"
     public: [[nodiscard]] auto get_entry_func() const& -> std::string;
 
-#line 2468 "reflect.h2"
+#line 2488 "reflect.h2"
     public: [[nodiscard]] auto create_named_group_lookup(cpp2::impl::in<std::map<std::string,int>> named_groups) const& -> std::string;
 
-#line 2492 "reflect.h2"
+#line 2512 "reflect.h2"
     //  Run the generation for the token.
     public: [[nodiscard]] auto run(cpp2::impl::in<token_ptr> token) & -> std::string;
     public: generation_context() = default;
@@ -1100,7 +1110,7 @@ class generation_context
     public: auto operator=(generation_context const&) -> void = delete;
 
 
-#line 2498 "reflect.h2"
+#line 2518 "reflect.h2"
 };
 
 //  Regex syntax: |  Example: ab|ba
@@ -1120,44 +1130,47 @@ class alternative_token
     public: auto operator=(alternative_token const&) -> void = delete;
 
 
-#line 2517 "reflect.h2"
+#line 2537 "reflect.h2"
 };
 
 class alternative_token_gen
 : public regex_token {
 
-#line 2523 "reflect.h2"
+#line 2543 "reflect.h2"
     private: token_vec alternatives; 
 
     public: explicit alternative_token_gen(cpp2::impl::in<token_vec> a);
 
-#line 2530 "reflect.h2"
+#line 2550 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2547 "reflect.h2"
+#line 2567 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
 
-#line 2554 "reflect.h2"
+#line 2574 "reflect.h2"
     public: [[nodiscard]] static auto gen_string(cpp2::impl::in<token_vec> a) -> std::string;
+
+#line 2587 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
     public: virtual ~alternative_token_gen() noexcept;
 
     public: alternative_token_gen(alternative_token_gen const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(alternative_token_gen const&) -> void = delete;
 
 
-#line 2566 "reflect.h2"
+#line 2599 "reflect.h2"
 };
 
-#line 2569 "reflect.h2"
+#line 2602 "reflect.h2"
 //  Regex syntax: .
 //
 class any_token
 : public regex_token_check {
 
-#line 2575 "reflect.h2"
+#line 2608 "reflect.h2"
     public: explicit any_token(cpp2::impl::in<bool> single_line);
 
-#line 2579 "reflect.h2"
+#line 2612 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
     public: virtual ~any_token() noexcept;
 
@@ -1165,37 +1178,43 @@ class any_token
     public: auto operator=(any_token const&) -> void = delete;
 
 
-#line 2584 "reflect.h2"
+#line 2617 "reflect.h2"
 };
 
-#line 2587 "reflect.h2"
+#line 2620 "reflect.h2"
 //  Regex syntax: a
 //
 class char_token
 : public regex_token {
 
-#line 2593 "reflect.h2"
+#line 2626 "reflect.h2"
     private: std::string token; 
     private: bool ignore_case; 
 
     public: explicit char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_);
 
-#line 2602 "reflect.h2"
+#line 2635 "reflect.h2"
+    public: explicit char_token(cpp2::impl::in<std::string> t, cpp2::impl::in<bool> ignore_case_);
+
+#line 2641 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 2606 "reflect.h2"
+#line 2645 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2629 "reflect.h2"
+#line 2668 "reflect.h2"
     public: auto gen_case_insensitive(cpp2::impl::in<std::string> lower, cpp2::impl::in<std::string> upper, generation_context& ctx) const& -> void;
 
-#line 2650 "reflect.h2"
+#line 2689 "reflect.h2"
     public: auto gen_case_sensitive(generation_context& ctx) const& -> void;
 
-#line 2668 "reflect.h2"
+#line 2707 "reflect.h2"
     public: [[nodiscard]] auto add_escapes(std::string str) const& -> std::string;
 
-#line 2683 "reflect.h2"
+#line 2722 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
+
+#line 2728 "reflect.h2"
     public: auto append(char_token const& that) & -> void;
     public: virtual ~char_token() noexcept;
 
@@ -1203,30 +1222,33 @@ class char_token
     public: auto operator=(char_token const&) -> void = delete;
 
 
-#line 2687 "reflect.h2"
+#line 2732 "reflect.h2"
 };
 
-#line 2690 "reflect.h2"
+#line 2735 "reflect.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 class class_token
 : public regex_token {
 
-#line 2696 "reflect.h2"
+#line 2741 "reflect.h2"
     private: bool negate; 
     private: bool case_insensitive; 
     private: std::string class_str; 
 
     public: explicit class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str);
 
-#line 2708 "reflect.h2"
+#line 2753 "reflect.h2"
     //  TODO: Rework class generation: Generate check functions for classes.
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 2834 "reflect.h2"
+#line 2879 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
+
+#line 2888 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2839 "reflect.h2"
+#line 2893 "reflect.h2"
     private: [[nodiscard]] static auto create_matcher(cpp2::impl::in<std::string> name, cpp2::impl::in<std::string> template_arguments) -> std::string;
     public: virtual ~class_token() noexcept;
 
@@ -1234,20 +1256,20 @@ class class_token
     public: auto operator=(class_token const&) -> void = delete;
 
 
-#line 2846 "reflect.h2"
+#line 2900 "reflect.h2"
 };
 
-#line 2849 "reflect.h2"
+#line 2903 "reflect.h2"
 //  Regex syntax: \a or \n or \[
 //
 [[nodiscard]] auto escape_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 2890 "reflect.h2"
+#line 2944 "reflect.h2"
 //  Regex syntax: \K Example: ab\Kcd
 //
 [[nodiscard]] auto global_group_reset_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 2901 "reflect.h2"
+#line 2955 "reflect.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -1257,16 +1279,20 @@ class class_token
 class group_ref_token
 : public regex_token {
 
-#line 2911 "reflect.h2"
+#line 2965 "reflect.h2"
     private: int id; 
     private: bool case_insensitive; 
+    private: bool reverse_eval; 
 
-    public: explicit group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> str);
+    public: explicit group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<bool> reverse_, cpp2::impl::in<std::string> str);
 
-#line 2921 "reflect.h2"
+#line 2977 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3022 "reflect.h2"
+#line 3078 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
+
+#line 3082 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
     public: virtual ~group_ref_token() noexcept;
 
@@ -1274,10 +1300,10 @@ class group_ref_token
     public: auto operator=(group_ref_token const&) -> void = delete;
 
 
-#line 3025 "reflect.h2"
+#line 3085 "reflect.h2"
 };
 
-#line 3028 "reflect.h2"
+#line 3088 "reflect.h2"
 //  Regex syntax: (<tokens>)      Example: (abc)
 //                (?<modifiers)            (?i)
 //                (?<modifiers>:<tokens>)  (?i:abc)
@@ -1291,22 +1317,26 @@ class group_ref_token
 class group_token
 : public regex_token {
 
-#line 3042 "reflect.h2"
+#line 3102 "reflect.h2"
     private: int number {-1}; 
+    private: bool reverse_eval {false}; 
     private: token_ptr inner {nullptr}; 
 
     public: [[nodiscard]] static auto parse_lookahead(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> positive) -> token_ptr;
 
-#line 3059 "reflect.h2"
+#line 3120 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3196 "reflect.h2"
+#line 3257 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
+
+#line 3265 "reflect.h2"
     public: [[nodiscard]] static auto gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string;
 
-#line 3214 "reflect.h2"
+#line 3283 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3234 "reflect.h2"
+#line 3314 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~group_token() noexcept;
 
@@ -1315,25 +1345,25 @@ class group_token
     public: auto operator=(group_token const&) -> void = delete;
 
 
-#line 3241 "reflect.h2"
+#line 3321 "reflect.h2"
 };
 
-#line 3244 "reflect.h2"
+#line 3324 "reflect.h2"
 //  Regex syntax: \x<number> or \x{<number>}  Example: \x{62}
 //
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3285 "reflect.h2"
+#line 3365 "reflect.h2"
 //  Regex syntax: $  Example: aa$
 //
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3305 "reflect.h2"
+#line 3385 "reflect.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3321 "reflect.h2"
+#line 3401 "reflect.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
@@ -1341,16 +1371,19 @@ class group_token
 class lookahead_token
 : public regex_token {
 
-#line 3329 "reflect.h2"
+#line 3409 "reflect.h2"
     protected: bool positive; 
     public:   token_ptr inner {nullptr}; 
 
     public: explicit lookahead_token(cpp2::impl::in<bool> positive_);
 
-#line 3336 "reflect.h2"
+#line 3416 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3342 "reflect.h2"
+#line 3422 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
+
+#line 3426 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~lookahead_token() noexcept;
 
@@ -1358,26 +1391,26 @@ class lookahead_token
     public: auto operator=(lookahead_token const&) -> void = delete;
 
 
-#line 3345 "reflect.h2"
+#line 3429 "reflect.h2"
 };
 
-#line 3348 "reflect.h2"
+#line 3432 "reflect.h2"
 // Named character classes
 //
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3376 "reflect.h2"
+#line 3460 "reflect.h2"
 //  Regex syntax: \o{<number>}  Example: \o{142}
 //
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3404 "reflect.h2"
+#line 3488 "reflect.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 class range_token
 : public regex_token {
 
-#line 3410 "reflect.h2"
+#line 3494 "reflect.h2"
               protected: int min_count {-1}; 
               protected: int max_count {-1}; 
               protected: int kind {range_flags::greedy}; 
@@ -1387,19 +1420,22 @@ class range_token
 
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3490 "reflect.h2"
+#line 3574 "reflect.h2"
     public: auto parse_modifier(parse_context& ctx) & -> void;
 
-#line 3502 "reflect.h2"
+#line 3586 "reflect.h2"
     public: [[nodiscard]] auto gen_mod_string() const& -> std::string;
 
-#line 3515 "reflect.h2"
+#line 3599 "reflect.h2"
     public: [[nodiscard]] auto gen_range_string() const& -> std::string;
 
-#line 3534 "reflect.h2"
+#line 3618 "reflect.h2"
+    public: [[nodiscard]] auto reverse() const -> token_ptr override;
+
+#line 3628 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3545 "reflect.h2"
+#line 3639 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~range_token() noexcept;
 
@@ -1407,16 +1443,16 @@ class range_token
     public: auto operator=(range_token const&) -> void = delete;
 
 
-#line 3549 "reflect.h2"
+#line 3643 "reflect.h2"
 };
 
-#line 3552 "reflect.h2"
+#line 3646 "reflect.h2"
 //  Regex syntax: *, +, or ?  Example: aa*
 //
 class special_range_token
 : public range_token {
 
-#line 3558 "reflect.h2"
+#line 3652 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
     public: virtual ~special_range_token() noexcept;
 
@@ -1425,7 +1461,7 @@ class special_range_token
     public: auto operator=(special_range_token const&) -> void = delete;
 
 
-#line 3588 "reflect.h2"
+#line 3682 "reflect.h2"
 };
 
 //  Regex syntax: \G  Example: \Gaa
@@ -1434,14 +1470,14 @@ class special_range_token
 //
 [[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr;
 
-#line 3610 "reflect.h2"
+#line 3704 "reflect.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3632 "reflect.h2"
+#line 3726 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  Parser for regular expression.
@@ -1462,24 +1498,24 @@ template<typename Error_out> class regex_generator
 
     public: explicit regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e);
 
-#line 3655 "reflect.h2"
+#line 3749 "reflect.h2"
     public: [[nodiscard]] auto parse() & -> std::string;
 
-#line 3692 "reflect.h2"
+#line 3786 "reflect.h2"
     private: auto extract_modifiers() & -> void;
     public: regex_generator(regex_generator const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_generator const&) -> void = delete;
 
 
-#line 3706 "reflect.h2"
+#line 3800 "reflect.h2"
 };
 
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string;
 
-#line 3718 "reflect.h2"
+#line 3812 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void;
 
-#line 3773 "reflect.h2"
+#line 3867 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  apply_metafunctions
@@ -1490,7 +1526,7 @@ auto regex_gen(meta::type_declaration& t) -> void;
     auto const& error
     ) -> bool;
 
-#line 3890 "reflect.h2"
+#line 3984 "reflect.h2"
 }
 
 }
@@ -3478,83 +3514,93 @@ std::string str {s}; return from_string(cpp2::string_util::replace_all(cpp2::mov
 
     //parse: (inout ctx: parse_context) -> token_ptr;
                                                                        // Generate the matching code.
+                                                                       // Create a reverse token for look behind expressions.
 
-#line 1679 "reflect.h2"
-    auto regex_token::add_groups([[maybe_unused]] std::set<int>& unnamed_param_2) const -> void{}// Adds all group indices to the set.
 #line 1680 "reflect.h2"
-    [[nodiscard]] auto regex_token::to_string() const& -> std::string{return string_rep; }// Create a string representation.
+    auto regex_token::add_groups([[maybe_unused]] std::set<int>& unnamed_param_2) const -> void{}// Adds all group indices to the set.
 #line 1681 "reflect.h2"
+    [[nodiscard]] auto regex_token::to_string() const& -> std::string{return string_rep; }// Create a string representation.
+#line 1682 "reflect.h2"
     auto regex_token::set_string(cpp2::impl::in<std::string> s) & -> void{string_rep = s; }
 
     regex_token::~regex_token() noexcept{}// Set the string representation.
 
-#line 1696 "reflect.h2"
+#line 1697 "reflect.h2"
     regex_token_check::regex_token_check(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> check_)
         : regex_token{ str }
         , check{ check_ }{
 
-#line 1699 "reflect.h2"
+#line 1700 "reflect.h2"
     }
 
-#line 1701 "reflect.h2"
+#line 1702 "reflect.h2"
     auto regex_token_check::generate_code(generation_context& ctx) const -> void{
         ctx.add_check(check + "(" + ctx.match_parameters() + ")");
     }
 
+#line 1706 "reflect.h2"
+    [[nodiscard]] auto regex_token_check::reverse() const -> token_ptr { return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_check>)(cpp2::shared, CPP2_UFCS(to_string)((*this)), (*this).check);  }
+
     regex_token_check::~regex_token_check() noexcept{}
 
-#line 1715 "reflect.h2"
+#line 1718 "reflect.h2"
     regex_token_code::regex_token_code(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> code_)
         : regex_token{ str }
         , code{ code_ }{
 
-#line 1718 "reflect.h2"
+#line 1721 "reflect.h2"
     }
 
-#line 1720 "reflect.h2"
+#line 1723 "reflect.h2"
     auto regex_token_code::generate_code(generation_context& ctx) const -> void{
         ctx.add(code);
     }
 
+#line 1727 "reflect.h2"
+    [[nodiscard]] auto regex_token_code::reverse() const -> token_ptr { return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_code>)(cpp2::shared, CPP2_UFCS(to_string)((*this)), (*this).code);  }
+
     regex_token_code::~regex_token_code() noexcept{}
 
-#line 1732 "reflect.h2"
+#line 1737 "reflect.h2"
     regex_token_empty::regex_token_empty(cpp2::impl::in<std::string> str)
         : regex_token{ str }{
 
-#line 1734 "reflect.h2"
+#line 1739 "reflect.h2"
     }
 
-#line 1736 "reflect.h2"
+#line 1741 "reflect.h2"
     auto regex_token_empty::generate_code([[maybe_unused]] generation_context& unnamed_param_2) const -> void{
         // Nothing.
     }
 
+#line 1745 "reflect.h2"
+    [[nodiscard]] auto regex_token_empty::reverse() const -> token_ptr { return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_empty>)(cpp2::shared, CPP2_UFCS(to_string)((*this)));  }
+
     regex_token_empty::~regex_token_empty() noexcept{}
 
-#line 1750 "reflect.h2"
+#line 1757 "reflect.h2"
     regex_token_list::regex_token_list(cpp2::impl::in<token_vec> t)
         : regex_token{ gen_string(t) }
         , tokens{ t }{
 
-#line 1753 "reflect.h2"
+#line 1760 "reflect.h2"
     }
 
-#line 1755 "reflect.h2"
+#line 1762 "reflect.h2"
     auto regex_token_list::generate_code(generation_context& ctx) const -> void{
         for ( auto const& token : tokens ) {
             (*cpp2::impl::assert_not_null(token)).generate_code(ctx);
         }
     }
 
-#line 1761 "reflect.h2"
+#line 1768 "reflect.h2"
     auto regex_token_list::add_groups(std::set<int>& groups) const -> void{
         for ( auto const& token : tokens ) {
             (*cpp2::impl::assert_not_null(token)).add_groups(groups);
         }
     }
 
-#line 1767 "reflect.h2"
+#line 1774 "reflect.h2"
     [[nodiscard]] auto regex_token_list::gen_string(cpp2::impl::in<token_vec> vec) -> std::string{
         std::string r {""}; 
         for ( auto const& token : vec ) {
@@ -3563,9 +3609,23 @@ std::string str {s}; return from_string(cpp2::string_util::replace_all(cpp2::mov
         return r; 
     }
 
+#line 1782 "reflect.h2"
+    [[nodiscard]] auto regex_token_list::reverse() const -> token_ptr{
+        int s {cpp2::unchecked_narrow<int>(tokens.size())}; 
+
+        token_vec reverse_vec {}; 
+        reverse_vec.resize(s);
+
+        int i {0}; 
+        for( ; cpp2::impl::cmp_less(i,CPP2_UFCS(ssize)(tokens)); (i += 1) ) {
+            CPP2_ASSERT_IN_BOUNDS(reverse_vec, s - 1 - i) = CPP2_UFCS(reverse)((*cpp2::impl::assert_not_null(CPP2_ASSERT_IN_BOUNDS(tokens, i))));
+        }
+        return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_list>)(cpp2::shared, cpp2::move(reverse_vec)); 
+    }
+
     regex_token_list::~regex_token_list() noexcept{}
 
-#line 1790 "reflect.h2"
+#line 1810 "reflect.h2"
     auto parse_context_group_state::next_alternative() & -> void{
         token_vec new_list {}; 
         std::swap(new_list, cur_match_list);
@@ -3573,14 +3633,14 @@ std::string str {s}; return from_string(cpp2::string_util::replace_all(cpp2::mov
         static_cast<void>(alternate_match_lists.insert(alternate_match_lists.end(), CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_list>)(cpp2::shared, cpp2::move(new_list))));
     }
 
-#line 1798 "reflect.h2"
+#line 1818 "reflect.h2"
     auto parse_context_group_state::swap(parse_context_group_state& t) & -> void{// NOLINT(performance-noexcept-swap)
         std::swap(cur_match_list, t.cur_match_list);
         std::swap(alternate_match_lists, t.alternate_match_lists);
         std::swap(modifiers, t.modifiers);
     }
 
-#line 1805 "reflect.h2"
+#line 1825 "reflect.h2"
     [[nodiscard]] auto parse_context_group_state::get_as_token() & -> token_ptr{
         if (alternate_match_lists.empty()) {
             post_process_list(cur_match_list);
@@ -3592,15 +3652,15 @@ std::string str {s}; return from_string(cpp2::string_util::replace_all(cpp2::mov
         }
     }
 
-#line 1817 "reflect.h2"
+#line 1837 "reflect.h2"
     auto parse_context_group_state::add(cpp2::impl::in<token_ptr> token) & -> void{
         cur_match_list.push_back(token);
     }
 
-#line 1822 "reflect.h2"
+#line 1842 "reflect.h2"
     [[nodiscard]] auto parse_context_group_state::empty() const& -> bool { return cur_match_list.empty();  }
 
-#line 1826 "reflect.h2"
+#line 1846 "reflect.h2"
     auto parse_context_group_state::post_process_list(token_vec& list) -> void{
         // Merge all characters
         auto merge_pos {list.begin()}; 
@@ -3621,7 +3681,7 @@ std::string str {s}; return from_string(cpp2::string_util::replace_all(cpp2::mov
                                                                                               , modifiers{ modifiers_ }{}
 parse_context_group_state::parse_context_group_state(){}
 
-#line 1852 "reflect.h2"
+#line 1872 "reflect.h2"
     [[nodiscard]] auto parse_context_branch_reset_state::next() & -> int{
         auto g {cur_group}; 
         cur_group += 1;
@@ -3630,20 +3690,20 @@ parse_context_group_state::parse_context_group_state(){}
         return g; 
     }
 
-#line 1861 "reflect.h2"
+#line 1881 "reflect.h2"
     auto parse_context_branch_reset_state::set_next(cpp2::impl::in<int> g) & -> void{
         cur_group = g;
         max_group = max(max_group, g);
     }
 
-#line 1867 "reflect.h2"
+#line 1887 "reflect.h2"
     auto parse_context_branch_reset_state::next_alternative() & -> void{
         if (is_active) {
             cur_group = from;
         }
     }
 
-#line 1874 "reflect.h2"
+#line 1894 "reflect.h2"
     auto parse_context_branch_reset_state::set_active_reset(cpp2::impl::in<int> restart) & -> void{
         is_active = true;
         cur_group = restart;
@@ -3658,16 +3718,16 @@ parse_context_group_state::parse_context_group_state(){}
                                                                                     , from{ from_ }{}
 parse_context_branch_reset_state::parse_context_branch_reset_state(){}
 
-#line 1904 "reflect.h2"
+#line 1924 "reflect.h2"
     parse_context::parse_context(cpp2::impl::in<std::string_view> r, auto const& e)
         : regex{ r }
         , root{ CPP2_UFCS_TEMPLATE_NONLOCAL(cpp2_new<regex_token_empty>)(cpp2::shared, "") }
         , error_out{ e }{
 
-#line 1908 "reflect.h2"
+#line 1928 "reflect.h2"
     }
 
-#line 1914 "reflect.h2"
+#line 1934 "reflect.h2"
     [[nodiscard]] auto parse_context::start_group() & -> parse_context_group_state
     {
         parse_context_group_state old_state {}; 
@@ -3677,7 +3737,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return old_state; 
     }
 
-#line 1924 "reflect.h2"
+#line 1944 "reflect.h2"
     [[nodiscard]] auto parse_context::end_group(cpp2::impl::in<parse_context_group_state> old_state) & -> token_ptr
     {
         auto inner {cur_group_state.get_as_token()}; 
@@ -3685,17 +3745,17 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return inner; 
     }
 
-#line 1931 "reflect.h2"
+#line 1951 "reflect.h2"
     [[nodiscard]] auto parse_context::get_modifiers() const& -> expression_flags{
         return cur_group_state.modifiers; 
     }
 
-#line 1935 "reflect.h2"
+#line 1955 "reflect.h2"
     auto parse_context::set_modifiers(cpp2::impl::in<expression_flags> mod) & -> void{
         cur_group_state.modifiers = mod;
     }
 
-#line 1942 "reflect.h2"
+#line 1962 "reflect.h2"
     [[nodiscard]] auto parse_context::branch_reset_new_state() & -> parse_context_branch_reset_state
     {
         parse_context_branch_reset_state old_state {}; 
@@ -3705,7 +3765,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return old_state; 
     }
 
-#line 1951 "reflect.h2"
+#line 1971 "reflect.h2"
     auto parse_context::branch_reset_restore_state(cpp2::impl::in<parse_context_branch_reset_state> old_state) & -> void
     {
         auto max_group {cur_branch_reset_state.max_group}; 
@@ -3713,24 +3773,24 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         cur_branch_reset_state.set_next(cpp2::move(max_group));
     }
 
-#line 1958 "reflect.h2"
+#line 1978 "reflect.h2"
     auto parse_context::next_alternative() & -> void
     {
         cur_group_state.next_alternative();
         cur_branch_reset_state.next_alternative();
     }
 
-#line 1966 "reflect.h2"
+#line 1986 "reflect.h2"
     auto parse_context::add_token(cpp2::impl::in<token_ptr> token) & -> void{
         cur_group_state.add(token);
     }
 
-#line 1970 "reflect.h2"
+#line 1990 "reflect.h2"
     [[nodiscard]] auto parse_context::has_token() const& -> bool{
         return !(cur_group_state.empty()); 
     }
 
-#line 1974 "reflect.h2"
+#line 1994 "reflect.h2"
     [[nodiscard]] auto parse_context::pop_token() & -> token_ptr
     {
         token_ptr r {nullptr}; 
@@ -3742,22 +3802,22 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return r; 
     }
 
-#line 1985 "reflect.h2"
+#line 2005 "reflect.h2"
     [[nodiscard]] auto parse_context::get_as_token() & -> token_ptr{
         return root; 
     }
 
-#line 1991 "reflect.h2"
+#line 2011 "reflect.h2"
     [[nodiscard]] auto parse_context::get_cur_group() const& -> int{
         return cur_branch_reset_state.cur_group; 
     }
 
-#line 1995 "reflect.h2"
+#line 2015 "reflect.h2"
     [[nodiscard]] auto parse_context::next_group() & -> int{
         return cur_branch_reset_state.next(); 
     }
 
-#line 1999 "reflect.h2"
+#line 2019 "reflect.h2"
     auto parse_context::set_named_group(cpp2::impl::in<std::string> name, cpp2::impl::in<int> id) & -> void
     {
         if (!(named_groups.contains(name))) {// Redefinition of group name is not an error. The left most one is retained.
@@ -3765,7 +3825,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2006 "reflect.h2"
+#line 2026 "reflect.h2"
     [[nodiscard]] auto parse_context::get_named_group(cpp2::impl::in<std::string> name) const& -> int
     {
         auto iter {named_groups.find(name)}; 
@@ -3777,10 +3837,10 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2019 "reflect.h2"
+#line 2039 "reflect.h2"
     [[nodiscard]] auto parse_context::current() const& -> char{return CPP2_ASSERT_IN_BOUNDS(regex, pos); }
 
-#line 2022 "reflect.h2"
+#line 2042 "reflect.h2"
     [[nodiscard]] auto parse_context::get_next_position(cpp2::impl::in<bool> in_class, cpp2::impl::in<bool> no_skip) const& -> size_t
     {
         auto perl_syntax {false}; 
@@ -3820,7 +3880,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return cur; 
     }
 
-#line 2062 "reflect.h2"
+#line 2082 "reflect.h2"
     [[nodiscard]] auto parse_context::next_impl(cpp2::impl::in<bool> in_class, cpp2::impl::in<bool> no_skip) & -> bool
     {
         pos = get_next_position(in_class, no_skip);
@@ -3832,14 +3892,14 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2073 "reflect.h2"
+#line 2093 "reflect.h2"
     [[nodiscard]] auto parse_context::next() & -> decltype(auto) { return next_impl(false, false); }
-#line 2074 "reflect.h2"
+#line 2094 "reflect.h2"
     [[nodiscard]] auto parse_context::next_in_class() & -> decltype(auto) { return next_impl(true, false);  }
-#line 2075 "reflect.h2"
+#line 2095 "reflect.h2"
     [[nodiscard]] auto parse_context::next_no_skip() & -> decltype(auto) { return next_impl(false, true); }
 
-#line 2077 "reflect.h2"
+#line 2097 "reflect.h2"
     [[nodiscard]] auto parse_context::next_n(cpp2::impl::in<int> n) & -> bool{
         auto r {true}; 
         auto cur {0}; 
@@ -3849,10 +3909,10 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return r; 
     }
 
-#line 2086 "reflect.h2"
+#line 2106 "reflect.h2"
     [[nodiscard]] auto parse_context::has_next() const& -> bool{return cpp2::impl::cmp_less(pos,regex.size()); }
 
-#line 2088 "reflect.h2"
+#line 2108 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_until_impl(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r, cpp2::impl::in<bool> any) & -> bool
     {
         auto end {pos}; // NOLINT(clang-analyzer-deadcode.DeadStores)
@@ -3874,14 +3934,14 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2109 "reflect.h2"
+#line 2129 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_until(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r) & -> decltype(auto) { return grab_until_impl(e, cpp2::impl::out(&r), false); }
-#line 2110 "reflect.h2"
+#line 2130 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_until(cpp2::impl::in<char> e, cpp2::impl::out<std::string> r) & -> decltype(auto) { return grab_until_impl(std::string(1, e), cpp2::impl::out(&r), false); }
-#line 2111 "reflect.h2"
+#line 2131 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_until_one_of(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r) & -> decltype(auto) { return grab_until_impl(e, cpp2::impl::out(&r), true);  }
 
-#line 2113 "reflect.h2"
+#line 2133 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_n(cpp2::impl::in<int> n, cpp2::impl::out<std::string> r) & -> bool
     {
         if (cpp2::impl::cmp_less_eq(pos + cpp2::impl::as_<size_t>(n),regex.size())) {
@@ -3895,7 +3955,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2126 "reflect.h2"
+#line 2146 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_number() & -> std::string
     {
         auto start {pos}; 
@@ -3917,7 +3977,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return cpp2::move(r.value()); 
     }
 
-#line 2147 "reflect.h2"
+#line 2167 "reflect.h2"
     [[nodiscard]] auto parse_context::peek_impl(cpp2::impl::in<bool> in_class) const& -> char{
         auto next_pos {get_next_position(in_class, false)}; 
         if (cpp2::impl::cmp_less(next_pos,regex.size())) {
@@ -3928,12 +3988,12 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2157 "reflect.h2"
+#line 2177 "reflect.h2"
     [[nodiscard]] auto parse_context::peek() const& -> decltype(auto) { return peek_impl(false); }
-#line 2158 "reflect.h2"
+#line 2178 "reflect.h2"
     [[nodiscard]] auto parse_context::peek_in_class() const& -> decltype(auto) { return peek_impl(true);  }
 
-#line 2163 "reflect.h2"
+#line 2183 "reflect.h2"
     [[nodiscard]] auto parse_context::parser_group_modifiers(cpp2::impl::in<std::string> change_str, expression_flags& parser_modifiers) & -> bool
     {
         auto is_negative {false}; 
@@ -3988,7 +4048,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return true; 
     }
 
-#line 2217 "reflect.h2"
+#line 2237 "reflect.h2"
     [[nodiscard]] auto parse_context::parse_until(cpp2::impl::in<char> term) & -> bool{
         token_ptr cur_token {}; 
 
@@ -4028,7 +4088,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return true; 
     }
 
-#line 2256 "reflect.h2"
+#line 2276 "reflect.h2"
     [[nodiscard]] auto parse_context::parse(cpp2::impl::in<std::string> modifiers) & -> bool
     {
 
@@ -4044,21 +4104,21 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return r; 
     }
 
-#line 2273 "reflect.h2"
+#line 2293 "reflect.h2"
     [[nodiscard]] auto parse_context::get_pos() const& -> decltype(auto) { return pos; }
-#line 2274 "reflect.h2"
+#line 2294 "reflect.h2"
     [[nodiscard]] auto parse_context::get_range(cpp2::impl::in<size_t> start, cpp2::impl::in<size_t> end) const& -> decltype(auto) { return std::string(regex.substr(start, end - start + 1));  }
-#line 2275 "reflect.h2"
+#line 2295 "reflect.h2"
     [[nodiscard]] auto parse_context::valid() const& -> bool{return has_next() && !(has_error); }
 
-#line 2277 "reflect.h2"
+#line 2297 "reflect.h2"
     [[nodiscard]] auto parse_context::error(cpp2::impl::in<std::string> err) & -> token_ptr{
         has_error = true;
         error_out("Error during parsing of regex '" + cpp2::to_string(regex) + "' at position '" + cpp2::to_string(pos) + "': " + cpp2::to_string(err) + "");
         return nullptr; 
     }
 
-#line 2292 "reflect.h2"
+#line 2312 "reflect.h2"
     auto generation_function_context::add_tabs(cpp2::impl::in<int> c) & -> void{
         int i {0}; 
         for( ; cpp2::impl::cmp_less(i,c); i += 1 ) {
@@ -4066,7 +4126,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2299 "reflect.h2"
+#line 2319 "reflect.h2"
     auto generation_function_context::remove_tabs(cpp2::impl::in<int> c) & -> void{
         tabs = tabs.substr(0, (cpp2::impl::as_<size_t>(c)) * 2);
     }
@@ -4076,22 +4136,22 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
                                                        , tabs{ tabs_ }{}
 generation_function_context::generation_function_context(){}
 
-#line 2317 "reflect.h2"
+#line 2337 "reflect.h2"
     [[nodiscard]] auto generation_context::match_parameters() const& -> std::string{return "r.pos, ctx"; }
 
-#line 2322 "reflect.h2"
+#line 2342 "reflect.h2"
     auto generation_context::add(cpp2::impl::in<std::string> s) & -> void{
         auto cur {get_current()}; 
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + cpp2::to_string(s) + "\n";
     }
 
-#line 2328 "reflect.h2"
+#line 2348 "reflect.h2"
     auto generation_context::add_check(cpp2::impl::in<std::string> check) & -> void{
         auto cur {get_current()}; 
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "if !cpp2::regex::" + cpp2::to_string(check) + " { r.matched = false; break; }\n";
     }
 
-#line 2334 "reflect.h2"
+#line 2354 "reflect.h2"
     auto generation_context::add_statefull(cpp2::impl::in<std::string> next_func, cpp2::impl::in<std::string> check) & -> void
     {
         end_func_statefull(check);
@@ -4100,7 +4160,7 @@ generation_function_context::generation_function_context(){}
         start_func_named(cpp2::move(name));
     }
 
-#line 2342 "reflect.h2"
+#line 2362 "reflect.h2"
     auto generation_context::start_func_named(cpp2::impl::in<std::string> name) & -> void
     {
         auto cur {new_context()}; 
@@ -4112,7 +4172,7 @@ generation_function_context::generation_function_context(){}
         (*cpp2::impl::assert_not_null(cpp2::move(cur))).add_tabs(3);
     }
 
-#line 2353 "reflect.h2"
+#line 2373 "reflect.h2"
     [[nodiscard]] auto generation_context::start_func() & -> std::string
     {
         auto name {gen_func_name()}; 
@@ -4120,7 +4180,7 @@ generation_function_context::generation_function_context(){}
         return cpp2::move(name) + "()"; 
     }
 
-#line 2360 "reflect.h2"
+#line 2380 "reflect.h2"
     auto generation_context::end_func_statefull(cpp2::impl::in<std::string> s) & -> void
     {
         auto cur {get_current()}; 
@@ -4140,7 +4200,7 @@ generation_function_context::generation_function_context(){}
         finish_context();
     }
 
-#line 2380 "reflect.h2"
+#line 2400 "reflect.h2"
     [[nodiscard]] auto generation_context::generate_func(cpp2::impl::in<token_ptr> token) & -> std::string
     {
         auto name {start_func()}; 
@@ -4150,7 +4210,7 @@ generation_function_context::generation_function_context(){}
         return name; 
     }
 
-#line 2390 "reflect.h2"
+#line 2410 "reflect.h2"
     [[nodiscard]] auto generation_context::generate_reset(cpp2::impl::in<std::set<int>> groups) & -> std::string
     {
         if (groups.empty()) {
@@ -4173,33 +4233,33 @@ generation_function_context::generation_function_context(){}
         return cpp2::move(name) + "()"; 
     }
 
-#line 2414 "reflect.h2"
+#line 2434 "reflect.h2"
     [[nodiscard]] auto generation_context::gen_func_name() & -> std::string{
         auto cur_id {matcher_func}; 
         matcher_func += 1;
         return "func_" + cpp2::to_string(cpp2::move(cur_id)) + ""; 
     }
 
-#line 2420 "reflect.h2"
+#line 2440 "reflect.h2"
     [[nodiscard]] auto generation_context::next_func_name() & -> std::string{
         return gen_func_name() + "()"; 
     }
 
-#line 2424 "reflect.h2"
+#line 2444 "reflect.h2"
     [[nodiscard]] auto generation_context::gen_reset_func_name() & -> std::string{
         auto cur_id {reset_func}; 
         reset_func += 1;
         return "reset_" + cpp2::to_string(cpp2::move(cur_id)) + ""; 
     }
 
-#line 2430 "reflect.h2"
+#line 2450 "reflect.h2"
     [[nodiscard]] auto generation_context::gen_temp() & -> std::string{
         auto cur_id {temp_name}; 
         temp_name += 1;
         return "tmp_" + cpp2::to_string(cpp2::move(cur_id)) + ""; 
     }
 
-#line 2438 "reflect.h2"
+#line 2458 "reflect.h2"
     [[nodiscard]] auto generation_context::new_context() & -> generation_function_context*{
         gen_stack.push_back(generation_function_context());
         auto cur {get_current()}; 
@@ -4208,7 +4268,7 @@ generation_function_context::generation_function_context(){}
         return cur; 
     }
 
-#line 2446 "reflect.h2"
+#line 2466 "reflect.h2"
     auto generation_context::finish_context() & -> void{
         auto cur {get_current()}; 
         auto base {get_base()}; 
@@ -4217,22 +4277,22 @@ generation_function_context::generation_function_context(){}
         gen_stack.pop_back();
     }
 
-#line 2456 "reflect.h2"
+#line 2476 "reflect.h2"
     [[nodiscard]] auto generation_context::get_current() & -> generation_function_context*{
         return &gen_stack.back(); 
     }
 
-#line 2460 "reflect.h2"
+#line 2480 "reflect.h2"
     [[nodiscard]] auto generation_context::get_base() & -> generation_function_context*{
         return &CPP2_ASSERT_IN_BOUNDS_LITERAL(gen_stack, 0); 
     }
 
-#line 2464 "reflect.h2"
+#line 2484 "reflect.h2"
     [[nodiscard]] auto generation_context::get_entry_func() const& -> std::string{
         return entry_func; 
     }
 
-#line 2468 "reflect.h2"
+#line 2488 "reflect.h2"
     [[nodiscard]] auto generation_context::create_named_group_lookup(cpp2::impl::in<std::map<std::string,int>> named_groups) const& -> std::string
     {
         std::string res {"get_named_group_index: (name) -> int = {\n"}; 
@@ -4256,18 +4316,18 @@ generation_function_context::generation_function_context(){}
         return res; 
     }
 
-#line 2493 "reflect.h2"
+#line 2513 "reflect.h2"
     [[nodiscard]] auto generation_context::run(cpp2::impl::in<token_ptr> token) & -> std::string{
         entry_func = generate_func(token);
 
         return (*cpp2::impl::assert_not_null(get_base())).code; 
     }
 
-#line 2508 "reflect.h2"
+#line 2528 "reflect.h2"
     alternative_token::alternative_token()
                             : regex_token_empty{ "" }{}
 
-#line 2510 "reflect.h2"
+#line 2530 "reflect.h2"
     [[nodiscard]] auto alternative_token::parse(parse_context& ctx) -> token_ptr{
         if (ctx.current() != '|') {return nullptr; }
 
@@ -4278,15 +4338,15 @@ generation_function_context::generation_function_context(){}
 
     alternative_token::~alternative_token() noexcept{}
 
-#line 2525 "reflect.h2"
+#line 2545 "reflect.h2"
     alternative_token_gen::alternative_token_gen(cpp2::impl::in<token_vec> a)
         : regex_token{ gen_string(a) }
         , alternatives{ a }{
 
-#line 2528 "reflect.h2"
+#line 2548 "reflect.h2"
     }
 
-#line 2530 "reflect.h2"
+#line 2550 "reflect.h2"
     auto alternative_token_gen::generate_code(generation_context& ctx) const -> void
     {
         std::string functions {""}; 
@@ -4304,7 +4364,7 @@ generation_function_context::generation_function_context(){}
         ctx.add_statefull(next_name, "cpp2::regex::alternative_token_matcher<char>::match(" + cpp2::to_string(ctx.match_parameters()) + ", other, " + cpp2::to_string(next_name) + " " + cpp2::to_string(cpp2::move(functions)) + ")");
     }
 
-#line 2547 "reflect.h2"
+#line 2567 "reflect.h2"
     auto alternative_token_gen::add_groups(std::set<int>& groups) const -> void
     {
         for ( auto const& cur : alternatives ) {
@@ -4312,7 +4372,7 @@ generation_function_context::generation_function_context(){}
         }
     }
 
-#line 2554 "reflect.h2"
+#line 2574 "reflect.h2"
     [[nodiscard]] auto alternative_token_gen::gen_string(cpp2::impl::in<token_vec> a) -> std::string
     {
         std::string r {""}; 
@@ -4326,16 +4386,30 @@ generation_function_context::generation_function_context(){}
         return r; 
     }
 
+#line 2587 "reflect.h2"
+    [[nodiscard]] auto alternative_token_gen::reverse() const -> token_ptr{
+        int s {cpp2::unchecked_narrow<int>(alternatives.size())}; 
+
+        token_vec reverse_vec {}; 
+        reverse_vec.resize(s);
+
+        int i {0}; 
+        for( ; cpp2::impl::cmp_less(i,s); (i += 1) ) {
+            CPP2_ASSERT_IN_BOUNDS(reverse_vec, i) = CPP2_UFCS(reverse)((*cpp2::impl::assert_not_null(CPP2_ASSERT_IN_BOUNDS(alternatives, i))));// We only reverse the alternatives, not the order in which they are checked.
+        }
+        return CPP2_UFCS_TEMPLATE(cpp2_new<alternative_token_gen>)(cpp2::shared, cpp2::move(reverse_vec)); 
+    }
+
     alternative_token_gen::~alternative_token_gen() noexcept{}
 
-#line 2575 "reflect.h2"
+#line 2608 "reflect.h2"
     any_token::any_token(cpp2::impl::in<bool> single_line)
         : regex_token_check{ ".", "any_token_matcher<char, " + cpp2::to_string(single_line) + ">" }{
 
-#line 2577 "reflect.h2"
+#line 2610 "reflect.h2"
     }
 
-#line 2579 "reflect.h2"
+#line 2612 "reflect.h2"
     [[nodiscard]] auto any_token::parse(parse_context& ctx) -> token_ptr{
         if ('.' != ctx.current()) {return nullptr; }
 
@@ -4344,21 +4418,30 @@ generation_function_context::generation_function_context(){}
 
     any_token::~any_token() noexcept{}
 
-#line 2596 "reflect.h2"
+#line 2629 "reflect.h2"
     char_token::char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_)
         : regex_token{ std::string(1, t) }
         , token{ t }
         , ignore_case{ ignore_case_ }{
 
-#line 2600 "reflect.h2"
+#line 2633 "reflect.h2"
     }
 
-#line 2602 "reflect.h2"
+#line 2635 "reflect.h2"
+    char_token::char_token(cpp2::impl::in<std::string> t, cpp2::impl::in<bool> ignore_case_)
+        : regex_token{ t }
+        , token{ t }
+        , ignore_case{ ignore_case_ }{
+
+#line 2639 "reflect.h2"
+    }
+
+#line 2641 "reflect.h2"
     [[nodiscard]] auto char_token::parse(parse_context& ctx) -> token_ptr{
         return CPP2_UFCS_TEMPLATE(cpp2_new<char_token>)(cpp2::shared, ctx.current(), ctx.get_modifiers().has(expression_flags::case_insensitive)); 
     }
 
-#line 2606 "reflect.h2"
+#line 2645 "reflect.h2"
     auto char_token::generate_code(generation_context& ctx) const -> void
     {
         if (ignore_case) {
@@ -4367,14 +4450,14 @@ generation_function_context::generation_function_context(){}
 {
 size_t i{0};
 
-#line 2612 "reflect.h2"
+#line 2651 "reflect.h2"
             for( ; cpp2::impl::cmp_less(i,token.size()); i += 1 ) {
                 CPP2_ASSERT_IN_BOUNDS(lower, i) = string_util::safe_tolower(CPP2_ASSERT_IN_BOUNDS(token, i));
                 CPP2_ASSERT_IN_BOUNDS(upper, i) = string_util::safe_toupper(CPP2_ASSERT_IN_BOUNDS(token, i));
             }
 }
 
-#line 2617 "reflect.h2"
+#line 2656 "reflect.h2"
             if (upper != lower) {
                 gen_case_insensitive(cpp2::move(lower), cpp2::move(upper), ctx);
             }
@@ -4387,7 +4470,7 @@ size_t i{0};
         }
     }
 
-#line 2629 "reflect.h2"
+#line 2668 "reflect.h2"
     auto char_token::gen_case_insensitive(cpp2::impl::in<std::string> lower, cpp2::impl::in<std::string> upper, generation_context& ctx) const& -> void
     {
         std::string name {"str_" + cpp2::to_string(ctx.gen_temp()) + ""}; 
@@ -4409,7 +4492,7 @@ size_t i{0};
         ctx.add("else { break; }");
     }
 
-#line 2650 "reflect.h2"
+#line 2689 "reflect.h2"
     auto char_token::gen_case_sensitive(generation_context& ctx) const& -> void
     {
         std::string name {"str_" + cpp2::to_string(ctx.gen_temp()) + ""}; 
@@ -4428,7 +4511,7 @@ size_t i{0};
         ctx.add("else { break; }");
     }
 
-#line 2668 "reflect.h2"
+#line 2707 "reflect.h2"
     [[nodiscard]] auto char_token::add_escapes(std::string str) const& -> std::string
     {
         str = string_util::replace_all(str, "\\", "\\\\");
@@ -4444,7 +4527,14 @@ size_t i{0};
         return cpp2::move(str); 
     }
 
-#line 2683 "reflect.h2"
+#line 2722 "reflect.h2"
+    [[nodiscard]] auto char_token::reverse() const -> token_ptr{
+        std::string reverse_str {token}; 
+        std::reverse(reverse_str.begin(), reverse_str.end());
+        return CPP2_UFCS_TEMPLATE(cpp2_new<char_token>)(cpp2::shared, cpp2::move(reverse_str), ignore_case); 
+    }
+
+#line 2728 "reflect.h2"
     auto char_token::append(char_token const& that) & -> void{
         (*this).token += that.token;
         (*this).string_rep += that.string_rep;
@@ -4452,19 +4542,19 @@ size_t i{0};
 
     char_token::~char_token() noexcept{}
 
-#line 2700 "reflect.h2"
+#line 2745 "reflect.h2"
     class_token::class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str)
         : regex_token{ str }
         , negate{ negate_ }
         , case_insensitive{ case_insensitive_ }
         , class_str{ class_str_ }
-#line 2701 "reflect.h2"
+#line 2746 "reflect.h2"
     {
 
-#line 2706 "reflect.h2"
+#line 2751 "reflect.h2"
     }
 
-#line 2709 "reflect.h2"
+#line 2754 "reflect.h2"
     [[nodiscard]] auto class_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '[') {return nullptr; }
@@ -4590,13 +4680,23 @@ size_t i{0};
             ); 
     }
 
-#line 2834 "reflect.h2"
+#line 2879 "reflect.h2"
+    [[nodiscard]] auto class_token::reverse() const -> token_ptr{
+        return CPP2_UFCS_TEMPLATE(cpp2_new<class_token>)(cpp2::shared, 
+            negate, 
+            case_insensitive, 
+            class_str, 
+            to_string()
+            ); 
+    }
+
+#line 2888 "reflect.h2"
     auto class_token::generate_code(generation_context& ctx) const -> void
     {
         ctx.add_check("class_token_matcher<char, " + cpp2::to_string(negate) + ", " + cpp2::to_string(case_insensitive) + ", " + cpp2::to_string(class_str) + ">::match(" + cpp2::to_string(ctx.match_parameters()) + ")");
     }
 
-#line 2839 "reflect.h2"
+#line 2893 "reflect.h2"
     [[nodiscard]] auto class_token::create_matcher(cpp2::impl::in<std::string> name, cpp2::impl::in<std::string> template_arguments) -> std::string
     {
         auto sep {", "}; 
@@ -4607,12 +4707,12 @@ size_t i{0};
 
     class_token::~class_token() noexcept{}
 
-#line 2851 "reflect.h2"
+#line 2905 "reflect.h2"
 [[nodiscard]] auto escape_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
 
-#line 2856 "reflect.h2"
+#line 2910 "reflect.h2"
     if (std::string::npos == std::string("afenrt^.[]()*{}?+|\\").find(ctx.peek())) {
         return nullptr; 
     }
@@ -4646,7 +4746,7 @@ size_t i{0};
 
 }
 
-#line 2892 "reflect.h2"
+#line 2946 "reflect.h2"
 [[nodiscard]] auto global_group_reset_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'K'))) {return nullptr; }
@@ -4655,18 +4755,19 @@ size_t i{0};
     return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_code>)(cpp2::shared, "\\K", "ctx..set_group_start(0, r.pos);"); 
 }
 
-#line 2914 "reflect.h2"
-    group_ref_token::group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> str)
+#line 2969 "reflect.h2"
+    group_ref_token::group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<bool> reverse_, cpp2::impl::in<std::string> str)
         : regex_token{ str }
         , id{ id_ }
         , case_insensitive{ case_insensitive_ }
-#line 2915 "reflect.h2"
+        , reverse_eval{ reverse_ }
+#line 2970 "reflect.h2"
     {
 
-#line 2919 "reflect.h2"
+#line 2975 "reflect.h2"
     }
 
-#line 2921 "reflect.h2"
+#line 2977 "reflect.h2"
     [[nodiscard]] auto group_ref_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '\\') {return nullptr; }
@@ -4765,17 +4866,22 @@ size_t i{0};
             if (-1 == group_id) {return ctx.error("Group names does not exist. (Name is: " + cpp2::to_string(cpp2::move(group)) + ")"); }
         }
 
-        return CPP2_UFCS_TEMPLATE(cpp2_new<group_ref_token>)(cpp2::shared, cpp2::move(group_id), ctx.get_modifiers().has(expression_flags::case_insensitive), cpp2::move(str)); 
+        return CPP2_UFCS_TEMPLATE(cpp2_new<group_ref_token>)(cpp2::shared, cpp2::move(group_id), ctx.get_modifiers().has(expression_flags::case_insensitive), false, cpp2::move(str)); 
     }
 
-#line 3022 "reflect.h2"
+#line 3078 "reflect.h2"
+    [[nodiscard]] auto group_ref_token::reverse() const -> token_ptr{
+        return CPP2_UFCS_TEMPLATE(cpp2_new<group_ref_token>)(cpp2::shared, id, case_insensitive, !(reverse_eval), to_string()); 
+    }
+
+#line 3082 "reflect.h2"
     auto group_ref_token::generate_code(generation_context& ctx) const -> void{
-        ctx.add_check("group_ref_token_matcher<char, " + cpp2::to_string(id) + ", " + cpp2::to_string(case_insensitive) + ">(" + cpp2::to_string(ctx.match_parameters()) + ")");
+        ctx.add_check("group_ref_token_matcher<char, " + cpp2::to_string(id) + ", " + cpp2::to_string(case_insensitive) + ", " + cpp2::to_string(reverse_eval) + ">(" + cpp2::to_string(ctx.match_parameters()) + ")");
     }
 
     group_ref_token::~group_ref_token() noexcept{}
 
-#line 3045 "reflect.h2"
+#line 3106 "reflect.h2"
     [[nodiscard]] auto group_token::parse_lookahead(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> positive) -> token_ptr
     {
         static_cast<void>(ctx.next());// Skip last token defining the syntax
@@ -4790,7 +4896,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3059 "reflect.h2"
+#line 3120 "reflect.h2"
     [[nodiscard]] auto group_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '(') {return nullptr; }
@@ -4928,7 +5034,16 @@ size_t i{0};
         }
     }
 
-#line 3196 "reflect.h2"
+#line 3257 "reflect.h2"
+    [[nodiscard]] auto group_token::reverse() const -> token_ptr{
+        auto r {CPP2_UFCS_TEMPLATE(cpp2_new<group_token>)(cpp2::shared)}; 
+        (*cpp2::impl::assert_not_null(r)).number = number;
+        (*cpp2::impl::assert_not_null(r)).reverse_eval = !(reverse_eval);
+        (*cpp2::impl::assert_not_null(r)).inner = CPP2_UFCS(reverse)((*cpp2::impl::assert_not_null(inner)));
+        return r; 
+    }
+
+#line 3265 "reflect.h2"
     [[nodiscard]] auto group_token::gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string
     {
         std::string start {"("}; 
@@ -4947,16 +5062,27 @@ size_t i{0};
         return cpp2::move(start) + (*cpp2::impl::assert_not_null(inner_)).to_string() + ")"; 
     }
 
-#line 3214 "reflect.h2"
+#line 3283 "reflect.h2"
     auto group_token::generate_code(generation_context& ctx) const -> void
     {
         if (-1 != number) {
-            ctx.add("ctx..set_group_start(" + cpp2::to_string(number) + ", r.pos);");
+            if (reverse_eval) {
+                ctx.add("ctx..set_group_end(" + cpp2::to_string(number) + ", r.pos);");
+            }
+            else {
+                ctx.add("ctx..set_group_start(" + cpp2::to_string(number) + ", r.pos);");
+            }
         }
 
         (*cpp2::impl::assert_not_null(inner)).generate_code(ctx);
         if (-1 != number) {
-            ctx.add("ctx..set_group_end(" + cpp2::to_string(number) + ", r.pos);");
+            if (reverse_eval) {
+                ctx.add("ctx..set_group_start(" + cpp2::to_string(number) + ", r.pos);");
+            }
+            else {
+                ctx.add("ctx..set_group_end(" + cpp2::to_string(number) + ", r.pos);");
+            }
+
             auto tmp_name {ctx.gen_temp()}; 
             ctx.add("" + cpp2::to_string(tmp_name) + "_func :=  :() = {");
             ctx.add("  if !r&$*.matched {");
@@ -4968,7 +5094,7 @@ size_t i{0};
         }
     }
 
-#line 3234 "reflect.h2"
+#line 3314 "reflect.h2"
     auto group_token::add_groups(std::set<int>& groups) const -> void
     {
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
@@ -4979,7 +5105,7 @@ size_t i{0};
 
     group_token::~group_token() noexcept{}
 
-#line 3246 "reflect.h2"
+#line 3326 "reflect.h2"
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'x'))) {return nullptr; }
@@ -5018,7 +5144,7 @@ size_t i{0};
     return r; 
 }
 
-#line 3287 "reflect.h2"
+#line 3367 "reflect.h2"
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() == '$' || (ctx.current() == '\\' && ctx.peek() == '$')) {
@@ -5036,7 +5162,7 @@ size_t i{0};
     }}
 }
 
-#line 3307 "reflect.h2"
+#line 3387 "reflect.h2"
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '^' && !((ctx.current() == '\\' && ctx.peek() == 'A'))) {return nullptr; }
@@ -5050,29 +5176,34 @@ size_t i{0};
     }
 }
 
-#line 3332 "reflect.h2"
+#line 3412 "reflect.h2"
     lookahead_token::lookahead_token(cpp2::impl::in<bool> positive_)
         : regex_token{ "" }
         , positive{ positive_ }{
 
-#line 3334 "reflect.h2"
+#line 3414 "reflect.h2"
     }
 
-#line 3336 "reflect.h2"
+#line 3416 "reflect.h2"
     auto lookahead_token::generate_code(generation_context& ctx) const -> void{
         auto inner_name {ctx.generate_func(inner)}; 
 
         ctx.add_check("lookahead_token_matcher<char, " + cpp2::to_string(positive) + ">(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ")");
     }
 
-#line 3342 "reflect.h2"
+#line 3422 "reflect.h2"
+    [[nodiscard]] auto lookahead_token::reverse() const -> token_ptr{
+        return nullptr; // TODO: 1) Implement error, 2) implement functionality.
+    }
+
+#line 3426 "reflect.h2"
     auto lookahead_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
     }
 
     lookahead_token::~lookahead_token() noexcept{}
 
-#line 3350 "reflect.h2"
+#line 3434 "reflect.h2"
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5098,7 +5229,7 @@ size_t i{0};
     return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_check>)(cpp2::shared, "\\" + cpp2::to_string(ctx.current()) + "", "" + cpp2::to_string(cpp2::move(name)) + "<char, " + cpp2::to_string(ctx.get_modifiers().has(expression_flags::case_insensitive)) + ">::match"); 
 }
 
-#line 3378 "reflect.h2"
+#line 3462 "reflect.h2"
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'o'))) {return nullptr; }
@@ -5124,11 +5255,11 @@ size_t i{0};
     return r; 
 }
 
-#line 3415 "reflect.h2"
+#line 3499 "reflect.h2"
     range_token::range_token()
                              : regex_token{ "" }{}
 
-#line 3417 "reflect.h2"
+#line 3501 "reflect.h2"
     [[nodiscard]] auto range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<range_token>)(cpp2::shared)}; 
@@ -5202,7 +5333,7 @@ size_t i{0};
         return nullptr; 
     }
 
-#line 3490 "reflect.h2"
+#line 3574 "reflect.h2"
     auto range_token::parse_modifier(parse_context& ctx) & -> void
     {
         if (ctx.peek() == '?') {
@@ -5215,7 +5346,7 @@ size_t i{0};
         }}
     }
 
-#line 3502 "reflect.h2"
+#line 3586 "reflect.h2"
     [[nodiscard]] auto range_token::gen_mod_string() const& -> std::string
     {
         if (kind == range_flags::not_greedy) {
@@ -5229,7 +5360,7 @@ size_t i{0};
         }}
     }
 
-#line 3515 "reflect.h2"
+#line 3599 "reflect.h2"
     [[nodiscard]] auto range_token::gen_range_string() const& -> std::string
     {
         std::string r {""}; 
@@ -5249,7 +5380,18 @@ size_t i{0};
         return r; 
     }
 
-#line 3534 "reflect.h2"
+#line 3618 "reflect.h2"
+    [[nodiscard]] auto range_token::reverse() const -> token_ptr{
+        auto r {CPP2_UFCS_TEMPLATE(cpp2_new<range_token>)(cpp2::shared)}; 
+        (*cpp2::impl::assert_not_null(r)).min_count = min_count;
+        (*cpp2::impl::assert_not_null(r)).max_count = max_count;
+        (*cpp2::impl::assert_not_null(r)).kind = kind;
+        (*cpp2::impl::assert_not_null(r)).inner_token = CPP2_UFCS(reverse)((*cpp2::impl::assert_not_null(inner_token)));
+
+        return r; 
+    }
+
+#line 3628 "reflect.h2"
     auto range_token::generate_code(generation_context& ctx) const -> void
     {
         auto inner_name {ctx.generate_func(inner_token)}; 
@@ -5261,14 +5403,14 @@ size_t i{0};
         ctx.add_statefull(next_name, "cpp2::regex::range_token_matcher<char, " + cpp2::to_string(min_count) + ", " + cpp2::to_string(max_count) + ", " + cpp2::to_string(kind) + ">::match(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ", " + cpp2::to_string(cpp2::move(reset_name)) + ", other, " + cpp2::to_string(next_name) + ")");
     }
 
-#line 3545 "reflect.h2"
+#line 3639 "reflect.h2"
     auto range_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner_token)).add_groups(groups);
     }
 
     range_token::~range_token() noexcept{}
 
-#line 3558 "reflect.h2"
+#line 3652 "reflect.h2"
     [[nodiscard]] auto special_range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<special_range_token>)(cpp2::shared)}; 
@@ -5292,7 +5434,7 @@ size_t i{0};
 
         if (!(ctx.has_token())) {return ctx.error("'" + cpp2::to_string(ctx.current()) + "' without previous element."); }
 
-#line 3582 "reflect.h2"
+#line 3676 "reflect.h2"
         (*cpp2::impl::assert_not_null(r)).parse_modifier(ctx);
 
         (*cpp2::impl::assert_not_null(r)).inner_token = ctx.pop_token();
@@ -5302,7 +5444,7 @@ size_t i{0};
 
     special_range_token::~special_range_token() noexcept{}
 
-#line 3594 "reflect.h2"
+#line 3688 "reflect.h2"
 [[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5318,7 +5460,7 @@ size_t i{0};
     }
 }
 
-#line 3614 "reflect.h2"
+#line 3708 "reflect.h2"
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5336,15 +5478,15 @@ size_t i{0};
     }}
 }
 
-#line 3650 "reflect.h2"
+#line 3744 "reflect.h2"
     template <typename Error_out> regex_generator<Error_out>::regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e)
         : regex{ r }
         , error_out{ e }{
 
-#line 3653 "reflect.h2"
+#line 3747 "reflect.h2"
     }
 
-#line 3655 "reflect.h2"
+#line 3749 "reflect.h2"
     template <typename Error_out> [[nodiscard]] auto regex_generator<Error_out>::parse() & -> std::string
     {
         // Extract modifiers and adapt regex.
@@ -5382,7 +5524,7 @@ size_t i{0};
         return source; 
     }
 
-#line 3692 "reflect.h2"
+#line 3786 "reflect.h2"
     template <typename Error_out> auto regex_generator<Error_out>::extract_modifiers() & -> void
     {
         if (regex.find_first_of("'/") == 0) {
@@ -5398,7 +5540,7 @@ size_t i{0};
         }
     }
 
-#line 3708 "reflect.h2"
+#line 3802 "reflect.h2"
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string
 {
     regex_generator<Err> parser {regex, err}; 
@@ -5407,7 +5549,7 @@ template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::str
     return r; 
 }
 
-#line 3718 "reflect.h2"
+#line 3812 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void
 {
     auto has_default {false}; 
@@ -5462,7 +5604,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     CPP2_UFCS(add_runtime_support_include)(t, "cpp2regex.h");
 }
 
-#line 3777 "reflect.h2"
+#line 3871 "reflect.h2"
 [[nodiscard]] auto apply_metafunctions(
     declaration_node& n, 
     type_declaration& rtype, 
@@ -5575,7 +5717,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     return true; 
 }
 
-#line 3890 "reflect.h2"
+#line 3984 "reflect.h2"
 }
 
 }

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -160,7 +160,7 @@ class compiler_services
     private: bool metafunctions_used {false}; 
 
 #line 44 "reflect.h2"
-    public: explicit compiler_services(
+    public: compiler_services(
 
         std::vector<error_entry>* errors_, 
         std::set<std::string>* includes_, 
@@ -222,7 +222,7 @@ template<typename T> class reflection_base
 #line 193 "reflect.h2"
     protected: T* n; 
 
-    protected: explicit reflection_base(
+    protected: reflection_base(
 
         T* n_, 
         cpp2::impl::in<compiler_services> s
@@ -243,7 +243,7 @@ class declaration
 : public reflection_base<declaration_node> {
 
 #line 226 "reflect.h2"
-    public: explicit declaration(
+    public: declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -318,7 +318,7 @@ class function_declaration
 : public declaration {
 
 #line 308 "reflect.h2"
-    public: explicit function_declaration(
+    public: function_declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -388,7 +388,7 @@ class object_declaration
 : public declaration {
 
 #line 400 "reflect.h2"
-    public: explicit object_declaration(
+    public: object_declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -413,7 +413,7 @@ class type_declaration
 : public declaration {
 
 #line 436 "reflect.h2"
-    public: explicit type_declaration(
+    public: type_declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -468,7 +468,7 @@ class alias_declaration
 : public declaration {
 
 #line 574 "reflect.h2"
-    public: explicit alias_declaration(
+    public: alias_declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -484,7 +484,7 @@ class statement
 : public reflection_base<statement_node> {
 
 #line 600 "reflect.h2"
-    public: explicit statement(
+    public: statement(
 
         statement_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -518,7 +518,7 @@ class compound_statement
 : public reflection_base<compound_statement_node> {
 
 #line 642 "reflect.h2"
-    public: explicit compound_statement(
+    public: compound_statement(
 
         compound_statement_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -660,7 +660,7 @@ class regex_token
  {
     public: std::string string_rep; 
 
-    public: explicit regex_token(cpp2::impl::in<std::string> str);
+    public: regex_token(cpp2::impl::in<std::string> str);
 
 #line 1672 "reflect.h2"
     public: explicit regex_token();
@@ -692,7 +692,7 @@ class regex_token_check
 #line 1695 "reflect.h2"
     private: std::string check; 
 
-    public: explicit regex_token_check(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> check_);
+    public: regex_token_check(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> check_);
 
 #line 1702 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
@@ -716,7 +716,7 @@ class regex_token_code
 #line 1716 "reflect.h2"
     private: std::string code; 
 
-    public: explicit regex_token_code(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> code_);
+    public: regex_token_code(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> code_);
 
 #line 1723 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
@@ -738,7 +738,7 @@ class regex_token_empty
 : public regex_token {
 
 #line 1737 "reflect.h2"
-    public: explicit regex_token_empty(cpp2::impl::in<std::string> str);
+    public: regex_token_empty(cpp2::impl::in<std::string> str);
 
 #line 1741 "reflect.h2"
     public: auto generate_code([[maybe_unused]] generation_context& unnamed_param_2) const -> void override;
@@ -762,7 +762,7 @@ class regex_token_list
 #line 1755 "reflect.h2"
     public: token_vec tokens; 
 
-    public: explicit regex_token_list(cpp2::impl::in<token_vec> t);
+    public: regex_token_list(cpp2::impl::in<token_vec> t);
 
 #line 1762 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
@@ -879,7 +879,7 @@ class parse_context
     private: error_func error_out; // TODO: Declaring std::function<void(std::string)> fails for cpp2.
     private: bool has_error {false}; 
 
-    public: explicit parse_context(cpp2::impl::in<std::string_view> r, auto const& e);
+    public: parse_context(cpp2::impl::in<std::string_view> r, auto const& e);
 
 #line 1930 "reflect.h2"
     //  State management functions
@@ -1142,7 +1142,7 @@ class alternative_token_gen
 #line 2544 "reflect.h2"
     private: token_vec alternatives; 
 
-    public: explicit alternative_token_gen(cpp2::impl::in<token_vec> a);
+    public: alternative_token_gen(cpp2::impl::in<token_vec> a);
 
 #line 2551 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
@@ -1171,7 +1171,7 @@ class any_token
 : public regex_token_check {
 
 #line 2609 "reflect.h2"
-    public: explicit any_token(cpp2::impl::in<bool> single_line);
+    public: any_token(cpp2::impl::in<bool> single_line);
 
 #line 2613 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
@@ -1219,10 +1219,10 @@ class char_token
     private: std::string token; 
     private: bool ignore_case; 
 
-    public: explicit char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_);
+    public: char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_);
 
 #line 2665 "reflect.h2"
-    public: explicit char_token(cpp2::impl::in<std::string> t, cpp2::impl::in<bool> ignore_case_);
+    public: char_token(cpp2::impl::in<std::string> t, cpp2::impl::in<bool> ignore_case_);
 
 #line 2671 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
@@ -1264,7 +1264,7 @@ class class_token
     private: bool case_insensitive; 
     private: std::string class_str; 
 
-    public: explicit class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str);
+    public: class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str);
 
 #line 2783 "reflect.h2"
     //  TODO: Rework class generation: Generate check functions for classes.
@@ -1312,7 +1312,7 @@ class group_ref_token
     private: bool case_insensitive; 
     private: bool reverse_eval; 
 
-    public: explicit group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<bool> reverse_, cpp2::impl::in<std::string> str);
+    public: group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<bool> reverse_, cpp2::impl::in<std::string> str);
 
 #line 3007 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
@@ -1407,7 +1407,7 @@ class lookahead_lookbehind_token
     protected: bool positive; 
     public:   token_ptr inner {nullptr}; 
 
-    public: explicit lookahead_lookbehind_token(cpp2::impl::in<bool> lookahead_, cpp2::impl::in<bool> positive_);
+    public: lookahead_lookbehind_token(cpp2::impl::in<bool> lookahead_, cpp2::impl::in<bool> positive_);
 
 #line 3488 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
@@ -1528,7 +1528,7 @@ template<typename Error_out> class regex_generator
 
     private: std::string source {""}; 
 
-    public: explicit regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e);
+    public: regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e);
 
 #line 3828 "reflect.h2"
     public: [[nodiscard]] auto parse() & -> std::string;

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -72,47 +72,47 @@ class parse_context_branch_reset_state;
 #line 1887 "reflect.h2"
 class parse_context;
 
-#line 2285 "reflect.h2"
+#line 2288 "reflect.h2"
 class generation_function_context;
     
 
-#line 2303 "reflect.h2"
+#line 2306 "reflect.h2"
 class generation_context;
 
-#line 2501 "reflect.h2"
+#line 2504 "reflect.h2"
 class alternative_token;
 
-#line 2516 "reflect.h2"
+#line 2519 "reflect.h2"
 class alternative_token_gen;
 
-#line 2568 "reflect.h2"
+#line 2571 "reflect.h2"
 class any_token;
 
-#line 2586 "reflect.h2"
+#line 2589 "reflect.h2"
 class char_token;
 
-#line 2689 "reflect.h2"
+#line 2692 "reflect.h2"
 class class_token;
 
-#line 2904 "reflect.h2"
+#line 2907 "reflect.h2"
 class group_ref_token;
 
-#line 3035 "reflect.h2"
+#line 3038 "reflect.h2"
 class group_token;
 
-#line 3322 "reflect.h2"
+#line 3325 "reflect.h2"
 class lookahead_token;
 
-#line 3403 "reflect.h2"
+#line 3406 "reflect.h2"
 class range_token;
 
-#line 3551 "reflect.h2"
+#line 3554 "reflect.h2"
 class special_range_token;
 
-#line 3618 "reflect.h2"
+#line 3640 "reflect.h2"
 template<typename Error_out> class regex_generator;
 
-#line 3866 "reflect.h2"
+#line 3890 "reflect.h2"
 }
 
 }
@@ -157,7 +157,7 @@ class compiler_services
     private: bool metafunctions_used {false}; 
 
 #line 44 "reflect.h2"
-    public: compiler_services(
+    public: explicit compiler_services(
 
         std::vector<error_entry>* errors_, 
         std::set<std::string>* includes_, 
@@ -219,7 +219,7 @@ template<typename T> class reflection_base
 #line 193 "reflect.h2"
     protected: T* n; 
 
-    protected: reflection_base(
+    protected: explicit reflection_base(
 
         T* n_, 
         cpp2::impl::in<compiler_services> s
@@ -240,7 +240,7 @@ class declaration
 : public reflection_base<declaration_node> {
 
 #line 226 "reflect.h2"
-    public: declaration(
+    public: explicit declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -315,7 +315,7 @@ class function_declaration
 : public declaration {
 
 #line 308 "reflect.h2"
-    public: function_declaration(
+    public: explicit function_declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -385,7 +385,7 @@ class object_declaration
 : public declaration {
 
 #line 400 "reflect.h2"
-    public: object_declaration(
+    public: explicit object_declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -410,7 +410,7 @@ class type_declaration
 : public declaration {
 
 #line 436 "reflect.h2"
-    public: type_declaration(
+    public: explicit type_declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -465,7 +465,7 @@ class alias_declaration
 : public declaration {
 
 #line 574 "reflect.h2"
-    public: alias_declaration(
+    public: explicit alias_declaration(
 
         declaration_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -481,7 +481,7 @@ class statement
 : public reflection_base<statement_node> {
 
 #line 600 "reflect.h2"
-    public: statement(
+    public: explicit statement(
 
         statement_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -515,7 +515,7 @@ class compound_statement
 : public reflection_base<compound_statement_node> {
 
 #line 642 "reflect.h2"
-    public: compound_statement(
+    public: explicit compound_statement(
 
         compound_statement_node* n_, 
         cpp2::impl::in<compiler_services> s
@@ -657,7 +657,7 @@ class regex_token
  {
     public: std::string string_rep; 
 
-    public: regex_token(cpp2::impl::in<std::string> str);
+    public: explicit regex_token(cpp2::impl::in<std::string> str);
 
 #line 1672 "reflect.h2"
     public: explicit regex_token();
@@ -688,7 +688,7 @@ class regex_token_check
 #line 1694 "reflect.h2"
     private: std::string check; 
 
-    public: regex_token_check(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> check_);
+    public: explicit regex_token_check(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> check_);
 
 #line 1701 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
@@ -710,7 +710,7 @@ class regex_token_code
 #line 1713 "reflect.h2"
     private: std::string code; 
 
-    public: regex_token_code(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> code_);
+    public: explicit regex_token_code(cpp2::impl::in<std::string> str, cpp2::impl::in<std::string> code_);
 
 #line 1720 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
@@ -730,7 +730,7 @@ class regex_token_empty
 : public regex_token {
 
 #line 1732 "reflect.h2"
-    public: regex_token_empty(cpp2::impl::in<std::string> str);
+    public: explicit regex_token_empty(cpp2::impl::in<std::string> str);
 
 #line 1736 "reflect.h2"
     public: auto generate_code([[maybe_unused]] generation_context& unnamed_param_2) const -> void override;
@@ -752,7 +752,7 @@ class regex_token_list
 #line 1748 "reflect.h2"
     public: token_vec tokens; 
 
-    public: regex_token_list(cpp2::impl::in<token_vec> t);
+    public: explicit regex_token_list(cpp2::impl::in<token_vec> t);
 
 #line 1755 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
@@ -855,75 +855,77 @@ class parse_context
     private: size_t pos {0};   // Current parsing position.
     private: token_ptr root;   // Token representing the regular expression.
 
+    public: bool is_start_match {false};  // If the regex contains \G at the beginning.
+
     private: parse_context_group_state cur_group_state {}; 
     private: parse_context_branch_reset_state cur_branch_reset_state {}; 
 
-#line 1897 "reflect.h2"
+#line 1899 "reflect.h2"
            public: std::map<std::string,int> named_groups {}; 
 
     private: error_func error_out; // TODO: Declaring std::function<void(std::string)> fails for cpp2.
     private: bool has_error {false}; 
 
-    public: parse_context(cpp2::impl::in<std::string_view> r, auto const& e);
+    public: explicit parse_context(cpp2::impl::in<std::string_view> r, auto const& e);
 
-#line 1908 "reflect.h2"
+#line 1910 "reflect.h2"
     //  State management functions
     //
 
     //  Returned group state needs to be stored and provided in `end_group`.
     public: [[nodiscard]] auto start_group() & -> parse_context_group_state;
 
-#line 1921 "reflect.h2"
+#line 1923 "reflect.h2"
     //  `old_state` argument needs to be from start group.
     public: [[nodiscard]] auto end_group(cpp2::impl::in<parse_context_group_state> old_state) & -> token_ptr;
 
-#line 1929 "reflect.h2"
+#line 1931 "reflect.h2"
     public: [[nodiscard]] auto get_modifiers() const& -> expression_flags;
 
-#line 1933 "reflect.h2"
+#line 1935 "reflect.h2"
     public: auto set_modifiers(cpp2::impl::in<expression_flags> mod) & -> void;
 
-#line 1937 "reflect.h2"
+#line 1939 "reflect.h2"
     //  Branch reset management functions
     //
 
     public: [[nodiscard]] auto branch_reset_new_state() & -> parse_context_branch_reset_state;
 
-#line 1949 "reflect.h2"
+#line 1951 "reflect.h2"
     public: auto branch_reset_restore_state(cpp2::impl::in<parse_context_branch_reset_state> old_state) & -> void;
 
-#line 1956 "reflect.h2"
+#line 1958 "reflect.h2"
     public: auto next_alternative() & -> void;
 
-#line 1962 "reflect.h2"
+#line 1964 "reflect.h2"
     //  Regex token management
     //
     public: auto add_token(cpp2::impl::in<token_ptr> token) & -> void;
 
-#line 1968 "reflect.h2"
+#line 1970 "reflect.h2"
     public: [[nodiscard]] auto has_token() const& -> bool;
 
-#line 1972 "reflect.h2"
+#line 1974 "reflect.h2"
     public: [[nodiscard]] auto pop_token() & -> token_ptr;
 
-#line 1983 "reflect.h2"
+#line 1985 "reflect.h2"
     public: [[nodiscard]] auto get_as_token() & -> token_ptr;
 
-#line 1987 "reflect.h2"
+#line 1989 "reflect.h2"
     //  Group management
     //
     public: [[nodiscard]] auto get_cur_group() const& -> int;
 
-#line 1993 "reflect.h2"
+#line 1995 "reflect.h2"
     public: [[nodiscard]] auto next_group() & -> int;
 
-#line 1997 "reflect.h2"
+#line 1999 "reflect.h2"
     public: auto set_named_group(cpp2::impl::in<std::string> name, cpp2::impl::in<int> id) & -> void;
 
-#line 2004 "reflect.h2"
+#line 2006 "reflect.h2"
     public: [[nodiscard]] auto get_named_group(cpp2::impl::in<std::string> name) const& -> int;
 
-#line 2015 "reflect.h2"
+#line 2017 "reflect.h2"
     //  Position management functions
     //
     public: [[nodiscard]] auto current() const& -> char;
@@ -931,51 +933,51 @@ class parse_context
     //  Get the next token in the regex, skipping spaces according to the parameters. See `x` and `xx` modifiers.
     private: [[nodiscard]] auto get_next_position(cpp2::impl::in<bool> in_class, cpp2::impl::in<bool> no_skip) const& -> size_t;
 
-#line 2059 "reflect.h2"
+#line 2061 "reflect.h2"
     //  Return true if next token is available.
     private: [[nodiscard]] auto next_impl(cpp2::impl::in<bool> in_class, cpp2::impl::in<bool> no_skip) & -> bool;
 
-#line 2071 "reflect.h2"
+#line 2073 "reflect.h2"
     public: [[nodiscard]] auto next() & -> decltype(auto);
     public: [[nodiscard]] auto next_in_class() & -> decltype(auto);
     public: [[nodiscard]] auto next_no_skip() & -> decltype(auto);
 
     public: [[nodiscard]] auto next_n(cpp2::impl::in<int> n) & -> bool;
 
-#line 2084 "reflect.h2"
+#line 2086 "reflect.h2"
     public: [[nodiscard]] auto has_next() const& -> bool;
 
     private: [[nodiscard]] auto grab_until_impl(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r, cpp2::impl::in<bool> any) & -> bool;
 
-#line 2107 "reflect.h2"
+#line 2109 "reflect.h2"
     public: [[nodiscard]] auto grab_until(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r) & -> decltype(auto);
     public: [[nodiscard]] auto grab_until(cpp2::impl::in<char> e, cpp2::impl::out<std::string> r) & -> decltype(auto);
     public: [[nodiscard]] auto grab_until_one_of(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r) & -> decltype(auto);
 
     public: [[nodiscard]] auto grab_n(cpp2::impl::in<int> n, cpp2::impl::out<std::string> r) & -> bool;
 
-#line 2124 "reflect.h2"
+#line 2126 "reflect.h2"
     public: [[nodiscard]] auto grab_number() & -> std::string;
 
-#line 2145 "reflect.h2"
+#line 2147 "reflect.h2"
     private: [[nodiscard]] auto peek_impl(cpp2::impl::in<bool> in_class) const& -> char;
 
-#line 2155 "reflect.h2"
+#line 2157 "reflect.h2"
     public: [[nodiscard]] auto peek() const& -> decltype(auto);
     public: [[nodiscard]] auto peek_in_class() const& -> decltype(auto);
 
-#line 2159 "reflect.h2"
+#line 2161 "reflect.h2"
     //  Parsing functions
     //
     public: [[nodiscard]] auto parser_group_modifiers(cpp2::impl::in<std::string> change_str, expression_flags& parser_modifiers) & -> bool;
 
-#line 2215 "reflect.h2"
+#line 2217 "reflect.h2"
     public: [[nodiscard]] auto parse_until(cpp2::impl::in<char> term) & -> bool;
 
-#line 2253 "reflect.h2"
+#line 2256 "reflect.h2"
     public: [[nodiscard]] auto parse(cpp2::impl::in<std::string> modifiers) & -> bool;
 
-#line 2268 "reflect.h2"
+#line 2271 "reflect.h2"
     //  Misc functions
 
     public: [[nodiscard]] auto get_pos() const& -> decltype(auto);
@@ -987,10 +989,10 @@ class parse_context
     public: auto operator=(parse_context const&) -> void = delete;
 
 
-#line 2279 "reflect.h2"
+#line 2282 "reflect.h2"
 };
 
-#line 2282 "reflect.h2"
+#line 2285 "reflect.h2"
 //  Context for one function generation. Generation of functions can be interleaved,
 //  therefore we buffer the code for one function here.
 //
@@ -1000,16 +1002,16 @@ class generation_function_context {
 
     public: auto add_tabs(cpp2::impl::in<int> c) & -> void;
 
-#line 2296 "reflect.h2"
+#line 2299 "reflect.h2"
     public: auto remove_tabs(cpp2::impl::in<int> c) & -> void;
     public: generation_function_context(auto const& code_, auto const& tabs_);
 public: generation_function_context();
 
 
-#line 2299 "reflect.h2"
+#line 2302 "reflect.h2"
 };
 
-#line 2302 "reflect.h2"
+#line 2305 "reflect.h2"
 //  Context for generating the state machine.
 class generation_context
  {
@@ -1029,68 +1031,68 @@ class generation_context
     //  Add code line.
     public: auto add(cpp2::impl::in<std::string> s) & -> void;
 
-#line 2324 "reflect.h2"
+#line 2327 "reflect.h2"
     //  Add check for token. The check needs to be a function call that returns a boolean.
     public: auto add_check(cpp2::impl::in<std::string> check) & -> void;
 
-#line 2330 "reflect.h2"
+#line 2333 "reflect.h2"
     //  Add a stateful check. The check needs to return a `match_return`.
     public: auto add_statefull(cpp2::impl::in<std::string> next_func, cpp2::impl::in<std::string> check) & -> void;
 
-#line 2339 "reflect.h2"
+#line 2342 "reflect.h2"
     protected: auto start_func_named(cpp2::impl::in<std::string> name) & -> void;
 
-#line 2350 "reflect.h2"
+#line 2353 "reflect.h2"
     protected: [[nodiscard]] auto start_func() & -> std::string;
 
-#line 2357 "reflect.h2"
+#line 2360 "reflect.h2"
     protected: auto end_func_statefull(cpp2::impl::in<std::string> s) & -> void;
 
-#line 2376 "reflect.h2"
+#line 2379 "reflect.h2"
     //  Generate the function for a token.
     public: [[nodiscard]] auto generate_func(cpp2::impl::in<token_ptr> token) & -> std::string;
 
-#line 2386 "reflect.h2"
+#line 2389 "reflect.h2"
     //  Generate the reset for a list of group identifiers.
     public: [[nodiscard]] auto generate_reset(cpp2::impl::in<std::set<int>> groups) & -> std::string;
 
-#line 2409 "reflect.h2"
+#line 2412 "reflect.h2"
     //  Name generation
     //
     protected: [[nodiscard]] auto gen_func_name() & -> std::string;
 
-#line 2417 "reflect.h2"
+#line 2420 "reflect.h2"
     public: [[nodiscard]] auto next_func_name() & -> std::string;
 
-#line 2421 "reflect.h2"
+#line 2424 "reflect.h2"
     protected: [[nodiscard]] auto gen_reset_func_name() & -> std::string;
 
-#line 2427 "reflect.h2"
+#line 2430 "reflect.h2"
     public: [[nodiscard]] auto gen_temp() & -> std::string;
 
-#line 2433 "reflect.h2"
+#line 2436 "reflect.h2"
     //  Context management
     //
     public: [[nodiscard]] auto new_context() & -> generation_function_context*;
 
-#line 2443 "reflect.h2"
+#line 2446 "reflect.h2"
     public: auto finish_context() & -> void;
 
-#line 2451 "reflect.h2"
+#line 2454 "reflect.h2"
     //  Misc functions
     //
     private: [[nodiscard]] auto get_current() & -> generation_function_context*;
 
-#line 2457 "reflect.h2"
+#line 2460 "reflect.h2"
     private: [[nodiscard]] auto get_base() & -> generation_function_context*;
 
-#line 2461 "reflect.h2"
+#line 2464 "reflect.h2"
     public: [[nodiscard]] auto get_entry_func() const& -> std::string;
 
-#line 2465 "reflect.h2"
+#line 2468 "reflect.h2"
     public: [[nodiscard]] auto create_named_group_lookup(cpp2::impl::in<std::map<std::string,int>> named_groups) const& -> std::string;
 
-#line 2489 "reflect.h2"
+#line 2492 "reflect.h2"
     //  Run the generation for the token.
     public: [[nodiscard]] auto run(cpp2::impl::in<token_ptr> token) & -> std::string;
     public: generation_context() = default;
@@ -1098,7 +1100,7 @@ class generation_context
     public: auto operator=(generation_context const&) -> void = delete;
 
 
-#line 2495 "reflect.h2"
+#line 2498 "reflect.h2"
 };
 
 //  Regex syntax: |  Example: ab|ba
@@ -1118,24 +1120,24 @@ class alternative_token
     public: auto operator=(alternative_token const&) -> void = delete;
 
 
-#line 2514 "reflect.h2"
+#line 2517 "reflect.h2"
 };
 
 class alternative_token_gen
 : public regex_token {
 
-#line 2520 "reflect.h2"
+#line 2523 "reflect.h2"
     private: token_vec alternatives; 
 
-    public: alternative_token_gen(cpp2::impl::in<token_vec> a);
+    public: explicit alternative_token_gen(cpp2::impl::in<token_vec> a);
 
-#line 2527 "reflect.h2"
+#line 2530 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2544 "reflect.h2"
+#line 2547 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
 
-#line 2551 "reflect.h2"
+#line 2554 "reflect.h2"
     public: [[nodiscard]] static auto gen_string(cpp2::impl::in<token_vec> a) -> std::string;
     public: virtual ~alternative_token_gen() noexcept;
 
@@ -1143,19 +1145,19 @@ class alternative_token_gen
     public: auto operator=(alternative_token_gen const&) -> void = delete;
 
 
-#line 2563 "reflect.h2"
+#line 2566 "reflect.h2"
 };
 
-#line 2566 "reflect.h2"
+#line 2569 "reflect.h2"
 //  Regex syntax: .
 //
 class any_token
 : public regex_token_check {
 
-#line 2572 "reflect.h2"
-    public: any_token(cpp2::impl::in<bool> single_line);
+#line 2575 "reflect.h2"
+    public: explicit any_token(cpp2::impl::in<bool> single_line);
 
-#line 2576 "reflect.h2"
+#line 2579 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
     public: virtual ~any_token() noexcept;
 
@@ -1163,37 +1165,37 @@ class any_token
     public: auto operator=(any_token const&) -> void = delete;
 
 
-#line 2581 "reflect.h2"
+#line 2584 "reflect.h2"
 };
 
-#line 2584 "reflect.h2"
+#line 2587 "reflect.h2"
 //  Regex syntax: a
 //
 class char_token
 : public regex_token {
 
-#line 2590 "reflect.h2"
+#line 2593 "reflect.h2"
     private: std::string token; 
     private: bool ignore_case; 
 
-    public: char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_);
+    public: explicit char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_);
 
-#line 2599 "reflect.h2"
+#line 2602 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 2603 "reflect.h2"
+#line 2606 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2626 "reflect.h2"
+#line 2629 "reflect.h2"
     public: auto gen_case_insensitive(cpp2::impl::in<std::string> lower, cpp2::impl::in<std::string> upper, generation_context& ctx) const& -> void;
 
-#line 2647 "reflect.h2"
+#line 2650 "reflect.h2"
     public: auto gen_case_sensitive(generation_context& ctx) const& -> void;
 
-#line 2665 "reflect.h2"
+#line 2668 "reflect.h2"
     public: [[nodiscard]] auto add_escapes(std::string str) const& -> std::string;
 
-#line 2680 "reflect.h2"
+#line 2683 "reflect.h2"
     public: auto append(char_token const& that) & -> void;
     public: virtual ~char_token() noexcept;
 
@@ -1201,30 +1203,30 @@ class char_token
     public: auto operator=(char_token const&) -> void = delete;
 
 
-#line 2684 "reflect.h2"
+#line 2687 "reflect.h2"
 };
 
-#line 2687 "reflect.h2"
+#line 2690 "reflect.h2"
 //  Regex syntax: [<character classes>]  Example: [abcx-y[:digits:]]
 //
 class class_token
 : public regex_token {
 
-#line 2693 "reflect.h2"
+#line 2696 "reflect.h2"
     private: bool negate; 
     private: bool case_insensitive; 
     private: std::string class_str; 
 
-    public: class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str);
+    public: explicit class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str);
 
-#line 2705 "reflect.h2"
+#line 2708 "reflect.h2"
     //  TODO: Rework class generation: Generate check functions for classes.
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 2831 "reflect.h2"
+#line 2834 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 2836 "reflect.h2"
+#line 2839 "reflect.h2"
     private: [[nodiscard]] static auto create_matcher(cpp2::impl::in<std::string> name, cpp2::impl::in<std::string> template_arguments) -> std::string;
     public: virtual ~class_token() noexcept;
 
@@ -1232,20 +1234,20 @@ class class_token
     public: auto operator=(class_token const&) -> void = delete;
 
 
-#line 2843 "reflect.h2"
+#line 2846 "reflect.h2"
 };
 
-#line 2846 "reflect.h2"
+#line 2849 "reflect.h2"
 //  Regex syntax: \a or \n or \[
 //
 [[nodiscard]] auto escape_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 2887 "reflect.h2"
+#line 2890 "reflect.h2"
 //  Regex syntax: \K Example: ab\Kcd
 //
 [[nodiscard]] auto global_group_reset_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 2898 "reflect.h2"
+#line 2901 "reflect.h2"
 //  Regex syntax: \<number>  Example: \1
 //                \g{name_or_number}
 //                \k{name_or_number}
@@ -1255,16 +1257,16 @@ class class_token
 class group_ref_token
 : public regex_token {
 
-#line 2908 "reflect.h2"
+#line 2911 "reflect.h2"
     private: int id; 
     private: bool case_insensitive; 
 
-    public: group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> str);
+    public: explicit group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> str);
 
-#line 2918 "reflect.h2"
+#line 2921 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3019 "reflect.h2"
+#line 3022 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
     public: virtual ~group_ref_token() noexcept;
 
@@ -1272,10 +1274,10 @@ class group_ref_token
     public: auto operator=(group_ref_token const&) -> void = delete;
 
 
-#line 3022 "reflect.h2"
+#line 3025 "reflect.h2"
 };
 
-#line 3025 "reflect.h2"
+#line 3028 "reflect.h2"
 //  Regex syntax: (<tokens>)      Example: (abc)
 //                (?<modifiers)            (?i)
 //                (?<modifiers>:<tokens>)  (?i:abc)
@@ -1289,22 +1291,22 @@ class group_ref_token
 class group_token
 : public regex_token {
 
-#line 3039 "reflect.h2"
+#line 3042 "reflect.h2"
     private: int number {-1}; 
     private: token_ptr inner {nullptr}; 
 
     public: [[nodiscard]] static auto parse_lookahead(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> positive) -> token_ptr;
 
-#line 3056 "reflect.h2"
+#line 3059 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3193 "reflect.h2"
+#line 3196 "reflect.h2"
     public: [[nodiscard]] static auto gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string;
 
-#line 3211 "reflect.h2"
+#line 3214 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3231 "reflect.h2"
+#line 3234 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~group_token() noexcept;
 
@@ -1313,25 +1315,25 @@ class group_token
     public: auto operator=(group_token const&) -> void = delete;
 
 
-#line 3238 "reflect.h2"
+#line 3241 "reflect.h2"
 };
 
-#line 3241 "reflect.h2"
+#line 3244 "reflect.h2"
 //  Regex syntax: \x<number> or \x{<number>}  Example: \x{62}
 //
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3282 "reflect.h2"
+#line 3285 "reflect.h2"
 //  Regex syntax: $  Example: aa$
 //
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3302 "reflect.h2"
+#line 3305 "reflect.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3318 "reflect.h2"
+#line 3321 "reflect.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
@@ -1339,16 +1341,16 @@ class group_token
 class lookahead_token
 : public regex_token {
 
-#line 3326 "reflect.h2"
+#line 3329 "reflect.h2"
     protected: bool positive; 
     public:   token_ptr inner {nullptr}; 
 
-    public: lookahead_token(cpp2::impl::in<bool> positive_);
+    public: explicit lookahead_token(cpp2::impl::in<bool> positive_);
 
-#line 3333 "reflect.h2"
+#line 3336 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3339 "reflect.h2"
+#line 3342 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~lookahead_token() noexcept;
 
@@ -1356,26 +1358,26 @@ class lookahead_token
     public: auto operator=(lookahead_token const&) -> void = delete;
 
 
-#line 3342 "reflect.h2"
+#line 3345 "reflect.h2"
 };
 
-#line 3345 "reflect.h2"
+#line 3348 "reflect.h2"
 // Named character classes
 //
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3373 "reflect.h2"
+#line 3376 "reflect.h2"
 //  Regex syntax: \o{<number>}  Example: \o{142}
 //
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3401 "reflect.h2"
+#line 3404 "reflect.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 class range_token
 : public regex_token {
 
-#line 3407 "reflect.h2"
+#line 3410 "reflect.h2"
               protected: int min_count {-1}; 
               protected: int max_count {-1}; 
               protected: int kind {range_flags::greedy}; 
@@ -1385,19 +1387,19 @@ class range_token
 
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3487 "reflect.h2"
+#line 3490 "reflect.h2"
     public: auto parse_modifier(parse_context& ctx) & -> void;
 
-#line 3499 "reflect.h2"
+#line 3502 "reflect.h2"
     public: [[nodiscard]] auto gen_mod_string() const& -> std::string;
 
-#line 3512 "reflect.h2"
+#line 3515 "reflect.h2"
     public: [[nodiscard]] auto gen_range_string() const& -> std::string;
 
-#line 3531 "reflect.h2"
+#line 3534 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3542 "reflect.h2"
+#line 3545 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~range_token() noexcept;
 
@@ -1405,16 +1407,16 @@ class range_token
     public: auto operator=(range_token const&) -> void = delete;
 
 
-#line 3546 "reflect.h2"
+#line 3549 "reflect.h2"
 };
 
-#line 3549 "reflect.h2"
+#line 3552 "reflect.h2"
 //  Regex syntax: *, +, or ?  Example: aa*
 //
 class special_range_token
 : public range_token {
 
-#line 3555 "reflect.h2"
+#line 3558 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
     public: virtual ~special_range_token() noexcept;
 
@@ -1423,17 +1425,23 @@ class special_range_token
     public: auto operator=(special_range_token const&) -> void = delete;
 
 
-#line 3585 "reflect.h2"
+#line 3588 "reflect.h2"
 };
 
-#line 3588 "reflect.h2"
+//  Regex syntax: \G  Example: \Gaa
+//
+//  Forces the match and/or consecutive matches to start at the position of the last match.
+//
+[[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr;
+
+#line 3610 "reflect.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3610 "reflect.h2"
+#line 3632 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  Parser for regular expression.
@@ -1452,26 +1460,26 @@ template<typename Error_out> class regex_generator
 
     private: std::string source {""}; 
 
-    public: regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e);
+    public: explicit regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e);
 
-#line 3633 "reflect.h2"
+#line 3655 "reflect.h2"
     public: [[nodiscard]] auto parse() & -> std::string;
 
-#line 3668 "reflect.h2"
+#line 3692 "reflect.h2"
     private: auto extract_modifiers() & -> void;
     public: regex_generator(regex_generator const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_generator const&) -> void = delete;
 
 
-#line 3682 "reflect.h2"
+#line 3706 "reflect.h2"
 };
 
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string;
 
-#line 3694 "reflect.h2"
+#line 3718 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void;
 
-#line 3749 "reflect.h2"
+#line 3773 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  apply_metafunctions
@@ -1482,7 +1490,7 @@ auto regex_gen(meta::type_declaration& t) -> void;
     auto const& error
     ) -> bool;
 
-#line 3866 "reflect.h2"
+#line 3890 "reflect.h2"
 }
 
 }
@@ -3650,16 +3658,16 @@ parse_context_group_state::parse_context_group_state(){}
                                                                                     , from{ from_ }{}
 parse_context_branch_reset_state::parse_context_branch_reset_state(){}
 
-#line 1902 "reflect.h2"
+#line 1904 "reflect.h2"
     parse_context::parse_context(cpp2::impl::in<std::string_view> r, auto const& e)
         : regex{ r }
         , root{ CPP2_UFCS_TEMPLATE_NONLOCAL(cpp2_new<regex_token_empty>)(cpp2::shared, "") }
         , error_out{ e }{
 
-#line 1906 "reflect.h2"
+#line 1908 "reflect.h2"
     }
 
-#line 1912 "reflect.h2"
+#line 1914 "reflect.h2"
     [[nodiscard]] auto parse_context::start_group() & -> parse_context_group_state
     {
         parse_context_group_state old_state {}; 
@@ -3669,7 +3677,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return old_state; 
     }
 
-#line 1922 "reflect.h2"
+#line 1924 "reflect.h2"
     [[nodiscard]] auto parse_context::end_group(cpp2::impl::in<parse_context_group_state> old_state) & -> token_ptr
     {
         auto inner {cur_group_state.get_as_token()}; 
@@ -3677,17 +3685,17 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return inner; 
     }
 
-#line 1929 "reflect.h2"
+#line 1931 "reflect.h2"
     [[nodiscard]] auto parse_context::get_modifiers() const& -> expression_flags{
         return cur_group_state.modifiers; 
     }
 
-#line 1933 "reflect.h2"
+#line 1935 "reflect.h2"
     auto parse_context::set_modifiers(cpp2::impl::in<expression_flags> mod) & -> void{
         cur_group_state.modifiers = mod;
     }
 
-#line 1940 "reflect.h2"
+#line 1942 "reflect.h2"
     [[nodiscard]] auto parse_context::branch_reset_new_state() & -> parse_context_branch_reset_state
     {
         parse_context_branch_reset_state old_state {}; 
@@ -3697,7 +3705,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return old_state; 
     }
 
-#line 1949 "reflect.h2"
+#line 1951 "reflect.h2"
     auto parse_context::branch_reset_restore_state(cpp2::impl::in<parse_context_branch_reset_state> old_state) & -> void
     {
         auto max_group {cur_branch_reset_state.max_group}; 
@@ -3705,24 +3713,24 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         cur_branch_reset_state.set_next(cpp2::move(max_group));
     }
 
-#line 1956 "reflect.h2"
+#line 1958 "reflect.h2"
     auto parse_context::next_alternative() & -> void
     {
         cur_group_state.next_alternative();
         cur_branch_reset_state.next_alternative();
     }
 
-#line 1964 "reflect.h2"
+#line 1966 "reflect.h2"
     auto parse_context::add_token(cpp2::impl::in<token_ptr> token) & -> void{
         cur_group_state.add(token);
     }
 
-#line 1968 "reflect.h2"
+#line 1970 "reflect.h2"
     [[nodiscard]] auto parse_context::has_token() const& -> bool{
         return !(cur_group_state.empty()); 
     }
 
-#line 1972 "reflect.h2"
+#line 1974 "reflect.h2"
     [[nodiscard]] auto parse_context::pop_token() & -> token_ptr
     {
         token_ptr r {nullptr}; 
@@ -3734,22 +3742,22 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return r; 
     }
 
-#line 1983 "reflect.h2"
+#line 1985 "reflect.h2"
     [[nodiscard]] auto parse_context::get_as_token() & -> token_ptr{
         return root; 
     }
 
-#line 1989 "reflect.h2"
+#line 1991 "reflect.h2"
     [[nodiscard]] auto parse_context::get_cur_group() const& -> int{
         return cur_branch_reset_state.cur_group; 
     }
 
-#line 1993 "reflect.h2"
+#line 1995 "reflect.h2"
     [[nodiscard]] auto parse_context::next_group() & -> int{
         return cur_branch_reset_state.next(); 
     }
 
-#line 1997 "reflect.h2"
+#line 1999 "reflect.h2"
     auto parse_context::set_named_group(cpp2::impl::in<std::string> name, cpp2::impl::in<int> id) & -> void
     {
         if (!(named_groups.contains(name))) {// Redefinition of group name is not an error. The left most one is retained.
@@ -3757,7 +3765,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2004 "reflect.h2"
+#line 2006 "reflect.h2"
     [[nodiscard]] auto parse_context::get_named_group(cpp2::impl::in<std::string> name) const& -> int
     {
         auto iter {named_groups.find(name)}; 
@@ -3769,10 +3777,10 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2017 "reflect.h2"
+#line 2019 "reflect.h2"
     [[nodiscard]] auto parse_context::current() const& -> char{return CPP2_ASSERT_IN_BOUNDS(regex, pos); }
 
-#line 2020 "reflect.h2"
+#line 2022 "reflect.h2"
     [[nodiscard]] auto parse_context::get_next_position(cpp2::impl::in<bool> in_class, cpp2::impl::in<bool> no_skip) const& -> size_t
     {
         auto perl_syntax {false}; 
@@ -3812,7 +3820,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return cur; 
     }
 
-#line 2060 "reflect.h2"
+#line 2062 "reflect.h2"
     [[nodiscard]] auto parse_context::next_impl(cpp2::impl::in<bool> in_class, cpp2::impl::in<bool> no_skip) & -> bool
     {
         pos = get_next_position(in_class, no_skip);
@@ -3824,14 +3832,14 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2071 "reflect.h2"
-    [[nodiscard]] auto parse_context::next() & -> decltype(auto) { return next_impl(false, false); }
-#line 2072 "reflect.h2"
-    [[nodiscard]] auto parse_context::next_in_class() & -> decltype(auto) { return next_impl(true, false);  }
 #line 2073 "reflect.h2"
+    [[nodiscard]] auto parse_context::next() & -> decltype(auto) { return next_impl(false, false); }
+#line 2074 "reflect.h2"
+    [[nodiscard]] auto parse_context::next_in_class() & -> decltype(auto) { return next_impl(true, false);  }
+#line 2075 "reflect.h2"
     [[nodiscard]] auto parse_context::next_no_skip() & -> decltype(auto) { return next_impl(false, true); }
 
-#line 2075 "reflect.h2"
+#line 2077 "reflect.h2"
     [[nodiscard]] auto parse_context::next_n(cpp2::impl::in<int> n) & -> bool{
         auto r {true}; 
         auto cur {0}; 
@@ -3841,10 +3849,10 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return r; 
     }
 
-#line 2084 "reflect.h2"
+#line 2086 "reflect.h2"
     [[nodiscard]] auto parse_context::has_next() const& -> bool{return cpp2::impl::cmp_less(pos,regex.size()); }
 
-#line 2086 "reflect.h2"
+#line 2088 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_until_impl(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r, cpp2::impl::in<bool> any) & -> bool
     {
         auto end {pos}; // NOLINT(clang-analyzer-deadcode.DeadStores)
@@ -3866,14 +3874,14 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2107 "reflect.h2"
-    [[nodiscard]] auto parse_context::grab_until(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r) & -> decltype(auto) { return grab_until_impl(e, cpp2::impl::out(&r), false); }
-#line 2108 "reflect.h2"
-    [[nodiscard]] auto parse_context::grab_until(cpp2::impl::in<char> e, cpp2::impl::out<std::string> r) & -> decltype(auto) { return grab_until_impl(std::string(1, e), cpp2::impl::out(&r), false); }
 #line 2109 "reflect.h2"
+    [[nodiscard]] auto parse_context::grab_until(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r) & -> decltype(auto) { return grab_until_impl(e, cpp2::impl::out(&r), false); }
+#line 2110 "reflect.h2"
+    [[nodiscard]] auto parse_context::grab_until(cpp2::impl::in<char> e, cpp2::impl::out<std::string> r) & -> decltype(auto) { return grab_until_impl(std::string(1, e), cpp2::impl::out(&r), false); }
+#line 2111 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_until_one_of(cpp2::impl::in<std::string> e, cpp2::impl::out<std::string> r) & -> decltype(auto) { return grab_until_impl(e, cpp2::impl::out(&r), true);  }
 
-#line 2111 "reflect.h2"
+#line 2113 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_n(cpp2::impl::in<int> n, cpp2::impl::out<std::string> r) & -> bool
     {
         if (cpp2::impl::cmp_less_eq(pos + cpp2::impl::as_<size_t>(n),regex.size())) {
@@ -3887,7 +3895,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2124 "reflect.h2"
+#line 2126 "reflect.h2"
     [[nodiscard]] auto parse_context::grab_number() & -> std::string
     {
         auto start {pos}; 
@@ -3909,7 +3917,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return cpp2::move(r.value()); 
     }
 
-#line 2145 "reflect.h2"
+#line 2147 "reflect.h2"
     [[nodiscard]] auto parse_context::peek_impl(cpp2::impl::in<bool> in_class) const& -> char{
         auto next_pos {get_next_position(in_class, false)}; 
         if (cpp2::impl::cmp_less(next_pos,regex.size())) {
@@ -3920,12 +3928,12 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2155 "reflect.h2"
+#line 2157 "reflect.h2"
     [[nodiscard]] auto parse_context::peek() const& -> decltype(auto) { return peek_impl(false); }
-#line 2156 "reflect.h2"
+#line 2158 "reflect.h2"
     [[nodiscard]] auto parse_context::peek_in_class() const& -> decltype(auto) { return peek_impl(true);  }
 
-#line 2161 "reflect.h2"
+#line 2163 "reflect.h2"
     [[nodiscard]] auto parse_context::parser_group_modifiers(cpp2::impl::in<std::string> change_str, expression_flags& parser_modifiers) & -> bool
     {
         auto is_negative {false}; 
@@ -3980,7 +3988,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return true; 
     }
 
-#line 2215 "reflect.h2"
+#line 2217 "reflect.h2"
     [[nodiscard]] auto parse_context::parse_until(cpp2::impl::in<char> term) & -> bool{
         token_ptr cur_token {}; 
 
@@ -4004,6 +4012,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
             if (!(cur_token) && valid()) {cur_token = octal_token_parse((*this)); }
             if (!(cur_token) && valid()) {cur_token = range_token::parse((*this)); }
             if (!(cur_token) && valid()) {cur_token = special_range_token::parse((*this)); }
+            if (!(cur_token) && valid()) {cur_token = start_match_parse((*this)); }
             if (!(cur_token) && valid()) {cur_token = word_boundary_token_parse((*this)); }
 
             // Everything else is matched as it is.
@@ -4019,7 +4028,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return true; 
     }
 
-#line 2253 "reflect.h2"
+#line 2256 "reflect.h2"
     [[nodiscard]] auto parse_context::parse(cpp2::impl::in<std::string> modifiers) & -> bool
     {
 
@@ -4035,21 +4044,21 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         return r; 
     }
 
-#line 2270 "reflect.h2"
+#line 2273 "reflect.h2"
     [[nodiscard]] auto parse_context::get_pos() const& -> decltype(auto) { return pos; }
-#line 2271 "reflect.h2"
+#line 2274 "reflect.h2"
     [[nodiscard]] auto parse_context::get_range(cpp2::impl::in<size_t> start, cpp2::impl::in<size_t> end) const& -> decltype(auto) { return std::string(regex.substr(start, end - start + 1));  }
-#line 2272 "reflect.h2"
+#line 2275 "reflect.h2"
     [[nodiscard]] auto parse_context::valid() const& -> bool{return has_next() && !(has_error); }
 
-#line 2274 "reflect.h2"
+#line 2277 "reflect.h2"
     [[nodiscard]] auto parse_context::error(cpp2::impl::in<std::string> err) & -> token_ptr{
         has_error = true;
         error_out("Error during parsing of regex '" + cpp2::to_string(regex) + "' at position '" + cpp2::to_string(pos) + "': " + cpp2::to_string(err) + "");
         return nullptr; 
     }
 
-#line 2289 "reflect.h2"
+#line 2292 "reflect.h2"
     auto generation_function_context::add_tabs(cpp2::impl::in<int> c) & -> void{
         int i {0}; 
         for( ; cpp2::impl::cmp_less(i,c); i += 1 ) {
@@ -4057,7 +4066,7 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
         }
     }
 
-#line 2296 "reflect.h2"
+#line 2299 "reflect.h2"
     auto generation_function_context::remove_tabs(cpp2::impl::in<int> c) & -> void{
         tabs = tabs.substr(0, (cpp2::impl::as_<size_t>(c)) * 2);
     }
@@ -4067,22 +4076,22 @@ parse_context_branch_reset_state::parse_context_branch_reset_state(){}
                                                        , tabs{ tabs_ }{}
 generation_function_context::generation_function_context(){}
 
-#line 2314 "reflect.h2"
+#line 2317 "reflect.h2"
     [[nodiscard]] auto generation_context::match_parameters() const& -> std::string{return "r.pos, ctx"; }
 
-#line 2319 "reflect.h2"
+#line 2322 "reflect.h2"
     auto generation_context::add(cpp2::impl::in<std::string> s) & -> void{
         auto cur {get_current()}; 
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + cpp2::to_string(s) + "\n";
     }
 
-#line 2325 "reflect.h2"
+#line 2328 "reflect.h2"
     auto generation_context::add_check(cpp2::impl::in<std::string> check) & -> void{
         auto cur {get_current()}; 
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "if !cpp2::regex::" + cpp2::to_string(check) + " { r.matched = false; break; }\n";
     }
 
-#line 2331 "reflect.h2"
+#line 2334 "reflect.h2"
     auto generation_context::add_statefull(cpp2::impl::in<std::string> next_func, cpp2::impl::in<std::string> check) & -> void
     {
         end_func_statefull(check);
@@ -4091,7 +4100,7 @@ generation_function_context::generation_function_context(){}
         start_func_named(cpp2::move(name));
     }
 
-#line 2339 "reflect.h2"
+#line 2342 "reflect.h2"
     auto generation_context::start_func_named(cpp2::impl::in<std::string> name) & -> void
     {
         auto cur {new_context()}; 
@@ -4103,7 +4112,7 @@ generation_function_context::generation_function_context(){}
         (*cpp2::impl::assert_not_null(cpp2::move(cur))).add_tabs(3);
     }
 
-#line 2350 "reflect.h2"
+#line 2353 "reflect.h2"
     [[nodiscard]] auto generation_context::start_func() & -> std::string
     {
         auto name {gen_func_name()}; 
@@ -4111,7 +4120,7 @@ generation_function_context::generation_function_context(){}
         return cpp2::move(name) + "()"; 
     }
 
-#line 2357 "reflect.h2"
+#line 2360 "reflect.h2"
     auto generation_context::end_func_statefull(cpp2::impl::in<std::string> s) & -> void
     {
         auto cur {get_current()}; 
@@ -4131,7 +4140,7 @@ generation_function_context::generation_function_context(){}
         finish_context();
     }
 
-#line 2377 "reflect.h2"
+#line 2380 "reflect.h2"
     [[nodiscard]] auto generation_context::generate_func(cpp2::impl::in<token_ptr> token) & -> std::string
     {
         auto name {start_func()}; 
@@ -4141,7 +4150,7 @@ generation_function_context::generation_function_context(){}
         return name; 
     }
 
-#line 2387 "reflect.h2"
+#line 2390 "reflect.h2"
     [[nodiscard]] auto generation_context::generate_reset(cpp2::impl::in<std::set<int>> groups) & -> std::string
     {
         if (groups.empty()) {
@@ -4164,33 +4173,33 @@ generation_function_context::generation_function_context(){}
         return cpp2::move(name) + "()"; 
     }
 
-#line 2411 "reflect.h2"
+#line 2414 "reflect.h2"
     [[nodiscard]] auto generation_context::gen_func_name() & -> std::string{
         auto cur_id {matcher_func}; 
         matcher_func += 1;
         return "func_" + cpp2::to_string(cpp2::move(cur_id)) + ""; 
     }
 
-#line 2417 "reflect.h2"
+#line 2420 "reflect.h2"
     [[nodiscard]] auto generation_context::next_func_name() & -> std::string{
         return gen_func_name() + "()"; 
     }
 
-#line 2421 "reflect.h2"
+#line 2424 "reflect.h2"
     [[nodiscard]] auto generation_context::gen_reset_func_name() & -> std::string{
         auto cur_id {reset_func}; 
         reset_func += 1;
         return "reset_" + cpp2::to_string(cpp2::move(cur_id)) + ""; 
     }
 
-#line 2427 "reflect.h2"
+#line 2430 "reflect.h2"
     [[nodiscard]] auto generation_context::gen_temp() & -> std::string{
         auto cur_id {temp_name}; 
         temp_name += 1;
         return "tmp_" + cpp2::to_string(cpp2::move(cur_id)) + ""; 
     }
 
-#line 2435 "reflect.h2"
+#line 2438 "reflect.h2"
     [[nodiscard]] auto generation_context::new_context() & -> generation_function_context*{
         gen_stack.push_back(generation_function_context());
         auto cur {get_current()}; 
@@ -4199,7 +4208,7 @@ generation_function_context::generation_function_context(){}
         return cur; 
     }
 
-#line 2443 "reflect.h2"
+#line 2446 "reflect.h2"
     auto generation_context::finish_context() & -> void{
         auto cur {get_current()}; 
         auto base {get_base()}; 
@@ -4208,22 +4217,22 @@ generation_function_context::generation_function_context(){}
         gen_stack.pop_back();
     }
 
-#line 2453 "reflect.h2"
+#line 2456 "reflect.h2"
     [[nodiscard]] auto generation_context::get_current() & -> generation_function_context*{
         return &gen_stack.back(); 
     }
 
-#line 2457 "reflect.h2"
+#line 2460 "reflect.h2"
     [[nodiscard]] auto generation_context::get_base() & -> generation_function_context*{
         return &CPP2_ASSERT_IN_BOUNDS_LITERAL(gen_stack, 0); 
     }
 
-#line 2461 "reflect.h2"
+#line 2464 "reflect.h2"
     [[nodiscard]] auto generation_context::get_entry_func() const& -> std::string{
         return entry_func; 
     }
 
-#line 2465 "reflect.h2"
+#line 2468 "reflect.h2"
     [[nodiscard]] auto generation_context::create_named_group_lookup(cpp2::impl::in<std::map<std::string,int>> named_groups) const& -> std::string
     {
         std::string res {"get_named_group_index: (name) -> int = {\n"}; 
@@ -4247,18 +4256,18 @@ generation_function_context::generation_function_context(){}
         return res; 
     }
 
-#line 2490 "reflect.h2"
+#line 2493 "reflect.h2"
     [[nodiscard]] auto generation_context::run(cpp2::impl::in<token_ptr> token) & -> std::string{
         entry_func = generate_func(token);
 
         return (*cpp2::impl::assert_not_null(get_base())).code; 
     }
 
-#line 2505 "reflect.h2"
+#line 2508 "reflect.h2"
     alternative_token::alternative_token()
                             : regex_token_empty{ "" }{}
 
-#line 2507 "reflect.h2"
+#line 2510 "reflect.h2"
     [[nodiscard]] auto alternative_token::parse(parse_context& ctx) -> token_ptr{
         if (ctx.current() != '|') {return nullptr; }
 
@@ -4269,15 +4278,15 @@ generation_function_context::generation_function_context(){}
 
     alternative_token::~alternative_token() noexcept{}
 
-#line 2522 "reflect.h2"
+#line 2525 "reflect.h2"
     alternative_token_gen::alternative_token_gen(cpp2::impl::in<token_vec> a)
         : regex_token{ gen_string(a) }
         , alternatives{ a }{
 
-#line 2525 "reflect.h2"
+#line 2528 "reflect.h2"
     }
 
-#line 2527 "reflect.h2"
+#line 2530 "reflect.h2"
     auto alternative_token_gen::generate_code(generation_context& ctx) const -> void
     {
         std::string functions {""}; 
@@ -4295,7 +4304,7 @@ generation_function_context::generation_function_context(){}
         ctx.add_statefull(next_name, "cpp2::regex::alternative_token_matcher<char>::match(" + cpp2::to_string(ctx.match_parameters()) + ", other, " + cpp2::to_string(next_name) + " " + cpp2::to_string(cpp2::move(functions)) + ")");
     }
 
-#line 2544 "reflect.h2"
+#line 2547 "reflect.h2"
     auto alternative_token_gen::add_groups(std::set<int>& groups) const -> void
     {
         for ( auto const& cur : alternatives ) {
@@ -4303,7 +4312,7 @@ generation_function_context::generation_function_context(){}
         }
     }
 
-#line 2551 "reflect.h2"
+#line 2554 "reflect.h2"
     [[nodiscard]] auto alternative_token_gen::gen_string(cpp2::impl::in<token_vec> a) -> std::string
     {
         std::string r {""}; 
@@ -4319,14 +4328,14 @@ generation_function_context::generation_function_context(){}
 
     alternative_token_gen::~alternative_token_gen() noexcept{}
 
-#line 2572 "reflect.h2"
+#line 2575 "reflect.h2"
     any_token::any_token(cpp2::impl::in<bool> single_line)
         : regex_token_check{ ".", "any_token_matcher<char, " + cpp2::to_string(single_line) + ">" }{
 
-#line 2574 "reflect.h2"
+#line 2577 "reflect.h2"
     }
 
-#line 2576 "reflect.h2"
+#line 2579 "reflect.h2"
     [[nodiscard]] auto any_token::parse(parse_context& ctx) -> token_ptr{
         if ('.' != ctx.current()) {return nullptr; }
 
@@ -4335,21 +4344,21 @@ generation_function_context::generation_function_context(){}
 
     any_token::~any_token() noexcept{}
 
-#line 2593 "reflect.h2"
+#line 2596 "reflect.h2"
     char_token::char_token(cpp2::impl::in<char> t, cpp2::impl::in<bool> ignore_case_)
         : regex_token{ std::string(1, t) }
         , token{ t }
         , ignore_case{ ignore_case_ }{
 
-#line 2597 "reflect.h2"
+#line 2600 "reflect.h2"
     }
 
-#line 2599 "reflect.h2"
+#line 2602 "reflect.h2"
     [[nodiscard]] auto char_token::parse(parse_context& ctx) -> token_ptr{
         return CPP2_UFCS_TEMPLATE(cpp2_new<char_token>)(cpp2::shared, ctx.current(), ctx.get_modifiers().has(expression_flags::case_insensitive)); 
     }
 
-#line 2603 "reflect.h2"
+#line 2606 "reflect.h2"
     auto char_token::generate_code(generation_context& ctx) const -> void
     {
         if (ignore_case) {
@@ -4358,14 +4367,14 @@ generation_function_context::generation_function_context(){}
 {
 size_t i{0};
 
-#line 2609 "reflect.h2"
+#line 2612 "reflect.h2"
             for( ; cpp2::impl::cmp_less(i,token.size()); i += 1 ) {
                 CPP2_ASSERT_IN_BOUNDS(lower, i) = string_util::safe_tolower(CPP2_ASSERT_IN_BOUNDS(token, i));
                 CPP2_ASSERT_IN_BOUNDS(upper, i) = string_util::safe_toupper(CPP2_ASSERT_IN_BOUNDS(token, i));
             }
 }
 
-#line 2614 "reflect.h2"
+#line 2617 "reflect.h2"
             if (upper != lower) {
                 gen_case_insensitive(cpp2::move(lower), cpp2::move(upper), ctx);
             }
@@ -4378,7 +4387,7 @@ size_t i{0};
         }
     }
 
-#line 2626 "reflect.h2"
+#line 2629 "reflect.h2"
     auto char_token::gen_case_insensitive(cpp2::impl::in<std::string> lower, cpp2::impl::in<std::string> upper, generation_context& ctx) const& -> void
     {
         std::string name {"str_" + cpp2::to_string(ctx.gen_temp()) + ""}; 
@@ -4400,7 +4409,7 @@ size_t i{0};
         ctx.add("else { break; }");
     }
 
-#line 2647 "reflect.h2"
+#line 2650 "reflect.h2"
     auto char_token::gen_case_sensitive(generation_context& ctx) const& -> void
     {
         std::string name {"str_" + cpp2::to_string(ctx.gen_temp()) + ""}; 
@@ -4419,7 +4428,7 @@ size_t i{0};
         ctx.add("else { break; }");
     }
 
-#line 2665 "reflect.h2"
+#line 2668 "reflect.h2"
     [[nodiscard]] auto char_token::add_escapes(std::string str) const& -> std::string
     {
         str = string_util::replace_all(str, "\\", "\\\\");
@@ -4435,7 +4444,7 @@ size_t i{0};
         return cpp2::move(str); 
     }
 
-#line 2680 "reflect.h2"
+#line 2683 "reflect.h2"
     auto char_token::append(char_token const& that) & -> void{
         (*this).token += that.token;
         (*this).string_rep += that.string_rep;
@@ -4443,19 +4452,19 @@ size_t i{0};
 
     char_token::~char_token() noexcept{}
 
-#line 2697 "reflect.h2"
+#line 2700 "reflect.h2"
     class_token::class_token(cpp2::impl::in<bool> negate_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> class_str_, cpp2::impl::in<std::string> str)
         : regex_token{ str }
         , negate{ negate_ }
         , case_insensitive{ case_insensitive_ }
         , class_str{ class_str_ }
-#line 2698 "reflect.h2"
+#line 2701 "reflect.h2"
     {
 
-#line 2703 "reflect.h2"
+#line 2706 "reflect.h2"
     }
 
-#line 2706 "reflect.h2"
+#line 2709 "reflect.h2"
     [[nodiscard]] auto class_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '[') {return nullptr; }
@@ -4581,13 +4590,13 @@ size_t i{0};
             ); 
     }
 
-#line 2831 "reflect.h2"
+#line 2834 "reflect.h2"
     auto class_token::generate_code(generation_context& ctx) const -> void
     {
         ctx.add_check("class_token_matcher<char, " + cpp2::to_string(negate) + ", " + cpp2::to_string(case_insensitive) + ", " + cpp2::to_string(class_str) + ">::match(" + cpp2::to_string(ctx.match_parameters()) + ")");
     }
 
-#line 2836 "reflect.h2"
+#line 2839 "reflect.h2"
     [[nodiscard]] auto class_token::create_matcher(cpp2::impl::in<std::string> name, cpp2::impl::in<std::string> template_arguments) -> std::string
     {
         auto sep {", "}; 
@@ -4598,12 +4607,12 @@ size_t i{0};
 
     class_token::~class_token() noexcept{}
 
-#line 2848 "reflect.h2"
+#line 2851 "reflect.h2"
 [[nodiscard]] auto escape_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
 
-#line 2853 "reflect.h2"
+#line 2856 "reflect.h2"
     if (std::string::npos == std::string("afenrt^.[]()*{}?+|\\").find(ctx.peek())) {
         return nullptr; 
     }
@@ -4637,7 +4646,7 @@ size_t i{0};
 
 }
 
-#line 2889 "reflect.h2"
+#line 2892 "reflect.h2"
 [[nodiscard]] auto global_group_reset_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'K'))) {return nullptr; }
@@ -4646,18 +4655,18 @@ size_t i{0};
     return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_code>)(cpp2::shared, "\\K", "ctx..set_group_start(0, r.pos);"); 
 }
 
-#line 2911 "reflect.h2"
+#line 2914 "reflect.h2"
     group_ref_token::group_ref_token(cpp2::impl::in<int> id_, cpp2::impl::in<bool> case_insensitive_, cpp2::impl::in<std::string> str)
         : regex_token{ str }
         , id{ id_ }
         , case_insensitive{ case_insensitive_ }
-#line 2912 "reflect.h2"
+#line 2915 "reflect.h2"
     {
 
-#line 2916 "reflect.h2"
+#line 2919 "reflect.h2"
     }
 
-#line 2918 "reflect.h2"
+#line 2921 "reflect.h2"
     [[nodiscard]] auto group_ref_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '\\') {return nullptr; }
@@ -4759,14 +4768,14 @@ size_t i{0};
         return CPP2_UFCS_TEMPLATE(cpp2_new<group_ref_token>)(cpp2::shared, cpp2::move(group_id), ctx.get_modifiers().has(expression_flags::case_insensitive), cpp2::move(str)); 
     }
 
-#line 3019 "reflect.h2"
+#line 3022 "reflect.h2"
     auto group_ref_token::generate_code(generation_context& ctx) const -> void{
         ctx.add_check("group_ref_token_matcher<char, " + cpp2::to_string(id) + ", " + cpp2::to_string(case_insensitive) + ">(" + cpp2::to_string(ctx.match_parameters()) + ")");
     }
 
     group_ref_token::~group_ref_token() noexcept{}
 
-#line 3042 "reflect.h2"
+#line 3045 "reflect.h2"
     [[nodiscard]] auto group_token::parse_lookahead(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> positive) -> token_ptr
     {
         static_cast<void>(ctx.next());// Skip last token defining the syntax
@@ -4781,7 +4790,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3056 "reflect.h2"
+#line 3059 "reflect.h2"
     [[nodiscard]] auto group_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '(') {return nullptr; }
@@ -4919,7 +4928,7 @@ size_t i{0};
         }
     }
 
-#line 3193 "reflect.h2"
+#line 3196 "reflect.h2"
     [[nodiscard]] auto group_token::gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string
     {
         std::string start {"("}; 
@@ -4938,7 +4947,7 @@ size_t i{0};
         return cpp2::move(start) + (*cpp2::impl::assert_not_null(inner_)).to_string() + ")"; 
     }
 
-#line 3211 "reflect.h2"
+#line 3214 "reflect.h2"
     auto group_token::generate_code(generation_context& ctx) const -> void
     {
         if (-1 != number) {
@@ -4959,7 +4968,7 @@ size_t i{0};
         }
     }
 
-#line 3231 "reflect.h2"
+#line 3234 "reflect.h2"
     auto group_token::add_groups(std::set<int>& groups) const -> void
     {
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
@@ -4970,7 +4979,7 @@ size_t i{0};
 
     group_token::~group_token() noexcept{}
 
-#line 3243 "reflect.h2"
+#line 3246 "reflect.h2"
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'x'))) {return nullptr; }
@@ -5009,7 +5018,7 @@ size_t i{0};
     return r; 
 }
 
-#line 3284 "reflect.h2"
+#line 3287 "reflect.h2"
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() == '$' || (ctx.current() == '\\' && ctx.peek() == '$')) {
@@ -5027,7 +5036,7 @@ size_t i{0};
     }}
 }
 
-#line 3304 "reflect.h2"
+#line 3307 "reflect.h2"
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '^' && !((ctx.current() == '\\' && ctx.peek() == 'A'))) {return nullptr; }
@@ -5041,29 +5050,29 @@ size_t i{0};
     }
 }
 
-#line 3329 "reflect.h2"
+#line 3332 "reflect.h2"
     lookahead_token::lookahead_token(cpp2::impl::in<bool> positive_)
         : regex_token{ "" }
         , positive{ positive_ }{
 
-#line 3331 "reflect.h2"
+#line 3334 "reflect.h2"
     }
 
-#line 3333 "reflect.h2"
+#line 3336 "reflect.h2"
     auto lookahead_token::generate_code(generation_context& ctx) const -> void{
         auto inner_name {ctx.generate_func(inner)}; 
 
         ctx.add_check("lookahead_token_matcher<char, " + cpp2::to_string(positive) + ">(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ")");
     }
 
-#line 3339 "reflect.h2"
+#line 3342 "reflect.h2"
     auto lookahead_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
     }
 
     lookahead_token::~lookahead_token() noexcept{}
 
-#line 3347 "reflect.h2"
+#line 3350 "reflect.h2"
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5089,7 +5098,7 @@ size_t i{0};
     return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_check>)(cpp2::shared, "\\" + cpp2::to_string(ctx.current()) + "", "" + cpp2::to_string(cpp2::move(name)) + "<char, " + cpp2::to_string(ctx.get_modifiers().has(expression_flags::case_insensitive)) + ">::match"); 
 }
 
-#line 3375 "reflect.h2"
+#line 3378 "reflect.h2"
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'o'))) {return nullptr; }
@@ -5115,11 +5124,11 @@ size_t i{0};
     return r; 
 }
 
-#line 3412 "reflect.h2"
+#line 3415 "reflect.h2"
     range_token::range_token()
                              : regex_token{ "" }{}
 
-#line 3414 "reflect.h2"
+#line 3417 "reflect.h2"
     [[nodiscard]] auto range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<range_token>)(cpp2::shared)}; 
@@ -5193,7 +5202,7 @@ size_t i{0};
         return nullptr; 
     }
 
-#line 3487 "reflect.h2"
+#line 3490 "reflect.h2"
     auto range_token::parse_modifier(parse_context& ctx) & -> void
     {
         if (ctx.peek() == '?') {
@@ -5206,7 +5215,7 @@ size_t i{0};
         }}
     }
 
-#line 3499 "reflect.h2"
+#line 3502 "reflect.h2"
     [[nodiscard]] auto range_token::gen_mod_string() const& -> std::string
     {
         if (kind == range_flags::not_greedy) {
@@ -5220,7 +5229,7 @@ size_t i{0};
         }}
     }
 
-#line 3512 "reflect.h2"
+#line 3515 "reflect.h2"
     [[nodiscard]] auto range_token::gen_range_string() const& -> std::string
     {
         std::string r {""}; 
@@ -5240,7 +5249,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3531 "reflect.h2"
+#line 3534 "reflect.h2"
     auto range_token::generate_code(generation_context& ctx) const -> void
     {
         auto inner_name {ctx.generate_func(inner_token)}; 
@@ -5252,14 +5261,14 @@ size_t i{0};
         ctx.add_statefull(next_name, "cpp2::regex::range_token_matcher<char, " + cpp2::to_string(min_count) + ", " + cpp2::to_string(max_count) + ", " + cpp2::to_string(kind) + ">::match(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ", " + cpp2::to_string(cpp2::move(reset_name)) + ", other, " + cpp2::to_string(next_name) + ")");
     }
 
-#line 3542 "reflect.h2"
+#line 3545 "reflect.h2"
     auto range_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner_token)).add_groups(groups);
     }
 
     range_token::~range_token() noexcept{}
 
-#line 3555 "reflect.h2"
+#line 3558 "reflect.h2"
     [[nodiscard]] auto special_range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<special_range_token>)(cpp2::shared)}; 
@@ -5283,7 +5292,7 @@ size_t i{0};
 
         if (!(ctx.has_token())) {return ctx.error("'" + cpp2::to_string(ctx.current()) + "' without previous element."); }
 
-#line 3579 "reflect.h2"
+#line 3582 "reflect.h2"
         (*cpp2::impl::assert_not_null(r)).parse_modifier(ctx);
 
         (*cpp2::impl::assert_not_null(r)).inner_token = ctx.pop_token();
@@ -5293,7 +5302,23 @@ size_t i{0};
 
     special_range_token::~special_range_token() noexcept{}
 
-#line 3592 "reflect.h2"
+#line 3594 "reflect.h2"
+[[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr
+{
+    if (ctx.current() != '\\') {return nullptr; }
+
+    if (ctx.peek() == 'G') {
+        if (0 != ctx.get_pos()) {return ctx.error("\\G is only supported at the first position in the regex."); }
+        static_cast<void>(ctx.next());
+        ctx.is_start_match = true;
+        return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_empty>)(cpp2::shared, "\\G"); 
+    }
+    else {
+        return nullptr; 
+    }
+}
+
+#line 3614 "reflect.h2"
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5311,15 +5336,15 @@ size_t i{0};
     }}
 }
 
-#line 3628 "reflect.h2"
+#line 3650 "reflect.h2"
     template <typename Error_out> regex_generator<Error_out>::regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e)
         : regex{ r }
         , error_out{ e }{
 
-#line 3631 "reflect.h2"
+#line 3653 "reflect.h2"
     }
 
-#line 3633 "reflect.h2"
+#line 3655 "reflect.h2"
     template <typename Error_out> [[nodiscard]] auto regex_generator<Error_out>::parse() & -> std::string
     {
         // Extract modifiers and adapt regex.
@@ -5344,10 +5369,12 @@ size_t i{0};
         source += "  }\n";
 
         source += cpp2::move(gen_ctx).create_named_group_lookup(parse_ctx.named_groups);
-        source += "}\n";
+        source += "  is_start_match: () -> bool == " + cpp2::to_string(parse_ctx.is_start_match) + ";";
+        source += "}\n"; // wrap end
 
         auto string {(*cpp2::impl::assert_not_null(parse_ctx.get_as_token())).to_string()}; 
         source += "  to_string: () -> std::string = { return R\"(" + cpp2::to_string(modifier_escape) + cpp2::to_string(cpp2::move(string)) + cpp2::to_string(modifier_escape) + cpp2::to_string(modifier) + ")\"; }\n";
+
         source += "}\n";
 
         static_cast<void>(cpp2::move(parse_ctx));
@@ -5355,7 +5382,7 @@ size_t i{0};
         return source; 
     }
 
-#line 3668 "reflect.h2"
+#line 3692 "reflect.h2"
     template <typename Error_out> auto regex_generator<Error_out>::extract_modifiers() & -> void
     {
         if (regex.find_first_of("'/") == 0) {
@@ -5371,7 +5398,7 @@ size_t i{0};
         }
     }
 
-#line 3684 "reflect.h2"
+#line 3708 "reflect.h2"
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string
 {
     regex_generator<Err> parser {regex, err}; 
@@ -5380,7 +5407,7 @@ template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::str
     return r; 
 }
 
-#line 3694 "reflect.h2"
+#line 3718 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void
 {
     auto has_default {false}; 
@@ -5435,7 +5462,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     CPP2_UFCS(add_runtime_support_include)(t, "cpp2regex.h");
 }
 
-#line 3753 "reflect.h2"
+#line 3777 "reflect.h2"
 [[nodiscard]] auto apply_metafunctions(
     declaration_node& n, 
     type_declaration& rtype, 
@@ -5548,7 +5575,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     return true; 
 }
 
-#line 3866 "reflect.h2"
+#line 3890 "reflect.h2"
 }
 
 }

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -4955,7 +4955,7 @@ size_t i{0};
         (*cpp2::impl::assert_not_null(r)).set_string("(" + cpp2::to_string(syntax) + cpp2::to_string((*cpp2::impl::assert_not_null((*cpp2::impl::assert_not_null(r)).inner)).to_string()) + ")");
 
         if (!(lookahead)) {
-            (*cpp2::impl::assert_not_null(r)).inner = CPP2_UFCS(reverse)((*cpp2::impl::assert_not_null((*cpp2::impl::assert_not_null(r)).inner)));
+            (*cpp2::impl::assert_not_null(r)).inner = (*cpp2::impl::assert_not_null((*cpp2::impl::assert_not_null(r)).inner)).reverse();
         }
 
         return r; 

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -100,19 +100,19 @@ class group_ref_token;
 #line 3098 "reflect.h2"
 class group_token;
 
-#line 3405 "reflect.h2"
-class lookahead_token;
+#line 3423 "reflect.h2"
+class lookahead_lookbehind_token;
 
-#line 3490 "reflect.h2"
+#line 3515 "reflect.h2"
 class range_token;
 
-#line 3648 "reflect.h2"
+#line 3673 "reflect.h2"
 class special_range_token;
 
-#line 3734 "reflect.h2"
+#line 3759 "reflect.h2"
 template<typename Error_out> class regex_generator;
 
-#line 3984 "reflect.h2"
+#line 4009 "reflect.h2"
 }
 
 }
@@ -1322,21 +1322,21 @@ class group_token
     private: bool reverse_eval {false}; 
     private: token_ptr inner {nullptr}; 
 
-    public: [[nodiscard]] static auto parse_lookahead(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> positive) -> token_ptr;
+    public: [[nodiscard]] static auto parse_lookahead_lookbehind(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> lookahead, cpp2::impl::in<bool> positive) -> token_ptr;
 
-#line 3120 "reflect.h2"
+#line 3124 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3257 "reflect.h2"
+#line 3275 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3265 "reflect.h2"
+#line 3283 "reflect.h2"
     public: [[nodiscard]] static auto gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string;
 
-#line 3283 "reflect.h2"
+#line 3301 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3314 "reflect.h2"
+#line 3332 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~group_token() noexcept;
 
@@ -1345,72 +1345,73 @@ class group_token
     public: auto operator=(group_token const&) -> void = delete;
 
 
-#line 3321 "reflect.h2"
+#line 3339 "reflect.h2"
 };
 
-#line 3324 "reflect.h2"
+#line 3342 "reflect.h2"
 //  Regex syntax: \x<number> or \x{<number>}  Example: \x{62}
 //
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3365 "reflect.h2"
+#line 3383 "reflect.h2"
 //  Regex syntax: $  Example: aa$
 //
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3385 "reflect.h2"
+#line 3403 "reflect.h2"
 //  Regex syntax: ^  Example: ^aa
 //
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3401 "reflect.h2"
+#line 3419 "reflect.h2"
 //  Regex syntax: (?=) or (?!) or (*pla), etc.  Example: (?=AA)
 //
 //  Parsed in group_token.
 //
-class lookahead_token
+class lookahead_lookbehind_token
 : public regex_token {
 
-#line 3409 "reflect.h2"
+#line 3427 "reflect.h2"
+    protected: bool lookahead; 
     protected: bool positive; 
     public:   token_ptr inner {nullptr}; 
 
-    public: explicit lookahead_token(cpp2::impl::in<bool> positive_);
+    public: explicit lookahead_lookbehind_token(cpp2::impl::in<bool> lookahead_, cpp2::impl::in<bool> positive_);
 
-#line 3416 "reflect.h2"
+#line 3436 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3422 "reflect.h2"
+#line 3447 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3426 "reflect.h2"
+#line 3451 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
-    public: virtual ~lookahead_token() noexcept;
+    public: virtual ~lookahead_lookbehind_token() noexcept;
 
-    public: lookahead_token(lookahead_token const&) = delete; /* No 'that' constructor, suppress copy */
-    public: auto operator=(lookahead_token const&) -> void = delete;
+    public: lookahead_lookbehind_token(lookahead_lookbehind_token const&) = delete; /* No 'that' constructor, suppress copy */
+    public: auto operator=(lookahead_lookbehind_token const&) -> void = delete;
 
 
-#line 3429 "reflect.h2"
+#line 3454 "reflect.h2"
 };
 
-#line 3432 "reflect.h2"
+#line 3457 "reflect.h2"
 // Named character classes
 //
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3460 "reflect.h2"
+#line 3485 "reflect.h2"
 //  Regex syntax: \o{<number>}  Example: \o{142}
 //
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3488 "reflect.h2"
+#line 3513 "reflect.h2"
 //  Regex syntax: <matcher>{min, max}  Example: a{2,4}
 //
 class range_token
 : public regex_token {
 
-#line 3494 "reflect.h2"
+#line 3519 "reflect.h2"
               protected: int min_count {-1}; 
               protected: int max_count {-1}; 
               protected: int kind {range_flags::greedy}; 
@@ -1420,22 +1421,22 @@ class range_token
 
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
 
-#line 3574 "reflect.h2"
+#line 3599 "reflect.h2"
     public: auto parse_modifier(parse_context& ctx) & -> void;
 
-#line 3586 "reflect.h2"
+#line 3611 "reflect.h2"
     public: [[nodiscard]] auto gen_mod_string() const& -> std::string;
 
-#line 3599 "reflect.h2"
+#line 3624 "reflect.h2"
     public: [[nodiscard]] auto gen_range_string() const& -> std::string;
 
-#line 3618 "reflect.h2"
+#line 3643 "reflect.h2"
     public: [[nodiscard]] auto reverse() const -> token_ptr override;
 
-#line 3628 "reflect.h2"
+#line 3653 "reflect.h2"
     public: auto generate_code(generation_context& ctx) const -> void override;
 
-#line 3639 "reflect.h2"
+#line 3664 "reflect.h2"
     public: auto add_groups(std::set<int>& groups) const -> void override;
     public: virtual ~range_token() noexcept;
 
@@ -1443,16 +1444,16 @@ class range_token
     public: auto operator=(range_token const&) -> void = delete;
 
 
-#line 3643 "reflect.h2"
+#line 3668 "reflect.h2"
 };
 
-#line 3646 "reflect.h2"
+#line 3671 "reflect.h2"
 //  Regex syntax: *, +, or ?  Example: aa*
 //
 class special_range_token
 : public range_token {
 
-#line 3652 "reflect.h2"
+#line 3677 "reflect.h2"
     public: [[nodiscard]] static auto parse(parse_context& ctx) -> token_ptr;
     public: virtual ~special_range_token() noexcept;
 
@@ -1461,7 +1462,7 @@ class special_range_token
     public: auto operator=(special_range_token const&) -> void = delete;
 
 
-#line 3682 "reflect.h2"
+#line 3707 "reflect.h2"
 };
 
 //  Regex syntax: \G  Example: \Gaa
@@ -1470,14 +1471,14 @@ class special_range_token
 //
 [[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr;
 
-#line 3704 "reflect.h2"
+#line 3729 "reflect.h2"
 //  Regex syntax: \b or \B  Example: \bword\b
 //
 //  Matches the start end end of word boundaries.
 //
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr;
 
-#line 3726 "reflect.h2"
+#line 3751 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  Parser for regular expression.
@@ -1498,24 +1499,24 @@ template<typename Error_out> class regex_generator
 
     public: explicit regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e);
 
-#line 3749 "reflect.h2"
+#line 3774 "reflect.h2"
     public: [[nodiscard]] auto parse() & -> std::string;
 
-#line 3786 "reflect.h2"
+#line 3811 "reflect.h2"
     private: auto extract_modifiers() & -> void;
     public: regex_generator(regex_generator const&) = delete; /* No 'that' constructor, suppress copy */
     public: auto operator=(regex_generator const&) -> void = delete;
 
 
-#line 3800 "reflect.h2"
+#line 3825 "reflect.h2"
 };
 
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string;
 
-#line 3812 "reflect.h2"
+#line 3837 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void;
 
-#line 3867 "reflect.h2"
+#line 3892 "reflect.h2"
 //-----------------------------------------------------------------------
 //
 //  apply_metafunctions
@@ -1526,7 +1527,7 @@ auto regex_gen(meta::type_declaration& t) -> void;
     auto const& error
     ) -> bool;
 
-#line 3984 "reflect.h2"
+#line 4009 "reflect.h2"
 }
 
 }
@@ -4882,21 +4883,25 @@ size_t i{0};
     group_ref_token::~group_ref_token() noexcept{}
 
 #line 3106 "reflect.h2"
-    [[nodiscard]] auto group_token::parse_lookahead(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> positive) -> token_ptr
+    [[nodiscard]] auto group_token::parse_lookahead_lookbehind(parse_context& ctx, cpp2::impl::in<std::string> syntax, cpp2::impl::in<bool> lookahead, cpp2::impl::in<bool> positive) -> token_ptr
     {
         static_cast<void>(ctx.next());// Skip last token defining the syntax
 
-        auto r {CPP2_UFCS_TEMPLATE(cpp2_new<lookahead_token>)(cpp2::shared, positive)}; 
+        auto r {CPP2_UFCS_TEMPLATE(cpp2_new<lookahead_lookbehind_token>)(cpp2::shared, lookahead, positive)}; 
 
         auto old_state {ctx.start_group()}; 
-        if (!(ctx.parse_until(')'))) {return ctx.error("Lookahead without a closing bracket."); }
+        if (!(ctx.parse_until(')'))) {return ctx.error("Group without a closing bracket."); }
         (*cpp2::impl::assert_not_null(r)).inner = ctx.end_group(cpp2::move(old_state));
         (*cpp2::impl::assert_not_null(r)).set_string("(" + cpp2::to_string(syntax) + cpp2::to_string((*cpp2::impl::assert_not_null((*cpp2::impl::assert_not_null(r)).inner)).to_string()) + ")");
+
+        if (!(lookahead)) {
+            (*cpp2::impl::assert_not_null(r)).inner = CPP2_UFCS(reverse)((*cpp2::impl::assert_not_null((*cpp2::impl::assert_not_null(r)).inner)));
+        }
 
         return r; 
     }
 
-#line 3120 "reflect.h2"
+#line 3124 "reflect.h2"
     [[nodiscard]] auto group_token::parse(parse_context& ctx) -> token_ptr
     {
         if (ctx.current() != '(') {return nullptr; }
@@ -4916,7 +4921,14 @@ size_t i{0};
             //  Special group
             if (!(ctx.next_no_skip())) {return ctx.error("Missing character after group opening."); }
 
-            if (ctx.current() == '<' || ctx.current() == '\'') 
+            if ( CPP2_UFCS(current)(ctx) == '<' && (CPP2_UFCS(peek)(ctx) == '=' || CPP2_UFCS(peek)(ctx) == '!')) 
+            {
+                // Lookbehind
+                static_cast<void>(CPP2_UFCS(next)(ctx));// Skip the '<'
+
+                return parse_lookahead_lookbehind(ctx, "?<" + cpp2::to_string(ctx.current()) + "", false, ctx.current() == '='); 
+            }
+            else {if (ctx.current() == '<' || ctx.current() == '\'') 
             {
                 //  Named group
                 auto end_char {ctx.current()}; 
@@ -4967,7 +4979,8 @@ size_t i{0};
             }
             else {if (ctx.current() == '=' || ctx.current() == '!') 
             {
-                return parse_lookahead(ctx, "?" + cpp2::to_string(ctx.current()) + "", ctx.current() == '='); 
+                // Lookahead
+                return parse_lookahead_lookbehind(ctx, "?" + cpp2::to_string(ctx.current()) + "", true, ctx.current() == '='); 
             }
             else 
             {
@@ -4984,7 +4997,7 @@ size_t i{0};
                 else {
                     if (!(ctx.next()))            { return ctx. error("Missing ending bracket for group.");  }/* skip ':' */
                 }
-            }}}}
+            }}}}}
         }
         else {if (ctx.current() == '*') 
         {
@@ -4994,14 +5007,20 @@ size_t i{0};
             if (!(ctx.grab_until(':', cpp2::impl::out(&name)))) {return ctx.error("Missing colon for named pattern."); }
 
             if (name == "pla" || name == "positive_lookahead") {
-                return parse_lookahead(ctx, "*" + cpp2::to_string(cpp2::move(name)) + ":", true); 
+                return parse_lookahead_lookbehind(ctx, "*" + cpp2::to_string(cpp2::move(name)) + ":", true, true); 
             }
             else {if (name == "nla" || name == "negative_lookahead") {
-                return parse_lookahead(ctx, "*" + cpp2::to_string(cpp2::move(name)) + ":", false); 
+                return parse_lookahead_lookbehind(ctx, "*" + cpp2::to_string(cpp2::move(name)) + ":", true, false); 
+            }
+            else {if (name == "plb" || name == "positive_lookbehind") {
+                return parse_lookahead_lookbehind(ctx, "*" + cpp2::to_string(cpp2::move(name)) + ":", false, true); 
+            }
+            else {if (name == "nlb" || name == "negative_lookbehind") {
+                return parse_lookahead_lookbehind(ctx, "*" + cpp2::to_string(cpp2::move(name)) + ":", false, false); 
             }
             else {
                 return ctx.error("Unknown named group pattern: '" + cpp2::to_string(cpp2::move(name)) + "'"); 
-            }}
+            }}}}
         }}
 
         if (cpp2::move(has_pattern)) 
@@ -5034,7 +5053,7 @@ size_t i{0};
         }
     }
 
-#line 3257 "reflect.h2"
+#line 3275 "reflect.h2"
     [[nodiscard]] auto group_token::reverse() const -> token_ptr{
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<group_token>)(cpp2::shared)}; 
         (*cpp2::impl::assert_not_null(r)).number = number;
@@ -5043,7 +5062,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3265 "reflect.h2"
+#line 3283 "reflect.h2"
     [[nodiscard]] auto group_token::gen_string(cpp2::impl::in<std::string> name, cpp2::impl::in<bool> name_brackets, cpp2::impl::in<bool> has_modifier, cpp2::impl::in<std::string> modifiers, cpp2::impl::in<token_ptr> inner_) -> std::string
     {
         std::string start {"("}; 
@@ -5062,7 +5081,7 @@ size_t i{0};
         return cpp2::move(start) + (*cpp2::impl::assert_not_null(inner_)).to_string() + ")"; 
     }
 
-#line 3283 "reflect.h2"
+#line 3301 "reflect.h2"
     auto group_token::generate_code(generation_context& ctx) const -> void
     {
         if (-1 != number) {
@@ -5094,7 +5113,7 @@ size_t i{0};
         }
     }
 
-#line 3314 "reflect.h2"
+#line 3332 "reflect.h2"
     auto group_token::add_groups(std::set<int>& groups) const -> void
     {
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
@@ -5105,7 +5124,7 @@ size_t i{0};
 
     group_token::~group_token() noexcept{}
 
-#line 3326 "reflect.h2"
+#line 3344 "reflect.h2"
 [[nodiscard]] auto hexadecimal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'x'))) {return nullptr; }
@@ -5144,7 +5163,7 @@ size_t i{0};
     return r; 
 }
 
-#line 3367 "reflect.h2"
+#line 3385 "reflect.h2"
 [[nodiscard]] auto line_end_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() == '$' || (ctx.current() == '\\' && ctx.peek() == '$')) {
@@ -5162,7 +5181,7 @@ size_t i{0};
     }}
 }
 
-#line 3387 "reflect.h2"
+#line 3405 "reflect.h2"
 [[nodiscard]] auto line_start_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '^' && !((ctx.current() == '\\' && ctx.peek() == 'A'))) {return nullptr; }
@@ -5176,34 +5195,40 @@ size_t i{0};
     }
 }
 
-#line 3412 "reflect.h2"
-    lookahead_token::lookahead_token(cpp2::impl::in<bool> positive_)
+#line 3431 "reflect.h2"
+    lookahead_lookbehind_token::lookahead_lookbehind_token(cpp2::impl::in<bool> lookahead_, cpp2::impl::in<bool> positive_)
         : regex_token{ "" }
+        , lookahead{ lookahead_ }
         , positive{ positive_ }{
 
-#line 3414 "reflect.h2"
+#line 3434 "reflect.h2"
     }
 
-#line 3416 "reflect.h2"
-    auto lookahead_token::generate_code(generation_context& ctx) const -> void{
+#line 3436 "reflect.h2"
+    auto lookahead_lookbehind_token::generate_code(generation_context& ctx) const -> void{
         auto inner_name {ctx.generate_func(inner)}; 
 
-        ctx.add_check("lookahead_token_matcher<char, " + cpp2::to_string(positive) + ">(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ")");
+        if (lookahead) {
+            ctx.add_check("lookahead_token_matcher<char, " + cpp2::to_string(positive) + ">(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ")");
+        }
+        else {
+            ctx.add_check("lookbehind_token_matcher<char, " + cpp2::to_string(positive) + ">(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ")");
+        }
     }
 
-#line 3422 "reflect.h2"
-    [[nodiscard]] auto lookahead_token::reverse() const -> token_ptr{
+#line 3447 "reflect.h2"
+    [[nodiscard]] auto lookahead_lookbehind_token::reverse() const -> token_ptr{
         return nullptr; // TODO: 1) Implement error, 2) implement functionality.
     }
 
-#line 3426 "reflect.h2"
-    auto lookahead_token::add_groups(std::set<int>& groups) const -> void{
+#line 3451 "reflect.h2"
+    auto lookahead_lookbehind_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner)).add_groups(groups);
     }
 
-    lookahead_token::~lookahead_token() noexcept{}
+    lookahead_lookbehind_token::~lookahead_lookbehind_token() noexcept{}
 
-#line 3434 "reflect.h2"
+#line 3459 "reflect.h2"
 [[nodiscard]] auto named_class_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5229,7 +5254,7 @@ size_t i{0};
     return CPP2_UFCS_TEMPLATE(cpp2_new<regex_token_check>)(cpp2::shared, "\\" + cpp2::to_string(ctx.current()) + "", "" + cpp2::to_string(cpp2::move(name)) + "<char, " + cpp2::to_string(ctx.get_modifiers().has(expression_flags::case_insensitive)) + ">::match"); 
 }
 
-#line 3462 "reflect.h2"
+#line 3487 "reflect.h2"
 [[nodiscard]] auto octal_token_parse(parse_context& ctx) -> token_ptr
 {
     if (!((ctx.current() == '\\' && ctx.peek() == 'o'))) {return nullptr; }
@@ -5255,11 +5280,11 @@ size_t i{0};
     return r; 
 }
 
-#line 3499 "reflect.h2"
+#line 3524 "reflect.h2"
     range_token::range_token()
                              : regex_token{ "" }{}
 
-#line 3501 "reflect.h2"
+#line 3526 "reflect.h2"
     [[nodiscard]] auto range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<range_token>)(cpp2::shared)}; 
@@ -5333,7 +5358,7 @@ size_t i{0};
         return nullptr; 
     }
 
-#line 3574 "reflect.h2"
+#line 3599 "reflect.h2"
     auto range_token::parse_modifier(parse_context& ctx) & -> void
     {
         if (ctx.peek() == '?') {
@@ -5346,7 +5371,7 @@ size_t i{0};
         }}
     }
 
-#line 3586 "reflect.h2"
+#line 3611 "reflect.h2"
     [[nodiscard]] auto range_token::gen_mod_string() const& -> std::string
     {
         if (kind == range_flags::not_greedy) {
@@ -5360,7 +5385,7 @@ size_t i{0};
         }}
     }
 
-#line 3599 "reflect.h2"
+#line 3624 "reflect.h2"
     [[nodiscard]] auto range_token::gen_range_string() const& -> std::string
     {
         std::string r {""}; 
@@ -5380,7 +5405,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3618 "reflect.h2"
+#line 3643 "reflect.h2"
     [[nodiscard]] auto range_token::reverse() const -> token_ptr{
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<range_token>)(cpp2::shared)}; 
         (*cpp2::impl::assert_not_null(r)).min_count = min_count;
@@ -5391,7 +5416,7 @@ size_t i{0};
         return r; 
     }
 
-#line 3628 "reflect.h2"
+#line 3653 "reflect.h2"
     auto range_token::generate_code(generation_context& ctx) const -> void
     {
         auto inner_name {ctx.generate_func(inner_token)}; 
@@ -5403,14 +5428,14 @@ size_t i{0};
         ctx.add_statefull(next_name, "cpp2::regex::range_token_matcher<char, " + cpp2::to_string(min_count) + ", " + cpp2::to_string(max_count) + ", " + cpp2::to_string(kind) + ">::match(" + cpp2::to_string(ctx.match_parameters()) + ", " + cpp2::to_string(cpp2::move(inner_name)) + ", " + cpp2::to_string(cpp2::move(reset_name)) + ", other, " + cpp2::to_string(next_name) + ")");
     }
 
-#line 3639 "reflect.h2"
+#line 3664 "reflect.h2"
     auto range_token::add_groups(std::set<int>& groups) const -> void{
         (*cpp2::impl::assert_not_null(inner_token)).add_groups(groups);
     }
 
     range_token::~range_token() noexcept{}
 
-#line 3652 "reflect.h2"
+#line 3677 "reflect.h2"
     [[nodiscard]] auto special_range_token::parse(parse_context& ctx) -> token_ptr
     {
         auto r {CPP2_UFCS_TEMPLATE(cpp2_new<special_range_token>)(cpp2::shared)}; 
@@ -5434,7 +5459,7 @@ size_t i{0};
 
         if (!(ctx.has_token())) {return ctx.error("'" + cpp2::to_string(ctx.current()) + "' without previous element."); }
 
-#line 3676 "reflect.h2"
+#line 3701 "reflect.h2"
         (*cpp2::impl::assert_not_null(r)).parse_modifier(ctx);
 
         (*cpp2::impl::assert_not_null(r)).inner_token = ctx.pop_token();
@@ -5444,7 +5469,7 @@ size_t i{0};
 
     special_range_token::~special_range_token() noexcept{}
 
-#line 3688 "reflect.h2"
+#line 3713 "reflect.h2"
 [[nodiscard]] auto start_match_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5460,7 +5485,7 @@ size_t i{0};
     }
 }
 
-#line 3708 "reflect.h2"
+#line 3733 "reflect.h2"
 [[nodiscard]] auto word_boundary_token_parse(parse_context& ctx) -> token_ptr
 {
     if (ctx.current() != '\\') {return nullptr; }
@@ -5478,15 +5503,15 @@ size_t i{0};
     }}
 }
 
-#line 3744 "reflect.h2"
+#line 3769 "reflect.h2"
     template <typename Error_out> regex_generator<Error_out>::regex_generator(cpp2::impl::in<std::string_view> r, Error_out const& e)
         : regex{ r }
         , error_out{ e }{
 
-#line 3747 "reflect.h2"
+#line 3772 "reflect.h2"
     }
 
-#line 3749 "reflect.h2"
+#line 3774 "reflect.h2"
     template <typename Error_out> [[nodiscard]] auto regex_generator<Error_out>::parse() & -> std::string
     {
         // Extract modifiers and adapt regex.
@@ -5524,7 +5549,7 @@ size_t i{0};
         return source; 
     }
 
-#line 3786 "reflect.h2"
+#line 3811 "reflect.h2"
     template <typename Error_out> auto regex_generator<Error_out>::extract_modifiers() & -> void
     {
         if (regex.find_first_of("'/") == 0) {
@@ -5540,7 +5565,7 @@ size_t i{0};
         }
     }
 
-#line 3802 "reflect.h2"
+#line 3827 "reflect.h2"
 template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::string_view> regex, Err const& err) -> std::string
 {
     regex_generator<Err> parser {regex, err}; 
@@ -5549,7 +5574,7 @@ template<typename Err> [[nodiscard]] auto generate_regex(cpp2::impl::in<std::str
     return r; 
 }
 
-#line 3812 "reflect.h2"
+#line 3837 "reflect.h2"
 auto regex_gen(meta::type_declaration& t) -> void
 {
     auto has_default {false}; 
@@ -5604,7 +5629,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     CPP2_UFCS(add_runtime_support_include)(t, "cpp2regex.h");
 }
 
-#line 3871 "reflect.h2"
+#line 3896 "reflect.h2"
 [[nodiscard]] auto apply_metafunctions(
     declaration_node& n, 
     type_declaration& rtype, 
@@ -5717,7 +5742,7 @@ auto regex_gen(meta::type_declaration& t) -> void
     return true; 
 }
 
-#line 3984 "reflect.h2"
+#line 4009 "reflect.h2"
 }
 
 }

--- a/source/reflect.h
+++ b/source/reflect.h
@@ -4167,7 +4167,7 @@ generation_function_context::generation_function_context(){}
         auto cur {new_context()}; 
 
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + cpp2::to_string(name) + ": @struct<noforward> type = {\n";
-        (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "  operator(): <Iter2> (this, cur: Iter2, inout ctx, other) -> cpp2::regex::match_return<Iter2> = {\n";
+        (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "  operator(): <Iter> (this, cur: Iter, inout ctx, other) -> cpp2::regex::match_return<Iter> = {\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    r := ctx..pass(cur);\n";
         (*cpp2::impl::assert_not_null(cur)).code += "" + cpp2::to_string((*cpp2::impl::assert_not_null(cur)).tabs) + "    do {\n";
         (*cpp2::impl::assert_not_null(cpp2::move(cur))).add_tabs(3);
@@ -5523,12 +5523,12 @@ size_t i{0};
         }
 
         source += "{\n";
-        source += " wrap: <Iter, CharT> type = {\n"; // TODO: Remove wrapper when template template parameters are available.
-        source += "  context: type == cpp2::regex::match_context<CharT, Iter, " + cpp2::to_string(parse_ctx.get_cur_group()) + ">;";
+        source += " wrap: <CharT> type = {\n"; // TODO: Remove wrapper when template template parameters are available.
+        source += "  context: <Iter> type == cpp2::regex::match_context<CharT, Iter, " + cpp2::to_string(parse_ctx.get_cur_group()) + ">;";
 
         generation_context gen_ctx {}; 
         source += gen_ctx.run(parse_ctx.get_as_token());
-        source += "  entry: (cur: Iter, inout ctx: context) -> cpp2::regex::match_return<Iter> = {\n";
+        source += "  entry: <Iter> (cur: Iter, inout ctx: context<Iter>) -> cpp2::regex::match_return<Iter> = {\n";
         source += "    ctx..set_group_start(0, cur);\n";
         source += "    r := " + cpp2::to_string(gen_ctx.get_entry_func()) + "(cur, ctx, cpp2::regex::true_end_func());\n";
         source += "    if r.matched { ctx..set_group_end(0, r.pos); }\n";

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -2364,7 +2364,7 @@ generation_context: type =
         cur := new_context();
 
         cur*.code += "(cur*.tabs)$(name)$: @struct<noforward> type = {\n";
-        cur*.code += "(cur*.tabs)$  operator(): <Iter2> (this, cur: Iter2, inout ctx, other) -> cpp2::regex::match_return<Iter2> = {\n";
+        cur*.code += "(cur*.tabs)$  operator(): <Iter> (this, cur: Iter, inout ctx, other) -> cpp2::regex::match_return<Iter> = {\n";
         cur*.code += "(cur*.tabs)$    r := ctx..pass(cur);\n";
         cur*.code += "(cur*.tabs)$    do {\n";
         cur*..add_tabs(3);
@@ -3782,12 +3782,12 @@ regex_generator: <Error_out> type =
         }
 
         source += "{\n";
-        source += " wrap: <Iter, CharT> type = {\n"; // TODO: Remove wrapper when template template parameters are available.
-        source += "  context: type == cpp2::regex::match_context<CharT, Iter, (parse_ctx..get_cur_group())$>;";
+        source += " wrap: <CharT> type = {\n"; // TODO: Remove wrapper when template template parameters are available.
+        source += "  context: <Iter> type == cpp2::regex::match_context<CharT, Iter, (parse_ctx..get_cur_group())$>;";
 
         gen_ctx: generation_context = ();
         source += gen_ctx..run(parse_ctx..get_as_token());
-        source += "  entry: (cur: Iter, inout ctx: context) -> cpp2::regex::match_return<Iter> = {\n";
+        source += "  entry: <Iter> (cur: Iter, inout ctx: context<Iter>) -> cpp2::regex::match_return<Iter> = {\n";
         source += "    ctx..set_group_start(0, cur);\n";
         source += "    r := (gen_ctx..get_entry_func())$(cur, ctx, cpp2::regex::true_end_func());\n";
         source += "    if r.matched { ctx..set_group_end(0, r.pos); }\n";

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -3782,7 +3782,6 @@ regex_generator: <Error_out> type =
         }
 
         source += "{\n";
-        source += " wrap: <CharT> type = {\n"; // TODO: Remove wrapper when template template parameters are available.
         source += "  context: <Iter> type == cpp2::regex::match_context<CharT, Iter, (parse_ctx..get_cur_group())$>;";
 
         gen_ctx: generation_context = ();
@@ -3796,7 +3795,6 @@ regex_generator: <Error_out> type =
 
         source += gen_ctx..create_named_group_lookup(parse_ctx.named_groups);
         source += "  is_start_match: () -> bool == (parse_ctx.is_start_match)$;";
-        source += "}\n"; // wrap end
 
         string := parse_ctx..get_as_token()*..to_string();
         source += "  to_string: () -> std::string = { return R\"((modifier_escape)$(string)$(modifier_escape)$(modifier)$)\"; }\n";
@@ -3880,8 +3878,8 @@ regex_gen: (inout t: meta::type_declaration) =
         regular_expression := generate_regex(expr.second, :(message) = t$.error(message););
 
         if !regular_expression..empty() {
-            t.add_member("public (expr.first)$_matcher: type = (regular_expression)$");
-            t.add_member("public (expr.first)$: cpp2::regex::regular_expression<char, (expr.first)$_matcher> = ();");
+            t.add_member("public (expr.first)$_matcher: <CharT> type = (regular_expression)$");
+            t.add_member("public (expr.first)$: cpp2::regex::regular_expression<char, (expr.first)$_matcher<char>> = ();\n");
         }
     }
 

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -2617,6 +2617,35 @@ any_token: @polymorphic_base type =
     }
 }
 
+//  Regex syntax: (?><matcher>)  Example: a(?>bc|c)c
+//
+atomic_group_token: @polymorphic_base type =
+{
+    this                 : regex_token = ("");
+
+    public  inner_token : token_ptr   = nullptr;
+
+    operator=: (out this) = {}
+
+    reverse: (override this) -> token_ptr = {
+        r := shared.new<atomic_group_token>();
+        r*.inner_token = inner_token*.reverse();
+
+        return r;
+    }
+
+    generate_code: (override this, inout ctx: generation_context) =
+    {
+        inner_name := ctx..generate_func(inner_token);
+
+        next_name := ctx..next_func_name();
+        ctx..add_statefull(next_name, "cpp2::regex::atomic_group_matcher<char>((ctx..match_parameters())$, (inner_name)$, other, (next_name)$)");
+    }
+
+    add_groups: (override this, inout groups: std::set<int>) = {
+        inner_token*..add_groups(groups);
+    }
+}
 
 //  Regex syntax: a
 //
@@ -3122,6 +3151,20 @@ group_token: @polymorphic_base type =
         return r;
     }
 
+    parse_atomic_pattern: (inout ctx: parse_context, syntax: std::string) -> token_ptr =
+    {
+        _ = ctx..next(); // Skip last token defining the syntax
+
+        r := shared.new<atomic_group_token>();
+
+        old_state := ctx..start_group();
+        if !ctx..parse_until(')') { return ctx..error("Group without a closing bracket."); }
+        r*.inner_token = ctx..end_group(old_state);
+        r*..set_string("((syntax)$(r*.inner_token*..to_string())$)");
+
+        return r;
+    }
+
     parse: (inout ctx: parse_context) -> token_ptr = 
     {
         if ctx..current() != '(' { return nullptr; }
@@ -3202,6 +3245,11 @@ group_token: @polymorphic_base type =
                 // Lookahead
                 return parse_lookahead_lookbehind(ctx, "?(ctx..current())$", true, ctx..current() == '=');
             }
+            else if ctx..current() == '>'
+            {
+                // Atomic pattern
+                return parse_atomic_pattern(ctx, "?(ctx..current())$");
+            }
             else 
             {
                 //  Simple modifier
@@ -3237,6 +3285,9 @@ group_token: @polymorphic_base type =
             }
             else if name == "nlb" || name == "negative_lookbehind" {
                 return parse_lookahead_lookbehind(ctx, "*(name)$:", false, false);
+            }
+            else if name == "atomic" {
+                return parse_atomic_pattern(ctx, "*(name)$:");
             }
             else {
                 return ctx..error("Unknown named group pattern: '(name)$'");
@@ -3668,7 +3719,6 @@ range_token: @polymorphic_base type =
     add_groups: (override this, inout groups: std::set<int>) = {
         inner_token*..add_groups(groups);
     }
-
 }
 
 

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -2364,7 +2364,7 @@ generation_context: type =
         cur := new_context();
 
         cur*.code += "(cur*.tabs)$(name)$: @struct<noforward> type = {\n";
-        cur*.code += "(cur*.tabs)$  operator(): <Iter> (this, cur: Iter, inout ctx, other) -> cpp2::regex::match_return<Iter> = {\n";
+        cur*.code += "(cur*.tabs)$  operator(): <Iter> (this, cur: Iter, forward ctx, other) -> cpp2::regex::match_return<Iter> = {\n";
         cur*.code += "(cur*.tabs)$    r := ctx..pass(cur);\n";
         cur*.code += "(cur*.tabs)$    do {\n";
         cur*..add_tabs(3);
@@ -2389,6 +2389,7 @@ generation_context: type =
         cur*.code += "(cur*.tabs)$    else {\n";
         cur*.code += "(cur*.tabs)$      r.pos = ctx.end;\n";
         cur*.code += "(cur*.tabs)$    }\n";
+        cur*.code += "(cur*.tabs)$    _ = ctx;\n";
         cur*.code += "(cur*.tabs)$    return r;\n";
         cur*.code += "(cur*.tabs)$  }\n";
         cur*.code += "(cur*.tabs)$}\n";
@@ -3445,7 +3446,10 @@ lookahead_lookbehind_token: @polymorphic_base type =
     }
 
     reverse: (override this) -> token_ptr = {
-        return nullptr; // TODO: 1) Implement error, 2) implement functionality.
+        r := shared.new<lookahead_lookbehind_token>(lookahead, positive);
+        r*.inner = inner; // We do not reverse here. Nested lookahead and lookbehind stay as they are.
+
+        return r;
     }
 
     add_groups: (override this, inout groups: std::set<int>) = {

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -2364,7 +2364,7 @@ generation_context: type =
         cur := new_context();
 
         cur*.code += "(cur*.tabs)$(name)$: @struct<noforward> type = {\n";
-        cur*.code += "(cur*.tabs)$  operator(): (this, cur: Iter, inout ctx: context, other) -> cpp2::regex::match_return<Iter> = {\n";
+        cur*.code += "(cur*.tabs)$  operator(): <Iter2> (this, cur: Iter2, inout ctx, other) -> cpp2::regex::match_return<Iter2> = {\n";
         cur*.code += "(cur*.tabs)$    r := ctx..pass(cur);\n";
         cur*.code += "(cur*.tabs)$    do {\n";
         cur*..add_tabs(3);

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -3145,7 +3145,7 @@ group_token: @polymorphic_base type =
         r*..set_string("((syntax)$(r*.inner*..to_string())$)");
 
         if !lookahead {
-            r*.inner = r*.inner*.reverse();
+            r*.inner = r*.inner*..reverse();
         }
 
         return r;

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -1675,6 +1675,7 @@ regex_token: @polymorphic_base type =
 
     //parse: (inout ctx: parse_context) -> token_ptr;
     generate_code: (virtual this, inout _: generation_context);        // Generate the matching code.
+    reverse:       (virtual this) -> std::shared_ptr<regex_token>;     // Create a reverse token for look behind expressions.
 
     add_groups: (virtual this, inout _: std::set<int>) = {}            // Adds all group indices to the set.
     to_string: (this) -> std::string         = { return string_rep; }  // Create a string representation.
@@ -1701,6 +1702,8 @@ regex_token_check: @polymorphic_base type =
     generate_code: (override this, inout ctx: generation_context) = {
         ctx..add_check(check + "(" + ctx..match_parameters() + ")");
     }
+
+    reverse: (override this) -> token_ptr = shared.new<regex_token_check>(this.to_string(), this.check);
 }
 
 
@@ -1720,6 +1723,8 @@ regex_token_code: @polymorphic_base type =
     generate_code: (override this, inout ctx: generation_context) = {
         ctx..add(code);
     }
+
+    reverse: (override this) -> token_ptr = shared.new<regex_token_code>(this.to_string(), this.code);
 }
 
 
@@ -1736,6 +1741,8 @@ regex_token_empty: @polymorphic_base type =
     generate_code: (override this, inout _: generation_context) = {
         // Nothing.
     }
+
+    reverse: (override this) -> token_ptr = shared.new<regex_token_empty>(this.to_string());
 }
 
 
@@ -1770,6 +1777,19 @@ regex_token_list: @polymorphic_base type =
             r += token*..to_string();
         }
         return r;
+    }
+
+    reverse: (override this) -> token_ptr = {
+        s : int = cpp2::unchecked_narrow<int>(tokens..size());
+
+        reverse_vec: token_vec = ();
+        reverse_vec..resize(s);
+
+        i: int = 0;
+        while i < tokens.ssize() next (i += 1) {
+            reverse_vec[s - 1 -i] = tokens[i]*.reverse();
+        }
+        return shared.new<regex_token_list>(reverse_vec);
     }
 }
 
@@ -2214,7 +2234,7 @@ parse_context: type =
         return true;
     }
 
-    parse_until:(inout this, term: char) -> bool = {
+    parse_until: (inout this, term: char) -> bool = {
         cur_token: token_ptr = ();
 
         while valid() next _ = next()
@@ -2563,6 +2583,19 @@ alternative_token_gen: @polymorphic_base type =
 
         return r;
     }
+
+    reverse: (override this) -> token_ptr = {
+        s : int = cpp2::unchecked_narrow<int>(alternatives..size());
+
+        reverse_vec: token_vec = ();
+        reverse_vec..resize(s);
+
+        i: int = 0;
+        while i < s next (i += 1) {
+            reverse_vec[i] = alternatives[i]*.reverse(); // We only reverse the alternatives, not the order in which they are checked.
+        }
+        return shared.new<alternative_token_gen>(reverse_vec);
+    }
 }
 
 
@@ -2595,6 +2628,12 @@ char_token: @polymorphic_base type =
 
     operator=: (out this, t: char, ignore_case_: bool) = {
         regex_token = (std::string(1, t));
+        token = t;
+        ignore_case = ignore_case_;
+    }
+
+    operator=: (out this, t: std::string, ignore_case_: bool) = {
+        regex_token = (t);
         token = t;
         ignore_case = ignore_case_;
     }
@@ -2678,6 +2717,12 @@ char_token: @polymorphic_base type =
         str = string_util::replace_all(str, "\t", "\\t");
 
         return str;
+    }
+
+    reverse: (override this) -> token_ptr = {
+        reverse_str: std::string = token;
+        std::reverse(reverse_str..begin(), reverse_str..end());
+        return shared.new<char_token>(reverse_str, ignore_case);
     }
 
     append: (inout this, that) = {
@@ -2831,6 +2876,15 @@ class_token: @polymorphic_base type =
             );
     }
 
+    reverse: (override this) -> token_ptr = {
+        return shared.new<class_token>(
+            negate,
+            case_insensitive,
+            class_str,
+            to_string()
+            );
+    }
+
     generate_code: (override this, inout ctx: generation_context) = 
     {
         ctx..add_check("class_token_matcher<char, (negate)$, (case_insensitive)$, (class_str)$>::match((ctx..match_parameters())$)");
@@ -2910,12 +2964,14 @@ group_ref_token: @polymorphic_base type =
 
     id              : int;
     case_insensitive: bool;
+    reverse_eval    : bool;
 
-    operator=:(out this, id_: int, case_insensitive_: bool, str: std::string) = 
+    operator=:(out this, id_: int, case_insensitive_: bool, reverse_: bool, str: std::string) =
     {
         regex_token      = str;
         id               = id_;
         case_insensitive = case_insensitive_;
+        reverse_eval     = reverse_;
     }
 
     parse: (inout ctx: parse_context) -> token_ptr = 
@@ -3016,11 +3072,15 @@ group_ref_token: @polymorphic_base type =
             if -1 == group_id { return ctx..error("Group names does not exist. (Name is: (group)$)");}
         }
 
-        return shared.new<group_ref_token>(group_id, ctx..get_modifiers()..has(expression_flags::case_insensitive), str);
+        return shared.new<group_ref_token>(group_id, ctx..get_modifiers()..has(expression_flags::case_insensitive), false, str);
+    }
+
+    reverse: (override this) -> token_ptr = {
+        return shared.new<group_ref_token>(id, case_insensitive, !reverse_eval, to_string());
     }
 
     generate_code: (override this, inout ctx: generation_context) = {
-        ctx..add_check("group_ref_token_matcher<char, (id)$, (case_insensitive)$>((ctx..match_parameters())$)");
+        ctx..add_check("group_ref_token_matcher<char, (id)$, (case_insensitive)$, (reverse_eval)$>((ctx..match_parameters())$)");
     }
 }
 
@@ -3039,8 +3099,9 @@ group_token: @polymorphic_base type =
 {
     this: regex_token = ();
 
-    number: int      = -1;
-    inner: token_ptr = nullptr;
+    number:       int       = -1;
+    reverse_eval: bool      = false;
+    inner:        token_ptr = nullptr;
 
     parse_lookahead: (inout ctx: parse_context, syntax: std::string, positive: bool) -> token_ptr = 
     {
@@ -3193,6 +3254,14 @@ group_token: @polymorphic_base type =
         }
     }
 
+    reverse: (override this) -> token_ptr = {
+        r := shared.new<group_token>();
+        r*.number = number;
+        r*.reverse_eval = !reverse_eval;
+        r*.inner = inner*.reverse();
+        return r;
+    }
+
     gen_string: (name: std::string, name_brackets: bool, has_modifier: bool, modifiers: std::string, inner_: token_ptr) -> std::string = 
     {
         start : std::string = "(";
@@ -3214,12 +3283,23 @@ group_token: @polymorphic_base type =
     generate_code: (override this, inout ctx: generation_context) = 
     {
         if -1 != number {
-            ctx..add("ctx..set_group_start((number)$, r.pos);");
+            if reverse_eval {
+                ctx..add("ctx..set_group_end((number)$, r.pos);");
+            }
+            else {
+                ctx..add("ctx..set_group_start((number)$, r.pos);");
+            }
         }
 
         inner*..generate_code(ctx);
         if -1 != number {
-            ctx..add("ctx..set_group_end((number)$, r.pos);");
+            if reverse_eval {
+                ctx..add("ctx..set_group_start((number)$, r.pos);");
+            }
+            else {
+                ctx..add("ctx..set_group_end((number)$, r.pos);");
+            }
+
             tmp_name := ctx..gen_temp();
             ctx..add("(tmp_name)$_func :=  :() = {");
             ctx..add("  if !r&$*.matched {");
@@ -3337,6 +3417,10 @@ lookahead_token: @polymorphic_base type =
         inner_name := ctx..generate_func(inner);
 
         ctx..add_check("lookahead_token_matcher<char, (positive)$>((ctx..match_parameters())$, (inner_name)$)");
+    }
+
+    reverse: (override this) -> token_ptr = {
+        return nullptr; // TODO: 1) Implement error, 2) implement functionality.
     }
 
     add_groups: (override this, inout groups: std::set<int>) = {
@@ -3527,6 +3611,16 @@ range_token: @polymorphic_base type =
         else {
             r += "{(min_count)$,(max_count)$}";
         }
+
+        return r;
+    }
+
+    reverse: (override this) -> token_ptr = {
+        r := shared.new<range_token>();
+        r*.min_count   = min_count;
+        r*.max_count   = max_count;
+        r*.kind        = kind;
+        r*.inner_token = inner_token*.reverse();
 
         return r;
     }

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -3103,16 +3103,20 @@ group_token: @polymorphic_base type =
     reverse_eval: bool      = false;
     inner:        token_ptr = nullptr;
 
-    parse_lookahead: (inout ctx: parse_context, syntax: std::string, positive: bool) -> token_ptr = 
+    parse_lookahead_lookbehind: (inout ctx: parse_context, syntax: std::string, lookahead: bool, positive: bool) -> token_ptr =
     {
         _ = ctx..next(); // Skip last token defining the syntax
 
-        r := shared.new<lookahead_token>(positive);
+        r := shared.new<lookahead_lookbehind_token>(lookahead, positive);
 
         old_state := ctx..start_group();
-        if !ctx..parse_until(')') { return ctx..error("Lookahead without a closing bracket."); }
+        if !ctx..parse_until(')') { return ctx..error("Group without a closing bracket."); }
         r*.inner = ctx..end_group(old_state);
         r*..set_string("((syntax)$(r*.inner*..to_string())$)");
+
+        if !lookahead {
+            r*.inner = r*.inner*.reverse();
+        }
 
         return r;
     }
@@ -3136,7 +3140,14 @@ group_token: @polymorphic_base type =
             //  Special group
             if !ctx..next_no_skip() { return ctx..error("Missing character after group opening.");  }
 
-            if ctx..current() == '<' || ctx..current() == '\'' 
+            if  ctx.current() == '<' && (ctx.peek() == '=' || ctx.peek() == '!')
+            {
+                // Lookbehind
+                _ = ctx.next(); // Skip the '<'
+
+                return parse_lookahead_lookbehind(ctx, "?<(ctx..current())$", false, ctx..current() == '=');
+            }
+            else if ctx..current() == '<' || ctx..current() == '\''
             {
                 //  Named group
                 end_char := ctx..current();
@@ -3187,7 +3198,8 @@ group_token: @polymorphic_base type =
             }
             else if ctx..current() == '=' || ctx..current() == '!' 
             {
-                return parse_lookahead(ctx, "?(ctx..current())$", ctx..current() == '=');
+                // Lookahead
+                return parse_lookahead_lookbehind(ctx, "?(ctx..current())$", true, ctx..current() == '=');
             }
             else 
             {
@@ -3214,10 +3226,16 @@ group_token: @polymorphic_base type =
             if !ctx..grab_until(':', out name) { return ctx..error("Missing colon for named pattern.");  }
 
             if name == "pla" || name == "positive_lookahead" {
-                return parse_lookahead(ctx, "*(name)$:", true);
+                return parse_lookahead_lookbehind(ctx, "*(name)$:", true, true);
             }
             else if name == "nla" || name == "negative_lookahead" {
-                return parse_lookahead(ctx, "*(name)$:", false);
+                return parse_lookahead_lookbehind(ctx, "*(name)$:", true, false);
+            }
+            else if name == "plb" || name == "positive_lookbehind" {
+                return parse_lookahead_lookbehind(ctx, "*(name)$:", false, true);
+            }
+            else if name == "nlb" || name == "negative_lookbehind" {
+                return parse_lookahead_lookbehind(ctx, "*(name)$:", false, false);
             }
             else {
                 return ctx..error("Unknown named group pattern: '(name)$'");
@@ -3402,21 +3420,28 @@ line_start_token_parse: (inout ctx: parse_context) -> token_ptr =
 //
 //  Parsed in group_token.
 //
-lookahead_token: @polymorphic_base type = 
+lookahead_lookbehind_token: @polymorphic_base type =
 {
     this: regex_token = ("");
 
-    protected positive: bool;
-    public    inner   : token_ptr = nullptr;
+    protected lookahead: bool;
+    protected positive:  bool;
+    public    inner   :  token_ptr = nullptr;
 
-    operator=: (out this, positive_: bool) = {
-        positive = positive_;
+    operator=: (out this, lookahead_: bool, positive_: bool) = {
+        lookahead = lookahead_;
+        positive  = positive_;
     }
 
     generate_code: (override this, inout ctx: generation_context) = {
         inner_name := ctx..generate_func(inner);
 
-        ctx..add_check("lookahead_token_matcher<char, (positive)$>((ctx..match_parameters())$, (inner_name)$)");
+        if lookahead {
+            ctx..add_check("lookahead_token_matcher<char, (positive)$>((ctx..match_parameters())$, (inner_name)$)");
+        }
+        else {
+            ctx..add_check("lookbehind_token_matcher<char, (positive)$>((ctx..match_parameters())$, (inner_name)$)");
+        }
     }
 
     reverse: (override this) -> token_ptr = {

--- a/source/reflect.h2
+++ b/source/reflect.h2
@@ -1890,6 +1890,8 @@ parse_context: type =
     pos:   size_t = 0;         // Current parsing position.
     root:  token_ptr;          // Token representing the regular expression.
 
+    public is_start_match: bool = false;  // If the regex contains \G at the beginning.
+
     cur_group_state:        parse_context_group_state = ();
     cur_branch_reset_state: parse_context_branch_reset_state = ();
 
@@ -2235,6 +2237,7 @@ parse_context: type =
             if !cur_token && valid() { cur_token = octal_token_parse(this); }
             if !cur_token && valid() { cur_token = range_token::parse(this); }
             if !cur_token && valid() { cur_token = special_range_token::parse(this); }
+            if !cur_token && valid() { cur_token = start_match_parse(this); }
             if !cur_token && valid() { cur_token = word_boundary_token_parse(this); }
 
             // Everything else is matched as it is.
@@ -3584,6 +3587,25 @@ special_range_token: @polymorphic_base type =
     }
 }
 
+//  Regex syntax: \G  Example: \Gaa
+//
+//  Forces the match and/or consecutive matches to start at the position of the last match.
+//
+start_match_parse: (inout ctx: parse_context) -> token_ptr =
+{
+    if ctx..current() != '\\' { return nullptr; }
+
+    if ctx..peek() == 'G' {
+        if 0 != ctx..get_pos() { return ctx..error("\\G is only supported at the first position in the regex."); }
+        _ = ctx..next();
+        ctx.is_start_match = true;
+        return shared.new<regex_token_empty>("\\G");
+    }
+    else {
+        return nullptr;
+    }
+}
+
 
 //  Regex syntax: \b or \B  Example: \bword\b
 //
@@ -3654,10 +3676,12 @@ regex_generator: <Error_out> type =
         source += "  }\n";
 
         source += gen_ctx..create_named_group_lookup(parse_ctx.named_groups);
-        source += "}\n";
+        source += "  is_start_match: () -> bool == (parse_ctx.is_start_match)$;";
+        source += "}\n"; // wrap end
 
         string := parse_ctx..get_as_token()*..to_string();
         source += "  to_string: () -> std::string = { return R\"((modifier_escape)$(string)$(modifier_escape)$(modifier)$)\"; }\n";
+
         source += "}\n";
 
         _ = parse_ctx;


### PR DESCRIPTION
Added some of the missing features for regular expression.

 - There is now a `find_all` method for the regular expressions.
 - Added handling of `\G`.
 - Added look behind matchers.
 - Added atomic group tokens.
 

The PR can be squashed into one commit. I left the commits for better review granularity.