### PR TITLE
Fix .h2 not converting to .h in the #include section

### DIFF
--- a/source/to_cpp1.h
+++ b/source/to_cpp1.h
@@ -1303,7 +1303,7 @@ public:
                 if (
                     line.cat == source_line::category::preprocessor
                     && contains(line.text, "#include")
-                    && !line.text.ends_with("*.h2\"")
+                    && !line.text.ends_with(".h2\"")
                     )
                 {
                     printer.print_cpp1(line.text, curr_lineno);


### PR DESCRIPTION
Remove the (*) since std::string::ends_with does not support wildcards.