### PR TITLE
CI Update regression test results after recent mods

### DIFF
--- a/regression-tests/test-results/apple-clang-14-c++2b/pure2-type-safety-1.cpp.execution
+++ b/regression-tests/test-results/apple-clang-14-c++2b/pure2-type-safety-1.cpp.execution
@@ -7,3 +7,5 @@
       variant<int, int, double> is int? true
                             any is int? true
                   optional<int> is int? true
+optional<int> is: int 
+optional<*D> is: *B *D 

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-check.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-check.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1156) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]
+../../../include/cpp2util.h(1235) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-safety-with-assert.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-bounds-safety-with-assert.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(965) : Bounds safety violation
+../../../include/cpp2util.h(546) : Bounds safety violation

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-initialization-safety-3-contract-violation.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-initialization-safety-3-contract-violation.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(965) : Contract violation: fill: value must contain at least count elements
+../../../include/cpp2util.h(546) : Contract violation: fill: value must contain at least count elements

--- a/regression-tests/test-results/apple-clang-15-c++2b/mixed-lifetime-safety-and-null-contracts.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/mixed-lifetime-safety-and-null-contracts.cpp.execution
@@ -1,2 +1,2 @@
 sending error to my framework... [dynamic null dereference attempt detected]
-from source location: ../../../include/cpp2util.h(1047) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]
+from source location: ../../../include/cpp2util.h(1126) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-expected-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-expected-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1047) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::expected<int, bool>]: Null safety violation: std::expected has an unexpected value
+../../../include/cpp2util.h(1126) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::expected<int, bool>]: Null safety violation: std::expected has an unexpected value

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-optional-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-optional-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1047) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value
+../../../include/cpp2util.h(1126) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-shared-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-shared-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1047) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty
+../../../include/cpp2util.h(1126) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-unique-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-assert-unique-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1047) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty
+../../../include/cpp2util.h(1126) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-regex-general.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-regex-general.cpp.execution
@@ -1,0 +1,11 @@
+Running tests_01_char_matcher:
+Not full match fails: 0
+Full match is ok:     1
+Search finds at position 1: 1
+Search finds at position 3: 3
+Find all finds at position: 1
+Find all finds at position: 4
+Find all finds at position: 7
+Find all found 3 matched: 3
+Find all finds at position: 2
+Find all found 1 match: 1

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/apple-clang-15-c++2b/pure2-type-safety-1.cpp.execution
+++ b/regression-tests/test-results/apple-clang-15-c++2b/pure2-type-safety-1.cpp.execution
@@ -7,3 +7,5 @@
       variant<int, int, double> is int? true
                             any is int? true
                   optional<int> is int? true
+optional<int> is: int 
+optional<*D> is: *B *D 

--- a/regression-tests/test-results/clang-15-c++20-libcpp/pure2-type-safety-1.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20-libcpp/pure2-type-safety-1.cpp.execution
@@ -7,3 +7,5 @@
       variant<int, int, double> is int? true
                             any is int? true
                   optional<int> is int? true
+optional<int> is: int 
+optional<*D> is: *B *D 

--- a/regression-tests/test-results/clang-15-c++20/mixed-bounds-check.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-bounds-check.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1156) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]
+../../../include/cpp2util.h(1235) decltype(auto) cpp2::impl::assert_in_bounds(auto &&, std::source_location) [arg = 5, x:auto = std::vector<int>]: Bounds safety violation: out of bounds access attempt detected - attempted access at index 5, [min,max] range is [0,4]

--- a/regression-tests/test-results/clang-15-c++20/mixed-bounds-safety-with-assert.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-bounds-safety-with-assert.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(965) : Bounds safety violation
+../../../include/cpp2util.h(546) : Bounds safety violation

--- a/regression-tests/test-results/clang-15-c++20/mixed-initialization-safety-3-contract-violation.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-initialization-safety-3-contract-violation.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(965) : Contract violation: fill: value must contain at least count elements
+../../../include/cpp2util.h(546) : Contract violation: fill: value must contain at least count elements

--- a/regression-tests/test-results/clang-15-c++20/mixed-lifetime-safety-and-null-contracts.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/mixed-lifetime-safety-and-null-contracts.cpp.execution
@@ -1,2 +1,2 @@
 sending error to my framework... [dynamic null dereference attempt detected]
