### PR TITLE
CI Update regression tests after recent mods

### DIFF
--- a/regression-tests/test-results/clang-15-c++20/pure2-expected-is-as.cpp.output
+++ b/regression-tests/test-results/clang-15-c++20/pure2-expected-is-as.cpp.output
@@ -89,66 +89,66 @@ pure2-expected-is-as.cpp2:34:24: error: use of undeclared identifier 'ex1'; did 
 __MATHCALL_VEC (exp,, (_Mdouble_ __x));
                 ^
 In file included from pure2-expected-is-as.cpp:7:
-../../../include/cpp2util.h:1770:72: error: invalid application of 'sizeof' to a function type
+../../../include/cpp2util.h:469:72: error: invalid application of 'sizeof' to a function type
     (std::is_floating_point_v<From> && std::is_floating_point_v<To> && sizeof(From) > sizeof(To)) || // NOLINT(misc-redundant-expression)
                                                                        ^~~~~~~~~~~~
-../../../include/cpp2util.h:2891:19: note: in instantiation of variable template specialization 'cpp2::impl::is_narrowing_v' requested here
+../../../include/cpp2util.h:2923:19: note: in instantiation of variable template specialization 'cpp2::impl::is_narrowing_v' requested here
     if constexpr (is_narrowing_v<C, CPP2_TYPEOF(x)>) {
                   ^
 pure2-expected-is-as.cpp2:39:28: note: in instantiation of function template specialization 'cpp2::impl::as_<int, double (&)(double) noexcept>' requested here
     auto val1 {cpp2::impl::as_<int>(ex1)}; 
                            ^
 In file included from pure2-expected-is-as.cpp:7:
-../../../include/cpp2util.h:2892:9: error: static assertion failed due to requirement 'program_violates_type_safety_guarantee<int, double (double) noexcept>': 'as' does not allow unsafe possibly-lossy narrowing conversions - if you're sure you want this, use 'unchecked_narrow<T>' to explicitly force the conversion and possibly lose information
+../../../include/cpp2util.h:2924:9: error: static assertion failed due to requirement 'program_violates_type_safety_guarantee<int, double (double) noexcept>': 'as' does not allow unsafe possibly-lossy narrowing conversions - if you're sure you want this, use 'unchecked_narrow<T>' to explicitly force the conversion and possibly lose information
         static_assert(
         ^
 pure2-expected-is-as.cpp2:39:28: note: in instantiation of function template specialization 'cpp2::impl::as_<int, double (&)(double) noexcept>' requested here
     auto val1 {cpp2::impl::as_<int>(ex1)}; 
                            ^
 In file included from pure2-expected-is-as.cpp:7:
-../../../include/cpp2util.h:2904:52: error: no matching function for call to 'as'
+../../../include/cpp2util.h:2936:52: error: no matching function for call to 'as'
     else if constexpr( std::is_same_v< CPP2_TYPEOF(as<C>(CPP2_FORWARD(x))), nonesuch_ > ) {
                                                    ^~~~~
-../../../include/cpp2util.h:315:66: note: expanded from macro 'CPP2_TYPEOF'
+../../../include/cpp2util.h:317:66: note: expanded from macro 'CPP2_TYPEOF'
 #define CPP2_TYPEOF(x)              std::remove_cvref_t<decltype(x)>
                                                                  ^
-../../../include/cpp2util.h:1838:16: note: candidate template ignored: constraints not satisfied [with C = int, x:auto = double (&)(double) noexcept]
+../../../include/cpp2util.h:1901:16: note: candidate template ignored: constraints not satisfied [with C = int, x:auto = double (&)(double) noexcept]
 constexpr auto as(auto&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
                ^
-../../../include/cpp2util.h:1844:18: note: because 'std::is_scalar_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
+../../../include/cpp2util.h:1907:18: note: because 'std::is_scalar_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
                 (std::is_scalar_v<CPP2_TYPEOF(x)> && !std::is_enum_v<CPP2_TYPEOF(x)>)
                  ^
-../../../include/cpp2util.h:1845:17: note: and 'std::is_floating_point_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
+../../../include/cpp2util.h:1908:17: note: and 'std::is_floating_point_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
             ||  std::is_floating_point_v<CPP2_TYPEOF(x)>
                 ^
-../../../include/cpp2util.h:1846:17: note: and 'std::is_base_of_v<int, std::remove_cvref_t<decltype(x)> >' evaluated to false
+../../../include/cpp2util.h:1909:17: note: and 'std::is_base_of_v<int, std::remove_cvref_t<decltype(x)> >' evaluated to false
             ||  std::is_base_of_v<C, CPP2_TYPEOF(x)>
                 ^
-../../../include/cpp2util.h:1847:17: note: and 'std::is_base_of_v<std::remove_cvref_t<decltype(x)>, int>' evaluated to false
+../../../include/cpp2util.h:1910:17: note: and 'std::is_base_of_v<std::remove_cvref_t<decltype(x)>, int>' evaluated to false
             ||  std::is_base_of_v<CPP2_TYPEOF(x), C>
                 ^
-../../../include/cpp2util.h:1848:30: note: and 'C{std::forward<decltype(x)>(x)}' would be invalid: cannot initialize a value of type 'int' with an lvalue of type 'double (double) noexcept'
+../../../include/cpp2util.h:1911:30: note: and 'C{std::forward<decltype(x)>(x)}' would be invalid: cannot initialize a value of type 'int' with an lvalue of type 'double (double) noexcept'
             ||  requires { C{CPP2_FORWARD(x)}; }
                              ^
-../../../include/cpp2util.h:325:37: note: expanded from macro 'CPP2_FORWARD'
+../../../include/cpp2util.h:327:37: note: expanded from macro 'CPP2_FORWARD'
 #define CPP2_FORWARD(x)             std::forward<decltype(x)>(x)
                                     ^
-../../../include/cpp2util.h:1977:6: note: candidate template ignored: constraints not satisfied [with C = int, X = double (&)(double) noexcept]
+../../../include/cpp2util.h:2040:6: note: candidate template ignored: constraints not satisfied [with C = int, X = double (&)(double) noexcept]
 auto as(X&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
      ^
-../../../include/cpp2util.h:1976:23: note: because 'specialization_of_template<double (&)(double) noexcept, std::variant>' evaluated to false
+../../../include/cpp2util.h:2039:23: note: because 'specialization_of_template<double (&)(double) noexcept, std::variant>' evaluated to false
 template< typename C, specialization_of_template<std::variant> X >
                       ^
-../../../include/cpp2util.h:724:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
+../../../include/cpp2util.h:891:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
       ^
-../../../include/cpp2util.h:2024:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
+../../../include/cpp2util.h:2087:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
 constexpr auto as( X && x ) -> decltype(auto) {
                ^
-../../../include/cpp2util.h:2023:22: note: because 'same_type_as<double (&)(double) noexcept, std::any>' evaluated to false
+../../../include/cpp2util.h:2086:22: note: because 'same_type_as<double (&)(double) noexcept, std::any>' evaluated to false
 template<typename T, same_type_as<std::any> X>
                      ^
-../../../include/cpp2util.h:754:24: note: because 'std::same_as<std::remove_cvref_t<double (&)(double) noexcept>, std::remove_cvref_t<any> >' evaluated to false
+../../../include/cpp2util.h:921:24: note: because 'std::same_as<std::remove_cvref_t<double (&)(double) noexcept>, std::remove_cvref_t<any> >' evaluated to false
 concept same_type_as = std::same_as<std::remove_cvref_t<X>, std::remove_cvref_t<C>>;
                        ^
 /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/concepts:63:9: note: because '__detail::__same_as<double (double) noexcept, std::any>' evaluated to false
@@ -157,64 +157,64 @@ concept same_type_as = std::same_as<std::remove_cvref_t<X>, std::remove_cvref_t<
 /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/concepts:57:27: note: because 'std::is_same_v<double (double) noexcept, std::any>' evaluated to false
       concept __same_as = std::is_same_v<_Tp, _Up>;
                           ^
-../../../include/cpp2util.h:2069:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
+../../../include/cpp2util.h:2130:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
 constexpr auto as( X&& x ) -> decltype(auto) { 
                ^
-../../../include/cpp2util.h:2068:22: note: because 'specialization_of_template<double (&)(double) noexcept, std::optional>' evaluated to false
+../../../include/cpp2util.h:2129:22: note: because 'specialization_of_template<double (&)(double) noexcept, std::optional>' evaluated to false
 template<typename T, specialization_of_template<std::optional> X>
                      ^
-../../../include/cpp2util.h:724:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
+../../../include/cpp2util.h:891:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
       ^
-../../../include/cpp2util.h:1813:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
+../../../include/cpp2util.h:1876:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
 constexpr auto as() -> auto
                ^
-../../../include/cpp2util.h:1824:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
+../../../include/cpp2util.h:1887:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
 constexpr auto as() -> auto
                ^
-../../../include/cpp2util.h:2905:9: error: static assertion failed due to requirement 'program_violates_type_safety_guarantee<int, double (double) noexcept>': No safe 'as' cast available - please check your cast
+../../../include/cpp2util.h:2937:9: error: static assertion failed due to requirement 'program_violates_type_safety_guarantee<int, double (double) noexcept>': No safe 'as' cast available - please check your cast
         static_assert(
         ^
-../../../include/cpp2util.h:2911:12: error: no matching function for call to 'as'
+../../../include/cpp2util.h:2943:12: error: no matching function for call to 'as'
     return as<C>(CPP2_FORWARD(x));
            ^~~~~
-../../../include/cpp2util.h:1838:16: note: candidate template ignored: constraints not satisfied [with C = int, x:auto = double (&)(double) noexcept]
+../../../include/cpp2util.h:1901:16: note: candidate template ignored: constraints not satisfied [with C = int, x:auto = double (&)(double) noexcept]
 constexpr auto as(auto&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
                ^
-../../../include/cpp2util.h:1844:18: note: because 'std::is_scalar_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
+../../../include/cpp2util.h:1907:18: note: because 'std::is_scalar_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
                 (std::is_scalar_v<CPP2_TYPEOF(x)> && !std::is_enum_v<CPP2_TYPEOF(x)>)
                  ^
-../../../include/cpp2util.h:1845:17: note: and 'std::is_floating_point_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
+../../../include/cpp2util.h:1908:17: note: and 'std::is_floating_point_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
             ||  std::is_floating_point_v<CPP2_TYPEOF(x)>
                 ^
-../../../include/cpp2util.h:1846:17: note: and 'std::is_base_of_v<int, std::remove_cvref_t<decltype(x)> >' evaluated to false
+../../../include/cpp2util.h:1909:17: note: and 'std::is_base_of_v<int, std::remove_cvref_t<decltype(x)> >' evaluated to false
             ||  std::is_base_of_v<C, CPP2_TYPEOF(x)>
                 ^
-../../../include/cpp2util.h:1847:17: note: and 'std::is_base_of_v<std::remove_cvref_t<decltype(x)>, int>' evaluated to false
+../../../include/cpp2util.h:1910:17: note: and 'std::is_base_of_v<std::remove_cvref_t<decltype(x)>, int>' evaluated to false
             ||  std::is_base_of_v<CPP2_TYPEOF(x), C>
                 ^
-../../../include/cpp2util.h:1848:30: note: and 'C{std::forward<decltype(x)>(x)}' would be invalid: cannot initialize a value of type 'int' with an lvalue of type 'double (double) noexcept'
+../../../include/cpp2util.h:1911:30: note: and 'C{std::forward<decltype(x)>(x)}' would be invalid: cannot initialize a value of type 'int' with an lvalue of type 'double (double) noexcept'
             ||  requires { C{CPP2_FORWARD(x)}; }
                              ^
-../../../include/cpp2util.h:325:37: note: expanded from macro 'CPP2_FORWARD'
+../../../include/cpp2util.h:327:37: note: expanded from macro 'CPP2_FORWARD'
 #define CPP2_FORWARD(x)             std::forward<decltype(x)>(x)
                                     ^
-../../../include/cpp2util.h:1977:6: note: candidate template ignored: constraints not satisfied [with C = int, X = double (&)(double) noexcept]
+../../../include/cpp2util.h:2040:6: note: candidate template ignored: constraints not satisfied [with C = int, X = double (&)(double) noexcept]
 auto as(X&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
      ^
-../../../include/cpp2util.h:1976:23: note: because 'specialization_of_template<double (&)(double) noexcept, std::variant>' evaluated to false
+../../../include/cpp2util.h:2039:23: note: because 'specialization_of_template<double (&)(double) noexcept, std::variant>' evaluated to false
 template< typename C, specialization_of_template<std::variant> X >
                       ^
-../../../include/cpp2util.h:724:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
+../../../include/cpp2util.h:891:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
       ^
-../../../include/cpp2util.h:2024:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
+../../../include/cpp2util.h:2087:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
 constexpr auto as( X && x ) -> decltype(auto) {
                ^
-../../../include/cpp2util.h:2023:22: note: because 'same_type_as<double (&)(double) noexcept, std::any>' evaluated to false
+../../../include/cpp2util.h:2086:22: note: because 'same_type_as<double (&)(double) noexcept, std::any>' evaluated to false
 template<typename T, same_type_as<std::any> X>
                      ^
-../../../include/cpp2util.h:754:24: note: because 'std::same_as<std::remove_cvref_t<double (&)(double) noexcept>, std::remove_cvref_t<any> >' evaluated to false
+../../../include/cpp2util.h:921:24: note: because 'std::same_as<std::remove_cvref_t<double (&)(double) noexcept>, std::remove_cvref_t<any> >' evaluated to false
 concept same_type_as = std::same_as<std::remove_cvref_t<X>, std::remove_cvref_t<C>>;
                        ^
 /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/concepts:63:9: note: because '__detail::__same_as<double (double) noexcept, std::any>' evaluated to false
@@ -223,19 +223,19 @@ concept same_type_as = std::same_as<std::remove_cvref_t<X>, std::remove_cvref_t<
 /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/concepts:57:27: note: because 'std::is_same_v<double (double) noexcept, std::any>' evaluated to false
       concept __same_as = std::is_same_v<_Tp, _Up>;
                           ^
-../../../include/cpp2util.h:2069:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
+../../../include/cpp2util.h:2130:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
 constexpr auto as( X&& x ) -> decltype(auto) { 
                ^
-../../../include/cpp2util.h:2068:22: note: because 'specialization_of_template<double (&)(double) noexcept, std::optional>' evaluated to false
+../../../include/cpp2util.h:2129:22: note: because 'specialization_of_template<double (&)(double) noexcept, std::optional>' evaluated to false
 template<typename T, specialization_of_template<std::optional> X>
                      ^
-../../../include/cpp2util.h:724:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
+../../../include/cpp2util.h:891:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
       ^
-../../../include/cpp2util.h:1813:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
+../../../include/cpp2util.h:1876:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
 constexpr auto as() -> auto
                ^
-../../../include/cpp2util.h:1824:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
+../../../include/cpp2util.h:1887:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
 constexpr auto as() -> auto
                ^
 pure2-expected-is-as.cpp2:39:37: error: use of undeclared identifier 'ex1'

--- a/regression-tests/test-results/clang-18-c++20/pure2-expected-is-as.cpp.output
+++ b/regression-tests/test-results/clang-18-c++20/pure2-expected-is-as.cpp.output
@@ -89,67 +89,67 @@ pure2-expected-is-as.cpp2:34:24: error: use of undeclared identifier 'ex1'; did 
    95 | __MATHCALL_VEC (exp,, (_Mdouble_ __x));
       |                 ^
 In file included from pure2-expected-is-as.cpp:7:
-../../../include/cpp2util.h:1770:72: error: invalid application of 'sizeof' to a function type
- 1770 |     (std::is_floating_point_v<From> && std::is_floating_point_v<To> && sizeof(From) > sizeof(To)) || // NOLINT(misc-redundant-expression)
+../../../include/cpp2util.h:469:72: error: invalid application of 'sizeof' to a function type
+  469 |     (std::is_floating_point_v<From> && std::is_floating_point_v<To> && sizeof(From) > sizeof(To)) || // NOLINT(misc-redundant-expression)
       |                                                                        ^~~~~~~~~~~~
-../../../include/cpp2util.h:2891:19: note: in instantiation of variable template specialization 'cpp2::impl::is_narrowing_v' requested here
- 2891 |     if constexpr (is_narrowing_v<C, CPP2_TYPEOF(x)>) {
+../../../include/cpp2util.h:2923:19: note: in instantiation of variable template specialization 'cpp2::impl::is_narrowing_v' requested here
+ 2923 |     if constexpr (is_narrowing_v<C, CPP2_TYPEOF(x)>) {
       |                   ^
 pure2-expected-is-as.cpp2:39:28: note: in instantiation of function template specialization 'cpp2::impl::as_<int, double (&)(double) noexcept>' requested here
    39 |     auto val1 {cpp2::impl::as_<int>(ex1)}; 
       |                            ^
 In file included from pure2-expected-is-as.cpp:7:
-../../../include/cpp2util.h:2893:13: error: static assertion failed due to requirement 'program_violates_type_safety_guarantee<int, double (double) noexcept>': 'as' does not allow unsafe possibly-lossy narrowing conversions - if you're sure you want this, use 'unchecked_narrow<T>' to explicitly force the conversion and possibly lose information
- 2893 |             program_violates_type_safety_guarantee<C, CPP2_TYPEOF(x)>,
+../../../include/cpp2util.h:2925:13: error: static assertion failed due to requirement 'program_violates_type_safety_guarantee<int, double (double) noexcept>': 'as' does not allow unsafe possibly-lossy narrowing conversions - if you're sure you want this, use 'unchecked_narrow<T>' to explicitly force the conversion and possibly lose information
+ 2925 |             program_violates_type_safety_guarantee<C, CPP2_TYPEOF(x)>,
       |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pure2-expected-is-as.cpp2:39:28: note: in instantiation of function template specialization 'cpp2::impl::as_<int, double (&)(double) noexcept>' requested here
    39 |     auto val1 {cpp2::impl::as_<int>(ex1)}; 
       |                            ^
 In file included from pure2-expected-is-as.cpp:7:
-../../../include/cpp2util.h:2904:52: error: no matching function for call to 'as'
- 2904 |     else if constexpr( std::is_same_v< CPP2_TYPEOF(as<C>(CPP2_FORWARD(x))), nonesuch_ > ) {
+../../../include/cpp2util.h:2936:52: error: no matching function for call to 'as'
+ 2936 |     else if constexpr( std::is_same_v< CPP2_TYPEOF(as<C>(CPP2_FORWARD(x))), nonesuch_ > ) {
       |                                                    ^~~~~
-../../../include/cpp2util.h:315:66: note: expanded from macro 'CPP2_TYPEOF'
-  315 | #define CPP2_TYPEOF(x)              std::remove_cvref_t<decltype(x)>
+../../../include/cpp2util.h:317:66: note: expanded from macro 'CPP2_TYPEOF'
+  317 | #define CPP2_TYPEOF(x)              std::remove_cvref_t<decltype(x)>
       |                                                                  ^
-../../../include/cpp2util.h:1838:16: note: candidate template ignored: constraints not satisfied [with C = int, x:auto = double (&)(double) noexcept]
- 1838 | constexpr auto as(auto&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
+../../../include/cpp2util.h:1901:16: note: candidate template ignored: constraints not satisfied [with C = int, x:auto = double (&)(double) noexcept]
+ 1901 | constexpr auto as(auto&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
       |                ^
-../../../include/cpp2util.h:1844:18: note: because 'std::is_scalar_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
- 1844 |                 (std::is_scalar_v<CPP2_TYPEOF(x)> && !std::is_enum_v<CPP2_TYPEOF(x)>)
+../../../include/cpp2util.h:1907:18: note: because 'std::is_scalar_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
+ 1907 |                 (std::is_scalar_v<CPP2_TYPEOF(x)> && !std::is_enum_v<CPP2_TYPEOF(x)>)
       |                  ^
-../../../include/cpp2util.h:1845:17: note: and 'std::is_floating_point_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
- 1845 |             ||  std::is_floating_point_v<CPP2_TYPEOF(x)>
+../../../include/cpp2util.h:1908:17: note: and 'std::is_floating_point_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
+ 1908 |             ||  std::is_floating_point_v<CPP2_TYPEOF(x)>
       |                 ^
-../../../include/cpp2util.h:1846:17: note: and 'std::is_base_of_v<int, std::remove_cvref_t<decltype(x)> >' evaluated to false
- 1846 |             ||  std::is_base_of_v<C, CPP2_TYPEOF(x)>
+../../../include/cpp2util.h:1909:17: note: and 'std::is_base_of_v<int, std::remove_cvref_t<decltype(x)> >' evaluated to false
+ 1909 |             ||  std::is_base_of_v<C, CPP2_TYPEOF(x)>
       |                 ^
-../../../include/cpp2util.h:1847:17: note: and 'std::is_base_of_v<std::remove_cvref_t<decltype(x)>, int>' evaluated to false
- 1847 |             ||  std::is_base_of_v<CPP2_TYPEOF(x), C>
+../../../include/cpp2util.h:1910:17: note: and 'std::is_base_of_v<std::remove_cvref_t<decltype(x)>, int>' evaluated to false
+ 1910 |             ||  std::is_base_of_v<CPP2_TYPEOF(x), C>
       |                 ^
-../../../include/cpp2util.h:1848:30: note: and 'C{std::forward<decltype(x)>(x)}' would be invalid: cannot initialize a value of type 'int' with an lvalue of type 'double (double) noexcept'
- 1848 |             ||  requires { C{CPP2_FORWARD(x)}; }
+../../../include/cpp2util.h:1911:30: note: and 'C{std::forward<decltype(x)>(x)}' would be invalid: cannot initialize a value of type 'int' with an lvalue of type 'double (double) noexcept'
+ 1911 |             ||  requires { C{CPP2_FORWARD(x)}; }
       |                              ^
-../../../include/cpp2util.h:325:37: note: expanded from macro 'CPP2_FORWARD'
-  325 | #define CPP2_FORWARD(x)             std::forward<decltype(x)>(x)
+../../../include/cpp2util.h:327:37: note: expanded from macro 'CPP2_FORWARD'
+  327 | #define CPP2_FORWARD(x)             std::forward<decltype(x)>(x)
       |                                     ^
-../../../include/cpp2util.h:1977:6: note: candidate template ignored: constraints not satisfied [with C = int, X = double (&)(double) noexcept]
- 1977 | auto as(X&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
+../../../include/cpp2util.h:2040:6: note: candidate template ignored: constraints not satisfied [with C = int, X = double (&)(double) noexcept]
+ 2040 | auto as(X&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
       |      ^
-../../../include/cpp2util.h:1976:23: note: because 'specialization_of_template<double (&)(double) noexcept, std::variant>' evaluated to false
- 1976 | template< typename C, specialization_of_template<std::variant> X >
+../../../include/cpp2util.h:2039:23: note: because 'specialization_of_template<double (&)(double) noexcept, std::variant>' evaluated to false
+ 2039 | template< typename C, specialization_of_template<std::variant> X >
       |                       ^
-../../../include/cpp2util.h:724:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
-  724 |     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
+../../../include/cpp2util.h:891:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
+  891 |     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
       |       ^
-../../../include/cpp2util.h:2024:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
- 2024 | constexpr auto as( X && x ) -> decltype(auto) {
+../../../include/cpp2util.h:2087:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
+ 2087 | constexpr auto as( X && x ) -> decltype(auto) {
       |                ^
-../../../include/cpp2util.h:2023:22: note: because 'same_type_as<double (&)(double) noexcept, std::any>' evaluated to false
- 2023 | template<typename T, same_type_as<std::any> X>
+../../../include/cpp2util.h:2086:22: note: because 'same_type_as<double (&)(double) noexcept, std::any>' evaluated to false
+ 2086 | template<typename T, same_type_as<std::any> X>
       |                      ^
-../../../include/cpp2util.h:754:24: note: because 'std::same_as<std::remove_cvref_t<double (&)(double) noexcept>, std::remove_cvref_t<any> >' evaluated to false
-  754 | concept same_type_as = std::same_as<std::remove_cvref_t<X>, std::remove_cvref_t<C>>;
+../../../include/cpp2util.h:921:24: note: because 'std::same_as<std::remove_cvref_t<double (&)(double) noexcept>, std::remove_cvref_t<any> >' evaluated to false
+  921 | concept same_type_as = std::same_as<std::remove_cvref_t<X>, std::remove_cvref_t<C>>;
       |                        ^
 /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/concepts:63:9: note: because '__detail::__same_as<double (double) noexcept, std::any>' evaluated to false
    63 |       = __detail::__same_as<_Tp, _Up> && __detail::__same_as<_Up, _Tp>;
@@ -157,65 +157,65 @@ In file included from pure2-expected-is-as.cpp:7:
 /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/concepts:57:27: note: because 'std::is_same_v<double (double) noexcept, std::any>' evaluated to false
    57 |       concept __same_as = std::is_same_v<_Tp, _Up>;
       |                           ^
-../../../include/cpp2util.h:2069:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
- 2069 | constexpr auto as( X&& x ) -> decltype(auto) { 
+../../../include/cpp2util.h:2130:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
+ 2130 | constexpr auto as( X&& x ) -> decltype(auto) { 
       |                ^
-../../../include/cpp2util.h:2068:22: note: because 'specialization_of_template<double (&)(double) noexcept, std::optional>' evaluated to false
- 2068 | template<typename T, specialization_of_template<std::optional> X>
+../../../include/cpp2util.h:2129:22: note: because 'specialization_of_template<double (&)(double) noexcept, std::optional>' evaluated to false
+ 2129 | template<typename T, specialization_of_template<std::optional> X>
       |                      ^
-../../../include/cpp2util.h:724:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
-  724 |     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
+../../../include/cpp2util.h:891:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
+  891 |     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
       |       ^
-../../../include/cpp2util.h:1813:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
- 1813 | constexpr auto as() -> auto
+../../../include/cpp2util.h:1876:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
+ 1876 | constexpr auto as() -> auto
       |                ^
-../../../include/cpp2util.h:1824:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
- 1824 | constexpr auto as() -> auto
+../../../include/cpp2util.h:1887:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
+ 1887 | constexpr auto as() -> auto
       |                ^
-../../../include/cpp2util.h:2906:13: error: static assertion failed due to requirement 'program_violates_type_safety_guarantee<int, double (double) noexcept>': No safe 'as' cast available - please check your cast
- 2906 |             program_violates_type_safety_guarantee<C, CPP2_TYPEOF(x)>,
+../../../include/cpp2util.h:2938:13: error: static assertion failed due to requirement 'program_violates_type_safety_guarantee<int, double (double) noexcept>': No safe 'as' cast available - please check your cast
+ 2938 |             program_violates_type_safety_guarantee<C, CPP2_TYPEOF(x)>,
       |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-../../../include/cpp2util.h:2911:12: error: no matching function for call to 'as'
- 2911 |     return as<C>(CPP2_FORWARD(x));
+../../../include/cpp2util.h:2943:12: error: no matching function for call to 'as'
+ 2943 |     return as<C>(CPP2_FORWARD(x));
       |            ^~~~~
-../../../include/cpp2util.h:1838:16: note: candidate template ignored: constraints not satisfied [with C = int, x:auto = double (&)(double) noexcept]
- 1838 | constexpr auto as(auto&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
+../../../include/cpp2util.h:1901:16: note: candidate template ignored: constraints not satisfied [with C = int, x:auto = double (&)(double) noexcept]
+ 1901 | constexpr auto as(auto&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
       |                ^
-../../../include/cpp2util.h:1844:18: note: because 'std::is_scalar_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
- 1844 |                 (std::is_scalar_v<CPP2_TYPEOF(x)> && !std::is_enum_v<CPP2_TYPEOF(x)>)
+../../../include/cpp2util.h:1907:18: note: because 'std::is_scalar_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
+ 1907 |                 (std::is_scalar_v<CPP2_TYPEOF(x)> && !std::is_enum_v<CPP2_TYPEOF(x)>)
       |                  ^
-../../../include/cpp2util.h:1845:17: note: and 'std::is_floating_point_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
- 1845 |             ||  std::is_floating_point_v<CPP2_TYPEOF(x)>
+../../../include/cpp2util.h:1908:17: note: and 'std::is_floating_point_v<std::remove_cvref_t<decltype(x)> >' evaluated to false
+ 1908 |             ||  std::is_floating_point_v<CPP2_TYPEOF(x)>
       |                 ^
-../../../include/cpp2util.h:1846:17: note: and 'std::is_base_of_v<int, std::remove_cvref_t<decltype(x)> >' evaluated to false
- 1846 |             ||  std::is_base_of_v<C, CPP2_TYPEOF(x)>
+../../../include/cpp2util.h:1909:17: note: and 'std::is_base_of_v<int, std::remove_cvref_t<decltype(x)> >' evaluated to false
+ 1909 |             ||  std::is_base_of_v<C, CPP2_TYPEOF(x)>
       |                 ^
-../../../include/cpp2util.h:1847:17: note: and 'std::is_base_of_v<std::remove_cvref_t<decltype(x)>, int>' evaluated to false
- 1847 |             ||  std::is_base_of_v<CPP2_TYPEOF(x), C>
+../../../include/cpp2util.h:1910:17: note: and 'std::is_base_of_v<std::remove_cvref_t<decltype(x)>, int>' evaluated to false
+ 1910 |             ||  std::is_base_of_v<CPP2_TYPEOF(x), C>
       |                 ^
-../../../include/cpp2util.h:1848:30: note: and 'C{std::forward<decltype(x)>(x)}' would be invalid: cannot initialize a value of type 'int' with an lvalue of type 'double (double) noexcept'
- 1848 |             ||  requires { C{CPP2_FORWARD(x)}; }
+../../../include/cpp2util.h:1911:30: note: and 'C{std::forward<decltype(x)>(x)}' would be invalid: cannot initialize a value of type 'int' with an lvalue of type 'double (double) noexcept'
+ 1911 |             ||  requires { C{CPP2_FORWARD(x)}; }
       |                              ^
-../../../include/cpp2util.h:325:37: note: expanded from macro 'CPP2_FORWARD'
-  325 | #define CPP2_FORWARD(x)             std::forward<decltype(x)>(x)
+../../../include/cpp2util.h:327:37: note: expanded from macro 'CPP2_FORWARD'
+  327 | #define CPP2_FORWARD(x)             std::forward<decltype(x)>(x)
       |                                     ^
-../../../include/cpp2util.h:1977:6: note: candidate template ignored: constraints not satisfied [with C = int, X = double (&)(double) noexcept]
- 1977 | auto as(X&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
+../../../include/cpp2util.h:2040:6: note: candidate template ignored: constraints not satisfied [with C = int, X = double (&)(double) noexcept]
+ 2040 | auto as(X&& x CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAULT_AS) -> decltype(auto)
       |      ^
-../../../include/cpp2util.h:1976:23: note: because 'specialization_of_template<double (&)(double) noexcept, std::variant>' evaluated to false
- 1976 | template< typename C, specialization_of_template<std::variant> X >
+../../../include/cpp2util.h:2039:23: note: because 'specialization_of_template<double (&)(double) noexcept, std::variant>' evaluated to false
+ 2039 | template< typename C, specialization_of_template<std::variant> X >
       |                       ^
-../../../include/cpp2util.h:724:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
-  724 |     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
+../../../include/cpp2util.h:891:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
+  891 |     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
       |       ^
-../../../include/cpp2util.h:2024:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
- 2024 | constexpr auto as( X && x ) -> decltype(auto) {
+../../../include/cpp2util.h:2087:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
+ 2087 | constexpr auto as( X && x ) -> decltype(auto) {
       |                ^
-../../../include/cpp2util.h:2023:22: note: because 'same_type_as<double (&)(double) noexcept, std::any>' evaluated to false
- 2023 | template<typename T, same_type_as<std::any> X>
+../../../include/cpp2util.h:2086:22: note: because 'same_type_as<double (&)(double) noexcept, std::any>' evaluated to false
+ 2086 | template<typename T, same_type_as<std::any> X>
       |                      ^
-../../../include/cpp2util.h:754:24: note: because 'std::same_as<std::remove_cvref_t<double (&)(double) noexcept>, std::remove_cvref_t<any> >' evaluated to false
-  754 | concept same_type_as = std::same_as<std::remove_cvref_t<X>, std::remove_cvref_t<C>>;
+../../../include/cpp2util.h:921:24: note: because 'std::same_as<std::remove_cvref_t<double (&)(double) noexcept>, std::remove_cvref_t<any> >' evaluated to false
+  921 | concept same_type_as = std::same_as<std::remove_cvref_t<X>, std::remove_cvref_t<C>>;
       |                        ^
 /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/concepts:63:9: note: because '__detail::__same_as<double (double) noexcept, std::any>' evaluated to false
    63 |       = __detail::__same_as<_Tp, _Up> && __detail::__same_as<_Up, _Tp>;
@@ -223,20 +223,20 @@ In file included from pure2-expected-is-as.cpp:7:
 /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/concepts:57:27: note: because 'std::is_same_v<double (double) noexcept, std::any>' evaluated to false
    57 |       concept __same_as = std::is_same_v<_Tp, _Up>;
       |                           ^
-../../../include/cpp2util.h:2069:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
- 2069 | constexpr auto as( X&& x ) -> decltype(auto) { 
+../../../include/cpp2util.h:2130:16: note: candidate template ignored: constraints not satisfied [with T = int, X = double (&)(double) noexcept]
+ 2130 | constexpr auto as( X&& x ) -> decltype(auto) { 
       |                ^
-../../../include/cpp2util.h:2068:22: note: because 'specialization_of_template<double (&)(double) noexcept, std::optional>' evaluated to false
- 2068 | template<typename T, specialization_of_template<std::optional> X>
+../../../include/cpp2util.h:2129:22: note: because 'specialization_of_template<double (&)(double) noexcept, std::optional>' evaluated to false
+ 2129 | template<typename T, specialization_of_template<std::optional> X>
       |                      ^
-../../../include/cpp2util.h:724:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
-  724 |     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
+../../../include/cpp2util.h:891:7: note: because 'specialization_of_template_helper<C>(std::forward<X>(x))' would be invalid: no matching function for call to 'specialization_of_template_helper'
+  891 |     { specialization_of_template_helper<C>(std::forward<X>(x)) } -> std::same_as<std::true_type>;
       |       ^
-../../../include/cpp2util.h:1813:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
- 1813 | constexpr auto as() -> auto
+../../../include/cpp2util.h:1876:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
+ 1876 | constexpr auto as() -> auto
       |                ^
-../../../include/cpp2util.h:1824:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
- 1824 | constexpr auto as() -> auto
+../../../include/cpp2util.h:1887:16: note: candidate function template not viable: requires 0 arguments, but 1 was provided
+ 1887 | constexpr auto as() -> auto
       |                ^
 pure2-expected-is-as.cpp2:39:37: error: use of undeclared identifier 'ex1'
    39 |     auto val1 {cpp2::impl::as_<int>(ex1)}; 

--- a/regression-tests/test-results/gcc-13-c++2b/mixed-bounds-safety-with-assert.cpp.execution
+++ b/regression-tests/test-results/gcc-13-c++2b/mixed-bounds-safety-with-assert.cpp.execution
@@ -1,1 +1,1 @@
-mixed-bounds-safety-with-assert.cpp2(11) void print_subrange(const auto:129&, cpp2::impl::in<int>, cpp2::impl::in<int>) [with auto:129 = std::vector<int>; cpp2::impl::in<int> = const int]: Bounds safety violation
+mixed-bounds-safety-with-assert.cpp2(11) void print_subrange(const auto:130&, cpp2::impl::in<int>, cpp2::impl::in<int>) [with auto:130 = std::vector<int>; cpp2::impl::in<int> = const int]: Bounds safety violation

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-assert-expected-not-null.cpp.output
@@ -14,7 +14,7 @@ pure2-assert-expected-not-null.cpp2(14): error C2143: syntax error: missing ';' 
 pure2-assert-expected-not-null.cpp2(14): error C2039: 'unexpected': is not a member of 'std'
 predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-assert-expected-not-null.cpp2(14): error C2660: 'unexpected': function does not take 1 arguments
-C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\eh.h(33): note: see declaration of 'unexpected'
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\eh.h(33): note: see declaration of 'unexpected'
 pure2-assert-expected-not-null.cpp2(14): note: while trying to match the argument list '(bool)'
 pure2-assert-expected-not-null.cpp2(14): error C2143: syntax error: missing ';' before '}'
 pure2-assert-expected-not-null.cpp2(15): error C2065: 'ex': undeclared identifier

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-expected-is-as.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-expected-is-as.cpp.output
@@ -1,21 +1,21 @@
 pure2-expected-is-as.cpp
 pure2-expected-is-as.cpp2(7): error C2039: 'expected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-expected-is-as.cpp2(7): error C2062: type 'int' unexpected
 pure2-expected-is-as.cpp2(7): error C2143: syntax error: missing ';' before '{'
 pure2-expected-is-as.cpp2(7): error C2143: syntax error: missing ';' before '}'
 pure2-expected-is-as.cpp2(8): error C2039: 'expected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-expected-is-as.cpp2(8): error C2062: type 'int' unexpected
 pure2-expected-is-as.cpp2(8): error C2143: syntax error: missing ';' before '{'
 pure2-expected-is-as.cpp2(8): error C2039: 'unexpected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-expected-is-as.cpp2(8): error C2660: 'unexpected': function does not take 1 arguments
-C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\eh.h(33): note: see declaration of 'unexpected'
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\eh.h(33): note: see declaration of 'unexpected'
 pure2-expected-is-as.cpp2(8): note: while trying to match the argument list '(int)'
 pure2-expected-is-as.cpp2(8): error C2143: syntax error: missing ';' before '}'
 pure2-expected-is-as.cpp2(9): error C2039: 'expected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-expected-is-as.cpp2(9): error C2275: 'std::string': expected an expression instead of a type
 pure2-expected-is-as.cpp2(9): error C2065: 'ex3': undeclared identifier
 pure2-expected-is-as.cpp2(9): error C2275: 'size_t': expected an expression instead of a type
@@ -23,7 +23,7 @@ pure2-expected-is-as.cpp2(11): error C2065: 'ex1': undeclared identifier
 pure2-expected-is-as.cpp2(15): error C2065: 'ex1': undeclared identifier
 pure2-expected-is-as.cpp2(20): error C2065: 'ex1': undeclared identifier
 pure2-expected-is-as.cpp2(25): error C2039: 'unexpected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-expected-is-as.cpp2(25): error C2062: type 'int' unexpected
 pure2-expected-is-as.cpp2(25): error C2059: syntax error: '>'
 pure2-expected-is-as.cpp2(25): error C2143: syntax error: missing ';' before '{'
@@ -35,7 +35,7 @@ pure2-expected-is-as.cpp2(42): error C2065: 'ex2': undeclared identifier
 pure2-expected-is-as.cpp2(47): error C2065: 'ex2': undeclared identifier
 pure2-expected-is-as.cpp2(52): error C2065: 'ex2': undeclared identifier
 pure2-expected-is-as.cpp2(57): error C2039: 'unexpected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-expected-is-as.cpp2(57): error C2062: type 'int' unexpected
 pure2-expected-is-as.cpp2(57): error C2059: syntax error: '>'
 pure2-expected-is-as.cpp2(57): error C2143: syntax error: missing ';' before '{'
@@ -43,14 +43,14 @@ pure2-expected-is-as.cpp2(58): error C2065: 'ex2': undeclared identifier
 pure2-expected-is-as.cpp2(61): error C2065: 'ex2': undeclared identifier
 pure2-expected-is-as.cpp2(62): error C2065: 'ex2': undeclared identifier
 pure2-expected-is-as.cpp2(65): error C2039: 'unexpected': is not a member of 'std'
-predefined C++ types (compiler internal)(347): note: see declaration of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
 pure2-expected-is-as.cpp2(65): error C2062: type 'int' unexpected
 pure2-expected-is-as.cpp2(65): error C2062: type 'unknown-type' unexpected
 pure2-expected-is-as.cpp2(65): error C2143: syntax error: missing ';' before '}'
 pure2-expected-is-as.cpp2(66): error C2143: syntax error: missing ';' before '<<'
 pure2-expected-is-as.cpp2(66): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
 pure2-expected-is-as.cpp2(66): error C2371: 'std::cout': redefinition; different basic types
-C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\iostream(39): note: see declaration of 'std::cout'
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\iostream(40): note: see declaration of 'std::cout'
 pure2-expected-is-as.cpp2(66): error C2059: syntax error: '<<'
 pure2-expected-is-as.cpp2(66): error C2143: syntax error: missing ';' before '{'
 pure2-expected-is-as.cpp2(66): error C2447: '{': missing function header (old-style formal list?)

--- a/regression-tests/test-results/msvc-2022-c++20/pure2-last-use.cpp.output
+++ b/regression-tests/test-results/msvc-2022-c++20/pure2-last-use.cpp.output
@@ -91,4 +91,20 @@ pure2-last-use.cpp2(774): error C3861: 'size': identifier not found
 pure2-last-use.cpp2(774): note: This diagnostic occurred in the compiler generated function 'decltype(auto) issue_888_1::<lambda_1>::operator ()(Obj &&,Params ...) noexcept(<expr>) const'
 pure2-last-use.cpp2(774): error C2065: 'size': undeclared identifier
 pure2-last-use.cpp2(774): note: This diagnostic occurred in the compiler generated function 'decltype(auto) issue_888_1::<lambda_1>::operator ()(Obj &&,Params ...) noexcept(<expr>) const'
-pure2-last-use.cpp2(773): fatal error C1075: '{': no matching token found
+pure2-last-use.cpp2(774): error C2338: static_assert failed: 'this function call syntax tries 'obj.func(...)', then 'func(obj,...);', but both failed - if this function call is passing a local variable that will be modified by the function, but that variable is never used again in the function so the new value is never used, that's likely the problem - if that's what you intended, add another line '_ = obj;' afterward to explicitly discard the new value of the object'
+pure2-last-use.cpp2(774): note: the template instantiation context (the oldest one first) is
+pure2-last-use.cpp2(774): note: see reference to function template instantiation 'decltype(auto) issue_888_1::<lambda_1>::operator ()<int,,false>(Obj &&) noexcept(false) const' being compiled
+        with
+        [
+            Obj=int
+        ]
+pure2-last-use.cpp2(790): error C2039: 'move_only_function': is not a member of 'std'
+predefined C++ types (compiler internal)(357): note: see declaration of 'std'
+pure2-last-use.cpp2(790): error C2143: syntax error: missing ')' before 'attribute specifier'
+pure2-last-use.cpp2(790): error C2065: 'move_only_function': undeclared identifier
+pure2-last-use.cpp2(790): error C2143: syntax error: missing ';' before 'attribute specifier'
+pure2-last-use.cpp2(790): error C2059: syntax error: ')'
+pure2-last-use.cpp2(790): error C2734: 'unnamed_param_1': 'const' object must be initialized if not 'extern'
+pure2-last-use.cpp2(790): error C2143: syntax error: missing ';' before '>'
+pure2-last-use.cpp2(790): error C2059: syntax error: '>'
+pure2-last-use.cpp2(790): fatal error C1003: error count exceeds 100; stopping compilation


### PR DESCRIPTION
Another update of regression test results still excluding the SIGSEGVs cause in Cland 18.1 in `pure2-regex-general.cpp2`.