### PR TITLE
CI Update singleton test results

### DIFF
--- a/regression-tests/test-results/clang-19-c++23-libcpp/pure2-singleton-and-static.cpp.output
+++ b/regression-tests/test-results/clang-19-c++23-libcpp/pure2-singleton-and-static.cpp.output
@@ -1,4 +1,0 @@
-pure2-singleton-and-static.cpp2:8:21: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
-    8 |     CPP2_UFCS(print)(test::instance());
-      |     ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
-1 warning generated.

--- a/regression-tests/test-results/gcc-13-c++2b/pure2-singleton-and-static.cpp.output
+++ b/regression-tests/test-results/gcc-13-c++2b/pure2-singleton-and-static.cpp.output
@@ -1,6 +1,0 @@
-pure2-singleton-and-static.cpp2: In function ‘int main()’:
-pure2-singleton-and-static.cpp2:8:21: warning: ignoring return value of ‘main()::<lambda(Obj&&, Params&& ...)> [with Obj = test&; Params = {}; bool IsNothrow = false]’, declared with attribute ‘nodiscard’ [-Wunused-result]
-In file included from pure2-singleton-and-static.cpp:7:
-../../../include/cpp2util.h:10059:1: note: declared here
-../../../include/cpp2util.h:10091:59: note: in expansion of macro ‘CPP2_UFCS_’
-pure2-singleton-and-static.cpp2:8:5: note: in expansion of macro ‘CPP2_UFCS’


### PR DESCRIPTION
Removes compilation error reports in `pure2-singleton-and-static` regression test for the GCC 13 and Clang 19 compilers.
The generated C++ code no compiles after recent update of the test.