-from source location: ../../../include/cpp2util.h(1047) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]
+from source location: ../../../include/cpp2util.h(1126) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = int *&]

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-optional-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-optional-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1047) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value
+../../../include/cpp2util.h(1126) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::optional<int>]: Null safety violation: std::optional does not contain a value

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-shared-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-shared-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1047) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty
+../../../include/cpp2util.h(1126) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::shared_ptr<int>]: Null safety violation: std::shared_ptr is empty

--- a/regression-tests/test-results/clang-15-c++20/pure2-assert-unique-ptr-not-null.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-assert-unique-ptr-not-null.cpp.execution
@@ -1,1 +1,1 @@
-../../../include/cpp2util.h(1047) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty
+../../../include/cpp2util.h(1126) decltype(auto) cpp2::impl::assert_not_null(auto &&, std::source_location) [arg:auto = std::unique_ptr<int>]: Null safety violation: std::unique_ptr is empty

--- a/regression-tests/test-results/clang-15-c++20/pure2-type-safety-1.cpp.execution
+++ b/regression-tests/test-results/clang-15-c++20/pure2-type-safety-1.cpp.execution
@@ -7,3 +7,5 @@
       variant<int, int, double> is int? true
                             any is int? true
                   optional<int> is int? true
+optional<int> is: int 
+optional<*D> is: *B *D 

--- a/regression-tests/test-results/clang-18-c++20/pure2-type-safety-1.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++20/pure2-type-safety-1.cpp.execution
@@ -7,3 +7,5 @@
       variant<int, int, double> is int? true
                             any is int? true
                   optional<int> is int? true
+optional<int> is: int 
+optional<*D> is: *B *D 

--- a/regression-tests/test-results/clang-18-c++23-libcpp/pure2-regex_04_start_end.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++23-libcpp/pure2-regex_04_start_end.cpp.execution
@@ -8,4 +8,5 @@ Running tests_04_start_end:
 07_y: OK regex: ^ parsed_regex: ^ str: abc result_expr: $& expected_results 
 08_y: OK regex: $ parsed_regex: $ str: abc result_expr: $& expected_results 
 09_n: OK regex: $b parsed_regex: $b str: b result_expr: - expected_results -
+10_n: OK regex: \GX.*X parsed_regex: \GX.*X str: aaaXbX result_expr: - expected_results -
 

--- a/regression-tests/test-results/clang-18-c++23-libcpp/pure2-regex_19_lookahead.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++23-libcpp/pure2-regex_19_lookahead.cpp.execution
@@ -27,6 +27,14 @@ Running tests_19_lookahead:
 26_y: OK regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) parsed_regex: ^(a*?)(?!(aa|aaaa)*$)(?=a\z) str: aaaaaaaa result_expr: $1 expected_results aaaaaaa
 27_y: OK regex: a(?!b(?!c))(..) parsed_regex: a(?!b(?!c))(..) str: abababc result_expr: $1 expected_results bc
 28_y: OK regex: a(?!b(?=a))(..) parsed_regex: a(?!b(?=a))(..) str: abababc result_expr: $1 expected_results bc
