### PR TITLE
Added meson build script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,30 @@
+project(
+  'cppfront',
+  ['cpp'],
+  version: files('./source/version.info'),
+  meson_version: '>= 1.1',
+  default_options: ['cpp_std=c++20'],
+)
+
+threads_dep = dependency('threads', required : true)
+
+executable('cppfront', './source/cppfront.cpp',
+  cpp_args : [
+    '-Wall',
+    '-Wextra',
+    '-Wold-style-cast',
+    '-Wunused-parameter',
+    '-Wpedantic',
+    '-Werror',
+    '-Wno-unknown-warning',
+    '-Wno-unknown-warning-option'
+  ],
+  dependencies: [threads_dep],
+  install:true
+)
+
+install_headers([
+    './include/cpp2regex.h',
+    './include/cpp2regex.h2',
+    './include/cpp2util.h'
+])

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
 
 threads_dep = dependency('threads', required : true)
 
-executable('cppfront', './source/cppfront.cpp',
+cppfront = executable('cppfront', './source/cppfront.cpp',
   cpp_args : [
     '-Wall',
     '-Wextra',
@@ -28,3 +28,6 @@ install_headers([
     './include/cpp2regex.h2',
     './include/cpp2util.h'
 ])
+
+meson.override_find_program('cppfront', cppfront)
+cpp2_dep = declare_dependency(include_directories: 'include')


### PR DESCRIPTION
At the moment there is no easy way to build and install cppfront. 
This PR adds a meson build file to do that.