### PR TITLE
Avoid string allocation/free traffic in assert_in_bounds()

### DIFF
--- a/include/cpp2util.h
+++ b/include/cpp2util.h
@@ -1224,14 +1224,14 @@ constexpr auto assert_not_zero(auto&& arg CPP2_SOURCE_LOCATION_PARAM_WITH_DEFAUL
         if constexpr (std::is_signed_v<CPP2_TYPEOF(arg)>) { return std::ssize(x); } \
         else { return std::size(x); } \
     }; \
-    auto msg = "out of bounds access attempt detected - attempted access at index " + std::to_string(arg) + ", "; \
-    if (max() > 0 ) { \
-        msg += "[min,max] range is [0," + std::to_string(max()-1) + "]"; \
-    } \
-    else { \
-        msg += "but container is empty"; \
-    } \
     if (!(0 <= arg && arg < max())) { \
+        auto msg = "out of bounds access attempt detected - attempted access at index " + std::to_string(arg) + ", "; \
+        if (max() > 0 ) { \
+            msg += "[min,max] range is [0," + std::to_string(max()-1) + "]"; \
+        } \
+        else { \
+            msg += "but container is empty"; \
+        } \
         bounds_safety.report_violation(msg.c_str()  CPP2_SOURCE_LOCATION_ARG); \
     } \
     return CPP2_FORWARD(x) [ arg ]; \


### PR DESCRIPTION
Move the construction of the OOB violation string to after the OOB check fails so that the code is not allocating, concatenating and freeing strings that are never used in regular operation. The change simply shunts the construction of the `msg` string inside the bounds check, given that the `msg` result is only ever used when the condition fails.

Discovered this by accident when an RNG class I had ported to cpp2 was reading and writing to a small fixed-size array and the RNG was used very frequently in an inner loop.

Profiling the app (-O3 build, clang 19) showed considerable work being done building and discarding strings for every access of the `std::array` member. Although that could be mitigated by switching to `unchecked_subscript`, avoiding this string build does not change the operation of the check but does remove the penalty.

