### PR TITLE
Create a simple makefile and allow regressions to use it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,11 @@ cppfront/x64/Debug/microsoft/STL/std.compat.ixx.ifc.dt.module.json.command
 cppfront/x64/Debug/microsoft/STL/std.ixx.ifc.dt.d.json
 cppfront/x64/Debug/microsoft/STL/std.ixx.ifc.dt.module.json
 cppfront/x64/Debug/microsoft/STL/std.ixx.ifc.dt.module.json.command
+
+# Crashes and hangs
+crashes/
+hangs/
+
+# Generated files
+cppfront.exe
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+#  Copyright 2022-2025 Herb Sutter
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#  
+#  Part of the Cppfront Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://github.com/hsutter/cppfront/blob/main/LICENSE for license information.
+#
+#  This Makefile is strictly optional and is just a convenience for building cppfront.
+#  You can also build cppfront by running the cppfront.cpp source file through your 
+#  C++ compiler in the normal manner.
+
+all: cppfront.exe source/reflect.h include/cpp2regex.h
+
+CXX ?= g++
+CPPFRONT ?= ./cppfront.exe
+CFLAGS ?=
+
+CFLAGS += -Wall -Werror -Wextra -Wpedantic
+
+ifeq (${DEBUG},1)
+CFLAGS += -g
+endif
+ifeq (${RELEASE},1)
+CFLAGS += -O3
+endif
+ifeq (${PROFILE},1)
+CFLAGS += -pg
+endif
+ifeq (${SANITIZE},1)
+CFLAGS += -fsanitize=address -fsanitize=undefined
+endif
+ifeq (${COVERAGE},1)
+CFLAGS += --coverage
+endif
+
+cppfront.exe: source/cppfront.cpp source/common.h source/cpp2regex.h include/cpp2regex.h source/cpp2util.h include/cpp2util.h source/io.h source/lex.h source/parse.h source/reflect.h source/sema.h source/to_cpp1.h
+	${CXX} -std=c++20 -o cppfront.exe -Iinclude ${CFLAGS} source/cppfront.cpp
+
+include/cpp2regex.h: include/cpp2regex.h2
+	${CPPFRONT} include/cpp2regex.h2 -o include/cpp2regex.h
+
+source/reflect.h: source/reflect.h2
+	${CPPFRONT} source/reflect.h2 -o source/reflect.h
+
+clean:
+	rm -f cppfront.exe


### PR DESCRIPTION
One of the frustrating things about cppfront is that I always have to remember the precise incantation to build cppfront. In addition, the regression tests always build cppfront whether or not it needs to be built.

This PR adds a simple Makefile. Nothing special and explicitly marked as optional. In addition, it allows the regression tests to be run with a pre-built version of cppfront. This allows us (for instance) to build a sanitized cppfront and run it through the regressions to see if we get any memory or undefined behavior errors.