+29_y: OK regex: (?=foo) parsed_regex: (?=foo) str: foo result_expr: @+ expected_results 0
+30_y: OK regex: (?=foo) parsed_regex: (?=foo) str: XfooY result_expr: @+ expected_results 1
+31_y: OK regex: .*(?=foo) parsed_regex: .*(?=foo) str: XfooY result_expr: @+ expected_results 1
+32_y: OK regex: (?=.*P)P parsed_regex: (?=.*P)P str: aP result_expr: @+ expected_results 2
+33_y: OK regex: X(?=foo)f parsed_regex: X(?=foo)f str: ..XfooY.. result_expr: @+ expected_results 4
+34_y: OK regex: X(?=foo) parsed_regex: X(?=foo) str: ..XfooY.. result_expr: @+ expected_results 3
+35_y: OK regex: (?=XY*foo) parsed_regex: (?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
+36_y: OK regex: ^(?=XY*foo) parsed_regex: ^(?=XY*foo) str: Xfoo result_expr: @+ expected_results 0
 37_y: OK regex: X(\w+)(?=\s)|X(\w+) parsed_regex: X(\w+)(?=\s)|X(\w+) str: Xab result_expr: [$1-$2] expected_results [-ab]
 38_y: OK regex: ^a*(?=b)b parsed_regex: ^a*(?=b)b str: ab result_expr: $& expected_results ab
 39_y: OK regex: '(?!\A)x'm parsed_regex: '(?!\A)x'm str: a\nxb\n result_expr: - expected_results -
@@ -44,4 +52,6 @@ Running tests_19_lookahead:
 51_y: OK regex: ((?s)b.)c(?!\N) parsed_regex: ((?s)b.)c(?!\N) str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 52_y: OK regex: '(b.)c(?!\N)'s parsed_regex: '(b.)c(?!\N)'s str: a\nb\nc\n result_expr: $1:$& expected_results b\n:b\nc
 53_n: OK regex: a*(?!) parsed_regex: a*(?!) str: aaaab result_expr: - expected_results -
+54_y: OK regex: (?<bar>)foo parsed_regex: (?<bar>)foo str: bar>ABCfoo result_expr: $& expected_results foo
+55_y: OK regex: (?<bar>ABC)foo parsed_regex: (?<bar>ABC)foo str: bar>ABCfoo result_expr: $& expected_results ABCfoo
 

--- a/regression-tests/test-results/clang-18-c++23-libcpp/pure2-regex_21_atomic_patterns.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++23-libcpp/pure2-regex_21_atomic_patterns.cpp.execution
@@ -1,0 +1,8 @@
+Running tests_21_atomic_patterns:
+01_y: OK regex: (?>a+)b parsed_regex: (?>a+)b str: aaab result_expr: - expected_results -
+02_y: OK regex: ((?>a+)b) parsed_regex: ((?>a+)b) str: aaab result_expr: $1 expected_results aaab
+03_y: OK regex: (?>(a+))b parsed_regex: (?>(a+))b str: aaab result_expr: $1 expected_results aaa
+04_y: OK regex: ((?>[^()]+)|\([^()]*\))+ parsed_regex: ((?>[^()]+)|\([^()]*\))+ str: ((abc(ade)ufh()()x result_expr: $& expected_results abc(ade)ufh()()x
+05_y: OK regex: round\(((?>[^()]+))\) parsed_regex: round\(((?>[^()]+))\) str: _I(round(xs * sz),1) result_expr: $1 expected_results xs * sz
+06_y: OK regex: ^((?>(?:aa)?b)?) parsed_regex: ^((?>(?:aa)?b)?) str: aab result_expr: $1 expected_results aab
+

--- a/regression-tests/test-results/clang-18-c++23-libcpp/pure2-type-safety-1.cpp.execution
+++ b/regression-tests/test-results/clang-18-c++23-libcpp/pure2-type-safety-1.cpp.execution
@@ -7,3 +7,5 @@
       variant<int, int, double> is int? true
                             any is int? true
                   optional<int> is int? true
+optional<int> is: int 
+optional<*D> is: *B *D 

--- a/regression-tests/test-results/gcc-13-c++2b/pure2-type-safety-1.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/pure2-type-safety-1.cpp.execution
@@ -7,3 +7,5 @@
       variant<int, int, double> is int? true
                             any is int? true
                   optional<int> is int? true
+optional<int> is: int 
+optional<*D> is: *B *D 

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
@@ -6,7 +6,7 @@ pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' b
 pure2-assert-expected-not-null.cpp2(7): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(9): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(9): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-..\..\..\include\cpp2util.h(1047): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
+..\..\..\include\cpp2util.h(1126): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
 pure2-assert-expected-not-null.cpp2(14): error C2039: 'expected': is not a member of 'std'
 predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-assert-expected-not-null.cpp2(14): error C2062: type 'int' unexpected
@@ -19,4 +19,4 @@ pure2-assert-expected-not-null.cpp2(14): note: while trying to match the argumen
 pure2-assert-expected-not-null.cpp2(14): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(15): error C2065: 'ex': undeclared identifier
 pure2-assert-expected-not-null.cpp2(15): error C2672: 'cpp2::impl::assert_not_null': no matching overloaded function found
-..\..\..\include\cpp2util.h(1047): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'
+..\..\..\include\cpp2util.h(1126): note: could be 'decltype(auto) cpp2::impl::assert_not_null(_T0 &&,std::source_location)'

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-type-safety-1.cpp.execution
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-type-safety-1.cpp.execution
@@ -7,3 +7,5 @@
       variant<int, int, double> is int? true
                             any is int? true
                   optional<int> is int? true
+optional<int> is: int 
+optional<*D> is: *B *D 


### PR DESCRIPTION
Update test results missed in recent updates:
- new test output.
- modified line numbers in error messages.

Compilation issues with `pure2-regex-general` using Clang 18 remain and will be investigated separately.